### PR TITLE
♻️ ref(core): add ui package and refactor git to struct-based API

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,25 +2,33 @@ package git
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 )
 
-func Run(args ...string) (string, error) {
+type Git struct {
+	Dir     string
+	Verbose bool
+}
+
+func (g *Git) Run(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
+	if g.Dir != "" {
+		cmd.Dir = g.Dir
+	}
+
+	if g.Verbose {
+		if g.Dir != "" {
+			fmt.Fprintf(os.Stderr, "$ git -C %s %s\n", g.Dir, strings.Join(args, " "))
+		} else {
+			fmt.Fprintf(os.Stderr, "$ git %s\n", strings.Join(args, " "))
+		}
+	}
+
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, out)
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-func RunInDir(dir string, args ...string) (string, error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("git -C %s %s: %w\n%s", dir, strings.Join(args, " "), err, out)
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -1,0 +1,78 @@
+package ui
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	reset  = "\033[0m"
+	bold   = "\033[1m"
+	dim    = "\033[2m"
+	red    = "\033[31m"
+	green  = "\033[32m"
+	yellow = "\033[33m"
+	cyan   = "\033[36m"
+)
+
+type UI struct {
+	NoColor bool
+}
+
+func (u *UI) Success(msg string) {
+	fmt.Printf("%s %s\n", u.Green("✔"), msg)
+}
+
+func (u *UI) Info(msg string) {
+	fmt.Println(msg)
+}
+
+func (u *UI) Warn(msg string) {
+	fmt.Printf("%s %s\n", u.Yellow("⚠"), msg)
+}
+
+func (u *UI) Errorf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, u.Red("error: ")+format+"\n", args...)
+}
+
+func (u *UI) Bold(s string) string {
+	if u.NoColor {
+		return s
+	}
+	return bold + s + reset
+}
+
+func (u *UI) Green(s string) string {
+	if u.NoColor {
+		return s
+	}
+	return green + s + reset
+}
+
+func (u *UI) Yellow(s string) string {
+	if u.NoColor {
+		return s
+	}
+	return yellow + s + reset
+}
+
+func (u *UI) Red(s string) string {
+	if u.NoColor {
+		return s
+	}
+	return red + s + reset
+}
+
+func (u *UI) Cyan(s string) string {
+	if u.NoColor {
+		return s
+	}
+	return cyan + s + reset
+}
+
+func (u *UI) Dim(s string) string {
+	if u.NoColor {
+		return s
+	}
+	return dim + s + reset
+}


### PR DESCRIPTION
## Summary
- Add `internal/ui` package with colored output helpers (`Success`, `Info`, `Warn`, `Errorf`) and ANSI styling methods that respect `--no-color`
- Refactor `internal/git` from package-level functions to `Git` struct with `Dir` and `Verbose` fields for flag propagation

## Test plan
- [x] `go build ./...` passes