### PR TITLE
✨ feat(cli): implement clone command

### DIFF
--- a/cmd/willow/main.go
+++ b/cmd/willow/main.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/iamrajjoshi/willow/internal/cli"
+	"github.com/iamrajjoshi/willow/internal/ui"
 )
 
 func main() {
 	root := cli.NewApp()
 	if err := root.Run(context.Background(), os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		u := &ui.UI{NoColor: root.Bool("no-color")}
+		u.Errorf("%v", err)
 		os.Exit(1)
 	}
 }

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1,10 +1,32 @@
 package cli
 
 import (
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/urfave/cli/v3"
 )
 
 var version = "dev"
+
+type Flags struct {
+	Verbose bool
+	NoColor bool
+}
+
+func parseFlags(cmd *cli.Command) Flags {
+	return Flags{
+		Verbose: cmd.Root().Bool("verbose"),
+		NoColor: cmd.Root().Bool("no-color"),
+	}
+}
+
+func (f Flags) NewGit() *git.Git {
+	return &git.Git{Verbose: f.Verbose}
+}
+
+func (f Flags) NewUI() *ui.UI {
+	return &ui.UI{NoColor: f.NoColor}
+}
 
 func NewApp() *cli.Command {
 	return &cli.Command{
@@ -27,6 +49,7 @@ func NewApp() *cli.Command {
 			},
 		},
 		Commands: []*cli.Command{
+			cloneCmd(),
 			newCmd(),
 			lsCmd(),
 			goCmd(),

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/urfave/cli/v3"
+)
+
+func cloneCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "clone",
+		Usage: "Clone a repo for willow (bare clone)",
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "url",
+				UsageText: "<repo-url>",
+			},
+			&cli.StringArg{
+				Name:      "name",
+				UsageText: "[name]",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			url := cmd.StringArg("url")
+			if url == "" {
+				return fmt.Errorf("repository URL is required\n\nUsage: ww clone <repo-url> [name]")
+			}
+
+			name := cmd.StringArg("name")
+			if name == "" {
+				name = repoNameFromURL(url)
+			}
+
+			bareDir := filepath.Join(config.ReposDir(), name+".git")
+			worktreesDir := filepath.Join(config.WorktreesDir(), name)
+
+			if _, err := os.Stat(bareDir); err == nil {
+				return fmt.Errorf("repository %q already exists at %s", name, bareDir)
+			}
+
+			if err := os.MkdirAll(config.ReposDir(), 0o755); err != nil {
+				return fmt.Errorf("failed to create repos directory: %w", err)
+			}
+			if err := os.MkdirAll(worktreesDir, 0o755); err != nil {
+				return fmt.Errorf("failed to create worktrees directory: %w", err)
+			}
+
+			// Bare clone
+			u.Info(fmt.Sprintf("Cloning %s into %s...", url, u.Bold(bareDir)))
+			if _, err := g.Run("clone", "--bare", url, bareDir); err != nil {
+				return fmt.Errorf("failed to clone repository: %w", err)
+			}
+
+			// Bare clones don't set up remote tracking by default.
+			// Configure the fetch refspec so `git fetch` populates refs/remotes/origin/*.
+			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+			if _, err := repoGit.Run("config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+				return fmt.Errorf("failed to configure fetch refs: %w", err)
+			}
+
+			u.Info("Fetching latest from origin...")
+			if _, err := repoGit.Run("fetch", "origin"); err != nil {
+				return fmt.Errorf("failed to fetch from origin: %w", err)
+			}
+
+			defaultBranch, err := detectDefaultBranch(repoGit)
+			if err != nil {
+				return fmt.Errorf("failed to detect default branch: %w", err)
+			}
+
+			// Create the initial worktree on the default branch
+			wtPath := filepath.Join(worktreesDir, defaultBranch)
+			u.Info(fmt.Sprintf("Creating worktree %s at %s...", u.Bold(defaultBranch), wtPath))
+			if _, err := repoGit.Run("worktree", "add", wtPath, defaultBranch); err != nil {
+				return fmt.Errorf("failed to create initial worktree: %w", err)
+			}
+
+			u.Success(fmt.Sprintf("Cloned %s", u.Bold(name)))
+			u.Info(fmt.Sprintf("  bare repo:  %s", u.Dim(bareDir)))
+			u.Info(fmt.Sprintf("  worktree:   %s", u.Dim(wtPath)))
+			return nil
+		},
+	}
+}
+
+// repoNameFromURL extracts the repository name from a git URL.
+// Handles both SSH (git@github.com:org/repo.git) and HTTPS (https://github.com/org/repo.git).
+func repoNameFromURL(url string) string {
+	if i := strings.LastIndex(url, ":"); i != -1 && !strings.Contains(url, "://") {
+		url = url[i+1:]
+	}
+	name := path.Base(url)
+	return strings.TrimSuffix(name, ".git")
+}
+
+func detectDefaultBranch(g *git.Git) (string, error) {
+	ref, err := g.Run("symbolic-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(ref, "refs/heads/"), nil
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -32,7 +32,7 @@ func (u *UI) Warn(msg string) {
 }
 
 func (u *UI) Errorf(format string, args ...any) {
-	fmt.Fprintf(os.Stderr, u.Red("error: ")+format+"\n", args...)
+	fmt.Fprintf(os.Stderr, "%s "+format+"\n", append([]any{u.Red("error:")}, args...)...)
 }
 
 func (u *UI) Bold(s string) string {


### PR DESCRIPTION
## Summary
- Add `ww clone <repo-url> [name]` — bare clones a repo into `~/.willow/repos/<name>.git`, configures fetch refs, and creates an initial worktree on the default branch
- Add `Flags` struct in `app.go` for type-safe global flag access (`parseFlags`, `NewGit`, `NewUI`)
- Use urfave/cli/v3 typed `Arguments` field instead of index-based `cmd.Args().Get()`
- Move error display to `ui.Errorf` in `main.go`

## Test plan
- [x] `go build ./...` passes
- [x] `ww clone` with no args shows error
- [x] `ww clone <url>` creates bare repo, worktree, and fetch refs
- [x] `ww clone <url> <name>` overrides repo name
- [x] Duplicate clone is rejected
- [x] `--verbose` shows git commands