### PR TITLE
✨ feat(cli): implement ls command

### DIFF
--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -2,8 +2,14 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
 
@@ -23,10 +29,109 @@ func lsCmd() *cli.Command {
 			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
-			fmt.Println("[stub] listing worktrees")
-			fmt.Println(" BRANCH                STATUS    PATH                                         AGE")
-			fmt.Println(" main                  clean     ~/.willow/worktrees/myrepo/main               3d")
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+
+			bareDir, err := resolveBareRepo(g)
+			if err != nil {
+				return err
+			}
+
+			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+			worktrees, err := worktree.List(repoGit)
+			if err != nil {
+				return fmt.Errorf("failed to list worktrees: %w", err)
+			}
+
+			// Filter out the bare repo entry
+			var filtered []worktree.Worktree
+			for _, wt := range worktrees {
+				if !wt.IsBare {
+					filtered = append(filtered, wt)
+				}
+			}
+
+			if cmd.Bool("path-only") {
+				for _, wt := range filtered {
+					fmt.Println(wt.Path)
+				}
+				return nil
+			}
+
+			if cmd.Bool("json") {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(filtered)
+			}
+
+			printTable(flags, filtered)
 			return nil
 		},
+	}
+}
+
+// resolveBareRepo finds the bare repo directory from the current working directory.
+func resolveBareRepo(g *git.Git) (string, error) {
+	dir, err := g.Run("rev-parse", "--git-common-dir")
+	if err != nil {
+		return "", fmt.Errorf("not inside a git repository (run 'ww clone' first)")
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	return absDir, nil
+}
+
+func printTable(flags Flags, worktrees []worktree.Worktree) {
+	u := flags.NewUI()
+
+	if len(worktrees) == 0 {
+		u.Info("No worktrees found.")
+		return
+	}
+
+	// Compute column widths
+	branchW := len("BRANCH")
+	pathW := len("PATH")
+	for _, wt := range worktrees {
+		if len(wt.Branch) > branchW {
+			branchW = len(wt.Branch)
+		}
+		if len(wt.Path) > pathW {
+			pathW = len(wt.Path)
+		}
+	}
+
+	header := fmt.Sprintf("  %-*s  %-*s  %s", branchW, "BRANCH", pathW, "PATH", "AGE")
+	u.Info(u.Bold(header))
+
+	for _, wt := range worktrees {
+		age := worktreeAge(wt.Path)
+		line := fmt.Sprintf("  %-*s  %-*s  %s", branchW, wt.Branch, pathW, u.Dim(wt.Path), u.Dim(age))
+		u.Info(line)
+	}
+}
+
+func worktreeAge(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "?"
+	}
+	return formatAge(time.Since(info.ModTime()))
+}
+
+func formatAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case d < 7*24*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	default:
+		return fmt.Sprintf("%dw", int(d.Hours()/(24*7)))
 	}
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,15 +1,47 @@
 package worktree
 
-import "github.com/iamrajjoshi/willow/internal/config"
+import (
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/git"
+)
 
 type Worktree struct {
-	Branch string
-	Path   string
-	Repo   string
+	Branch string `json:"branch"`
+	Path   string `json:"path"`
+	Head   string `json:"head"`
+	IsBare bool   `json:"-"`
 }
 
-func List(repoName string) ([]Worktree, error) {
-	_ = config.WorktreesDir()
-	// TODO: implement via git worktree list --porcelain
-	return nil, nil
+func List(g *git.Git) ([]Worktree, error) {
+	out, err := g.Run("worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, err
+	}
+	return parsePorcelain(out), nil
+}
+
+func parsePorcelain(output string) []Worktree {
+	var worktrees []Worktree
+	for _, block := range strings.Split(strings.TrimSpace(output), "\n\n") {
+		var wt Worktree
+		for _, line := range strings.Split(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "worktree "):
+				wt.Path = strings.TrimPrefix(line, "worktree ")
+			case strings.HasPrefix(line, "HEAD "):
+				wt.Head = strings.TrimPrefix(line, "HEAD ")
+			case strings.HasPrefix(line, "branch "):
+				wt.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+			case line == "bare":
+				wt.IsBare = true
+			case line == "detached":
+				wt.Branch = "(detached)"
+			}
+		}
+		if wt.Path != "" {
+			worktrees = append(worktrees, wt)
+		}
+	}
+	return worktrees
 }


### PR DESCRIPTION
## Summary
- Rewrite `internal/worktree` with porcelain parser for `git worktree list --porcelain`, handling bare entries and detached HEADs
- Implement `ww ls` with three output modes: table (default), `--json`, `--path-only`
- Add `resolveBareRepo()` using `git rev-parse --git-common-dir` for repo discovery from cwd
- Drop the STATUS column from `ls` — keeping it fast, no per-worktree git status checks

## Test plan
- [x] `go build ./...` passes
- [x] Table output shows BRANCH, PATH, AGE columns
- [x] `--json` outputs valid JSON with branch, path, head
- [x] `--path-only` prints one path per line
- [x] Running outside a git repo shows clear error