### PR TITLE
✨ feat(cli): implement new command

### DIFF
--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -104,10 +104,3 @@ func repoNameFromURL(url string) string {
 	return strings.TrimSuffix(name, ".git")
 }
 
-func detectDefaultBranch(g *git.Git) (string, error) {
-	ref, err := g.Run("symbolic-ref", "HEAD")
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimPrefix(ref, "refs/heads/"), nil
-}

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/iamrajjoshi/willow/internal/git"
@@ -68,19 +67,6 @@ func lsCmd() *cli.Command {
 			return nil
 		},
 	}
-}
-
-// resolveBareRepo finds the bare repo directory from the current working directory.
-func resolveBareRepo(g *git.Git) (string, error) {
-	dir, err := g.Run("rev-parse", "--git-common-dir")
-	if err != nil {
-		return "", fmt.Errorf("not inside a git repository (run 'ww clone' first)")
-	}
-	absDir, err := filepath.Abs(dir)
-	if err != nil {
-		return "", err
-	}
-	return absDir, nil
 }
 
 func printTable(flags Flags, worktrees []worktree.Worktree) {

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -3,7 +3,11 @@ package cli
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/urfave/cli/v3"
 )
 
@@ -12,15 +16,17 @@ func newCmd() *cli.Command {
 		Name:    "new",
 		Aliases: []string{"n"},
 		Usage:   "Create a new worktree",
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "branch",
+				UsageText: "<branch>",
+			},
+		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "base",
 				Aliases: []string{"b"},
 				Usage:   "Base branch to fork from",
-			},
-			&cli.StringFlag{
-				Name:  "name",
-				Usage: "Human-friendly workspace name",
 			},
 			&cli.BoolFlag{
 				Name:    "existing",
@@ -37,11 +43,76 @@ func newCmd() *cli.Command {
 			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
-			branch := cmd.Args().First()
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+			cdOnly := cmd.Bool("cd")
+
+			branch := cmd.StringArg("branch")
 			if branch == "" {
-				branch = "(auto)"
+				return fmt.Errorf("branch name is required\n\nUsage: ww new <branch> [flags]")
 			}
-			fmt.Printf("[stub] new worktree branch=%s base=%s\n", branch, cmd.String("base"))
+
+			bareDir, err := resolveBareRepo(g)
+			if err != nil {
+				return err
+			}
+
+			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+			repoName := repoNameFromDir(bareDir)
+
+			// Resolve base branch
+			baseBranch := cmd.String("base")
+			if baseBranch == "" {
+				baseBranch, err = detectDefaultBranch(repoGit)
+				if err != nil {
+					return fmt.Errorf("failed to detect default branch (use --base to specify): %w", err)
+				}
+			}
+
+			// Fetch latest from remote
+			if !cmd.Bool("no-fetch") {
+				if !cdOnly {
+					u.Info(fmt.Sprintf("Fetching %s from origin...", u.Bold(baseBranch)))
+				}
+				if _, err := repoGit.Run("fetch", "origin", baseBranch); err != nil {
+					return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
+				}
+			}
+
+			dirName := strings.ReplaceAll(branch, "/", "")
+			wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
+
+			if cmd.Bool("existing") {
+				if !cdOnly {
+					u.Info(fmt.Sprintf("Creating worktree for existing branch %s...", u.Bold(branch)))
+				}
+				if _, err := repoGit.Run("worktree", "add", wtPath, branch); err != nil {
+					return fmt.Errorf("failed to create worktree: %w", err)
+				}
+			} else {
+				if !cdOnly {
+					u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold("origin/"+baseBranch)))
+				}
+				if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+					return fmt.Errorf("failed to create worktree: %w", err)
+				}
+			}
+
+			// Configure push.autoSetupRemote so `git push` works without --set-upstream
+			wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
+			if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
+				return fmt.Errorf("failed to configure push.autoSetupRemote: %w", err)
+			}
+
+			if cdOnly {
+				fmt.Println(wtPath)
+				return nil
+			}
+
+			u.Success(fmt.Sprintf("Created worktree %s", u.Bold(branch)))
+			u.Info(fmt.Sprintf("  path:   %s", u.Dim(wtPath)))
+			u.Info(fmt.Sprintf("  base:   %s", u.Dim("origin/"+baseBranch)))
 			return nil
 		},
 	}

--- a/internal/cli/repo.go
+++ b/internal/cli/repo.go
@@ -1,0 +1,36 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/git"
+)
+
+// resolveBareRepo finds the bare repo directory from the current working directory.
+func resolveBareRepo(g *git.Git) (string, error) {
+	dir, err := g.Run("rev-parse", "--git-common-dir")
+	if err != nil {
+		return "", fmt.Errorf("not inside a git repository (run 'ww clone' first)")
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	return absDir, nil
+}
+
+// repoNameFromDir extracts the repo name from a bare repo path.
+// e.g. ~/.willow/repos/myrepo.git → myrepo
+func repoNameFromDir(bareDir string) string {
+	return strings.TrimSuffix(filepath.Base(bareDir), ".git")
+}
+
+func detectDefaultBranch(g *git.Git) (string, error) {
+	ref, err := g.Run("symbolic-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(ref, "refs/heads/"), nil
+}


### PR DESCRIPTION
## Summary
- Implement `ww new <branch>` — creates a worktree with a new branch forked from the base branch
- Flags: `--base/-b`, `--existing/-e`, `--no-fetch`, `--cd`
- Extract shared helpers (`resolveBareRepo`, `detectDefaultBranch`, `repoNameFromDir`) from clone.go/ls.go into `repo.go`
- Worktree directory name strips slashes from branch name (e.g. `feature/auth` → `featureauth`)
- Configures `push.autoSetupRemote` in each new worktree
- `--cd` suppresses all UI output and prints only the path (for `cd $(ww new <branch> --cd)`)

## Test plan
- [x] `go build ./...` passes
- [x] `ww new <branch>` creates worktree forked from auto-detected default branch
- [x] `ww new <branch> --base develop` forks from specified base
- [x] `--cd` prints only the path
- [x] `--verbose` shows all git commands
- [x] Duplicate branch is rejected by git
- [x] Existing commands (clone, ls) still work after helper extraction