### PR TITLE
✨ feat(cli): implement prune command

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -55,6 +55,7 @@ func NewApp() *cli.Command {
 			goCmd(),
 			rmCmd(),
 			runCmd(),
+			pruneCmd(),
 		},
 	}
 }

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/urfave/cli/v3"
+)
+
+func pruneCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "prune",
+		Usage: "Clean up stale worktrees",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "dry-run",
+				Usage: "Show what would be pruned without doing it",
+			},
+			&cli.BoolFlag{
+				Name:    "yes",
+				Aliases: []string{"y"},
+				Usage:   "Skip confirmation",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			bareDir, err := g.BareRepoDir()
+			if err != nil {
+				return err
+			}
+
+			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+
+			// Preview what would be pruned
+			preview, err := repoGit.Run("worktree", "prune", "--dry-run", "-v")
+			if err != nil {
+				return fmt.Errorf("failed to check stale worktrees: %w", err)
+			}
+
+			if preview == "" {
+				u.Info("Nothing to prune.")
+				return nil
+			}
+
+			u.Info(preview)
+
+			if cmd.Bool("dry-run") {
+				return nil
+			}
+
+			if !cmd.Bool("yes") {
+				if !confirm("Prune stale worktrees?") {
+					u.Info("Aborted.")
+					return nil
+				}
+			}
+
+			if _, err := repoGit.Run("worktree", "prune", "-v"); err != nil {
+				return fmt.Errorf("failed to prune worktrees: %w", err)
+			}
+
+			u.Success("Pruned stale worktrees")
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Implement `ww prune` to clean up stale worktrees whose directories no longer exist on disk
- Wraps `git worktree prune` with preview, confirmation prompt, and verbose output
- Flags: `--dry-run` (preview only), `--yes/-y` (skip confirmation)

## Test plan
- [x] `go build ./...` passes
- [x] No stale worktrees shows "Nothing to prune."
- [x] `--dry-run` shows stale entries without removing
- [x] Actual prune removes stale worktree entries
- [x] Confirmation prompt works (reuses `confirm` from rm)