### PR TITLE
♻️ ref(cli): rename go command to pwd

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -52,7 +52,7 @@ func NewApp() *cli.Command {
 			cloneCmd(),
 			newCmd(),
 			lsCmd(),
-			goCmd(),
+			pwdCmd(),
 			rmCmd(),
 			runCmd(),
 			pruneCmd(),

--- a/internal/cli/pwd.go
+++ b/internal/cli/pwd.go
@@ -10,11 +10,10 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-func goCmd() *cli.Command {
+func pwdCmd() *cli.Command {
 	return &cli.Command{
-		Name:    "go",
-		Aliases: []string{"g"},
-		Usage:   "Print worktree path",
+		Name:  "pwd",
+		Usage: "Print worktree path",
 		Arguments: []cli.Argument{
 			&cli.StringArg{
 				Name:      "branch",
@@ -27,7 +26,7 @@ func goCmd() *cli.Command {
 
 			target := cmd.StringArg("branch")
 			if target == "" {
-				return fmt.Errorf("branch or worktree name is required\n\nUsage: ww go <branch-or-name>")
+				return fmt.Errorf("branch or worktree name is required\n\nUsage: ww pwd <branch-or-name>")
 			}
 
 			bareDir, err := g.BareRepoDir()


### PR DESCRIPTION
## Summary
- Rename `ww go` to `ww pwd` — it prints the worktree path, doesn't navigate
- `ww go` will be a shell function (via `ww shell-init`) that wraps `ww pwd` with `cd`

## Test plan
- [x] `go build ./...` passes
- [x] `ww pwd <branch>` prints worktree path
- [x] `ww go` no longer exists as a subcommand