### PR TITLE
feat(cli): implement init and config commands

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -56,6 +56,8 @@ func NewApp() *cli.Command {
 			rmCmd(),
 			runCmd(),
 			pruneCmd(),
+			initCmd(),
+			configCmd(),
 		},
 	}
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -1,0 +1,300 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/ui"
+	"github.com/urfave/cli/v3"
+)
+
+var configKeys = []string{
+	"baseBranch",
+	"branchPrefix",
+	"setup",
+	"teardown",
+	"defaults.fetch",
+	"defaults.autoSetupRemote",
+}
+
+func configCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "config",
+		Usage: "View or edit configuration",
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "key",
+				UsageText: "[key]",
+			},
+			&cli.StringArg{
+				Name:      "value",
+				UsageText: "[value]",
+			},
+		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "global",
+				Usage: "Target global config",
+			},
+			&cli.BoolFlag{
+				Name:    "list",
+				Aliases: []string{"l"},
+				Usage:   "List all config values with sources",
+			},
+			&cli.BoolFlag{
+				Name:  "edit",
+				Usage: "Open config file in $EDITOR",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			if cmd.Bool("list") {
+				return configList(g, u)
+			}
+
+			if cmd.Bool("edit") {
+				return configEdit(cmd, g)
+			}
+
+			key := cmd.StringArg("key")
+			value := cmd.StringArg("value")
+
+			if key == "" {
+				return configList(g, u)
+			}
+
+			if value != "" {
+				return configSet(cmd, g, u, key, value)
+			}
+
+			return configGet(g, u, key)
+		},
+	}
+}
+
+func configList(g *git.Git, u *ui.UI) error {
+	bareDir, _ := g.BareRepoDir()
+	worktreeRoot, _ := g.WorktreeRoot()
+
+	type tier struct {
+		name string
+		path string
+		cfg  *config.Config
+	}
+
+	tiers := []tier{
+		{name: "global", path: config.GlobalConfigPath()},
+	}
+
+	if worktreeRoot != "" {
+		tiers = append(tiers, tier{
+			name: "shared",
+			path: config.SharedConfigPath(worktreeRoot),
+		})
+	}
+
+	if bareDir != "" {
+		tiers = append(tiers, tier{
+			name: "local",
+			path: config.LocalConfigPath(bareDir),
+		})
+	}
+
+	for i := range tiers {
+		cfg, _ := config.LoadFile(tiers[i].path)
+		tiers[i].cfg = cfg
+	}
+
+	for _, key := range configKeys {
+		source := "default"
+		value := getDefaultValue(key)
+
+		for _, t := range tiers {
+			if t.cfg == nil {
+				continue
+			}
+			if v, ok := getFieldValue(t.cfg, key); ok {
+				value = v
+				source = t.name
+			}
+		}
+
+		fmt.Printf("%s = %s %s\n", key, value, u.Dim("("+source+")"))
+	}
+	return nil
+}
+
+func configGet(g *git.Git, u *ui.UI, key string) error {
+	if !isValidKey(key) {
+		return fmt.Errorf("unknown config key: %s\n\nValid keys: %s", key, strings.Join(configKeys, ", "))
+	}
+
+	bareDir, _ := g.BareRepoDir()
+	worktreeRoot, _ := g.WorktreeRoot()
+	cfg := config.Load(bareDir, worktreeRoot)
+
+	value, _ := getFieldValue(cfg, key)
+	fmt.Println(value)
+	return nil
+}
+
+func configSet(cmd *cli.Command, g *git.Git, u *ui.UI, key, value string) error {
+	if !isValidKey(key) {
+		return fmt.Errorf("unknown config key: %s\n\nValid keys: %s", key, strings.Join(configKeys, ", "))
+	}
+
+	var configPath string
+	if cmd.Bool("global") {
+		configPath = config.GlobalConfigPath()
+	} else {
+		bareDir, err := g.BareRepoDir()
+		if err != nil {
+			return fmt.Errorf("not inside a willow-managed repo (use --global for global config)")
+		}
+		configPath = config.LocalConfigPath(bareDir)
+	}
+
+	cfg, _ := config.LoadFile(configPath)
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+
+	if err := setFieldValue(cfg, key, value); err != nil {
+		return err
+	}
+
+	if err := config.Save(cfg, configPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	u.Success(fmt.Sprintf("%s = %s", key, value))
+	return nil
+}
+
+func configEdit(cmd *cli.Command, g *git.Git) error {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vi"
+	}
+
+	var configPath string
+	if cmd.Bool("global") {
+		configPath = config.GlobalConfigPath()
+	} else {
+		bareDir, err := g.BareRepoDir()
+		if err != nil {
+			return fmt.Errorf("not inside a willow-managed repo (use --global for global config)")
+		}
+		configPath = config.LocalConfigPath(bareDir)
+	}
+
+	// Create the file with defaults if it doesn't exist
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		if err := config.Save(&config.Config{}, configPath); err != nil {
+			return fmt.Errorf("failed to create config: %w", err)
+		}
+	}
+
+	e := exec.Command(editor, configPath)
+	e.Stdin = os.Stdin
+	e.Stdout = os.Stdout
+	e.Stderr = os.Stderr
+	return e.Run()
+}
+
+func getDefaultValue(key string) string {
+	switch key {
+	case "defaults.fetch":
+		return "true"
+	case "defaults.autoSetupRemote":
+		return "true"
+	default:
+		return ""
+	}
+}
+
+func getFieldValue(cfg *config.Config, key string) (string, bool) {
+	switch key {
+	case "baseBranch":
+		if cfg.BaseBranch != "" {
+			return cfg.BaseBranch, true
+		}
+	case "branchPrefix":
+		if cfg.BranchPrefix != "" {
+			return cfg.BranchPrefix, true
+		}
+	case "setup":
+		if cfg.Setup != nil {
+			return strings.Join(cfg.Setup, ", "), true
+		}
+	case "teardown":
+		if cfg.Teardown != nil {
+			return strings.Join(cfg.Teardown, ", "), true
+		}
+	case "defaults.fetch":
+		if cfg.Defaults.Fetch != nil {
+			return fmt.Sprintf("%t", *cfg.Defaults.Fetch), true
+		}
+	case "defaults.autoSetupRemote":
+		if cfg.Defaults.AutoSetupRemote != nil {
+			return fmt.Sprintf("%t", *cfg.Defaults.AutoSetupRemote), true
+		}
+	}
+	return "", false
+}
+
+func setFieldValue(cfg *config.Config, key, value string) error {
+	switch key {
+	case "baseBranch":
+		cfg.BaseBranch = value
+	case "branchPrefix":
+		cfg.BranchPrefix = value
+	case "setup":
+		cfg.Setup = splitCommands(value)
+	case "teardown":
+		cfg.Teardown = splitCommands(value)
+	case "defaults.fetch":
+		b, err := parseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for %s: %w", key, err)
+		}
+		cfg.Defaults.Fetch = config.BoolPtr(b)
+	case "defaults.autoSetupRemote":
+		b, err := parseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for %s: %w", key, err)
+		}
+		cfg.Defaults.AutoSetupRemote = config.BoolPtr(b)
+	default:
+		return fmt.Errorf("unknown config key: %s", key)
+	}
+	return nil
+}
+
+func isValidKey(key string) bool {
+	for _, k := range configKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+func parseBool(s string) (bool, error) {
+	switch strings.ToLower(s) {
+	case "true", "1", "yes":
+		return true, nil
+	case "false", "0", "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("must be true or false, got %q", s)
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/urfave/cli/v3"
+)
+
+func initCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "init",
+		Usage: "Initialize config for a willow-managed repo",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "global",
+				Usage: "Create global config at ~/.config/willow/config.json",
+			},
+			&cli.BoolFlag{
+				Name:  "shared",
+				Usage: "Create shared config tracked in the repo",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			var configPath string
+			var bareDir string
+			var err error
+
+			if cmd.Bool("global") {
+				configPath = config.GlobalConfigPath()
+			} else {
+				bareDir, err = g.BareRepoDir()
+				if err != nil {
+					return fmt.Errorf("not inside a willow-managed repo (use --global for global config)")
+				}
+				if cmd.Bool("shared") {
+					wtRoot, err := g.WorktreeRoot()
+					if err != nil {
+						return fmt.Errorf("not inside a worktree: %w", err)
+					}
+					configPath = config.SharedConfigPath(wtRoot)
+				} else {
+					configPath = config.LocalConfigPath(bareDir)
+				}
+			}
+
+			// Pre-fill from existing config file
+			existing, _ := config.LoadFile(configPath)
+			if existing == nil {
+				existing = &config.Config{}
+			}
+
+			// Auto-detect default branch for the prompt default
+			detectedBranch := ""
+			if bareDir != "" {
+				repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+				detectedBranch, _ = repoGit.DefaultBranch()
+			}
+
+			baseBranchDefault := existing.BaseBranch
+			if baseBranchDefault == "" {
+				baseBranchDefault = detectedBranch
+			}
+
+			cfg := &config.Config{}
+			cfg.BaseBranch = prompt("Base branch", baseBranchDefault)
+			cfg.BranchPrefix = prompt("Branch prefix (e.g. your-username)", existing.BranchPrefix)
+
+			setupDefault := ""
+			if len(existing.Setup) > 0 {
+				setupDefault = strings.Join(existing.Setup, ", ")
+			}
+			if s := prompt("Setup command (run after creating worktree)", setupDefault); s != "" {
+				cfg.Setup = splitCommands(s)
+			}
+
+			teardownDefault := ""
+			if len(existing.Teardown) > 0 {
+				teardownDefault = strings.Join(existing.Teardown, ", ")
+			}
+			if s := prompt("Teardown command (run before removing worktree)", teardownDefault); s != "" {
+				cfg.Teardown = splitCommands(s)
+			}
+
+			if err := config.Save(cfg, configPath); err != nil {
+				return fmt.Errorf("failed to save config: %w", err)
+			}
+
+			u.Success(fmt.Sprintf("Config saved to %s", u.Dim(configPath)))
+			return nil
+		},
+	}
+}
+
+func prompt(label, defaultVal string) string {
+	if defaultVal != "" {
+		fmt.Fprintf(os.Stderr, "%s [%s]: ", label, defaultVal)
+	} else {
+		fmt.Fprintf(os.Stderr, "%s: ", label)
+	}
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		val := strings.TrimSpace(scanner.Text())
+		if val != "" {
+			return val
+		}
+	}
+	return defaultVal
+}
+
+func splitCommands(s string) []string {
+	var cmds []string
+	for _, c := range strings.Split(s, ",") {
+		c = strings.TrimSpace(c)
+		if c != "" {
+			cmds = append(cmds, c)
+		}
+	}
+	return cmds
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,13 +20,13 @@ type Defaults struct {
 	AutoSetupRemote *bool `json:"autoSetupRemote,omitempty"`
 }
 
-func boolPtr(v bool) *bool { return &v }
+func BoolPtr(v bool) *bool { return &v }
 
 func DefaultConfig() *Config {
 	return &Config{
 		Defaults: Defaults{
-			Fetch:           boolPtr(true),
-			AutoSetupRemote: boolPtr(true),
+			Fetch:           BoolPtr(true),
+			AutoSetupRemote: BoolPtr(true),
 		},
 	}
 }
@@ -63,18 +63,18 @@ func SharedConfigPath(worktreeRoot string) string {
 func Load(bareDir, worktreeRoot string) *Config {
 	cfg := DefaultConfig()
 
-	if global, err := loadFile(GlobalConfigPath()); err == nil {
+	if global, err := LoadFile(GlobalConfigPath()); err == nil {
 		merge(cfg, global)
 	}
 
 	if worktreeRoot != "" {
-		if shared, err := loadFile(SharedConfigPath(worktreeRoot)); err == nil {
+		if shared, err := LoadFile(SharedConfigPath(worktreeRoot)); err == nil {
 			merge(cfg, shared)
 		}
 	}
 
 	if bareDir != "" {
-		if local, err := loadFile(LocalConfigPath(bareDir)); err == nil {
+		if local, err := LoadFile(LocalConfigPath(bareDir)); err == nil {
 			merge(cfg, local)
 		}
 	}
@@ -82,7 +82,7 @@ func Load(bareDir, worktreeRoot string) *Config {
 	return cfg
 }
 
-func loadFile(path string) (*Config, error) {
+func LoadFile(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,7 +85,7 @@ func TestMerge_NilSliceDoesNotOverride(t *testing.T) {
 func TestMerge_BoolPointerOverride(t *testing.T) {
 	base := DefaultConfig() // fetch=true, autoSetupRemote=true
 	overlay := &Config{
-		Defaults: Defaults{Fetch: boolPtr(false)},
+		Defaults: Defaults{Fetch: BoolPtr(false)},
 	}
 
 	merge(base, overlay)
@@ -114,9 +114,9 @@ func TestLoadFile_ValidJSON(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	os.WriteFile(path, []byte(`{"baseBranch": "develop", "defaults": {"fetch": false}}`), 0o644)
 
-	cfg, err := loadFile(path)
+	cfg, err := LoadFile(path)
 	if err != nil {
-		t.Fatalf("loadFile() error: %v", err)
+		t.Fatalf("LoadFile() error: %v", err)
 	}
 	if cfg.BaseBranch != "develop" {
 		t.Errorf("BaseBranch = %q, want %q", cfg.BaseBranch, "develop")
@@ -127,9 +127,9 @@ func TestLoadFile_ValidJSON(t *testing.T) {
 }
 
 func TestLoadFile_MissingFile(t *testing.T) {
-	_, err := loadFile("/nonexistent/config.json")
+	_, err := LoadFile("/nonexistent/config.json")
 	if err == nil {
-		t.Error("loadFile() should return error for missing file")
+		t.Error("LoadFile() should return error for missing file")
 	}
 }
 
@@ -138,9 +138,9 @@ func TestLoadFile_InvalidJSON(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	os.WriteFile(path, []byte(`{not json}`), 0o644)
 
-	_, err := loadFile(path)
+	_, err := LoadFile(path)
 	if err == nil {
-		t.Error("loadFile() should return error for invalid JSON")
+		t.Error("LoadFile() should return error for invalid JSON")
 	}
 }
 
@@ -153,8 +153,8 @@ func TestSaveAndLoad(t *testing.T) {
 		BranchPrefix: "raj",
 		Setup:        []string{"npm install"},
 		Defaults: Defaults{
-			Fetch:           boolPtr(false),
-			AutoSetupRemote: boolPtr(true),
+			Fetch:           BoolPtr(false),
+			AutoSetupRemote: BoolPtr(true),
 		},
 	}
 
@@ -162,9 +162,9 @@ func TestSaveAndLoad(t *testing.T) {
 		t.Fatalf("Save() error: %v", err)
 	}
 
-	loaded, err := loadFile(path)
+	loaded, err := LoadFile(path)
 	if err != nil {
-		t.Fatalf("loadFile() error: %v", err)
+		t.Fatalf("LoadFile() error: %v", err)
 	}
 
 	if loaded.BaseBranch != "main" {
@@ -223,13 +223,13 @@ func TestLoad_ThreeTierMerge(t *testing.T) {
 
 	cfg := DefaultConfig()
 
-	global, _ := loadFile(filepath.Join(globalDir, "config.json"))
+	global, _ := LoadFile(filepath.Join(globalDir, "config.json"))
 	merge(cfg, global)
 
-	shared, _ := loadFile(filepath.Join(sharedDir, "config.json"))
+	shared, _ := LoadFile(filepath.Join(sharedDir, "config.json"))
 	merge(cfg, shared)
 
-	local, _ := loadFile(filepath.Join(localDir, "config.json"))
+	local, _ := LoadFile(filepath.Join(localDir, "config.json"))
 	merge(cfg, local)
 
 	// baseBranch: global=main, local=develop → develop wins


### PR DESCRIPTION
## Summary

- Add `ww init` — interactive config creation with pre-filling from existing values
  - Supports `--global` and `--shared` flags for targeting different config tiers
  - Prompts for: base branch (auto-detected default), branch prefix, setup/teardown commands
- Add `ww config` — view and edit configuration
  - `--list` shows all values with their source tier (default/global/shared/local)
  - `--edit` opens config in `$EDITOR`
  - `ww config <key>` gets a merged value
  - `ww config <key> <value>` sets a value in local config (`--global` for global)
  - Valid keys: `baseBranch`, `branchPrefix`, `setup`, `teardown`, `defaults.fetch`, `defaults.autoSetupRemote`
- Export `LoadFile` and `BoolPtr` from config package

## Test plan

- [x] All existing config tests pass
- [x] Manual: `ww clone`, `ww config baseBranch main`, `ww config --list` shows source
- [x] Manual: `ww config branchPrefix raj`, `ww new test-branch` creates `raj/test-branch`
- [x] Manual: `ww config defaults.fetch false`, `ww new` skips fetch
- [x] Manual: `ww config badKey` shows error with valid keys