### PR TITLE
feat(cli): implement shell-init command

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -58,6 +58,7 @@ func NewApp() *cli.Command {
 			pruneCmd(),
 			initCmd(),
 			configCmd(),
+			shellInitCmd(),
 		},
 	}
 }

--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+)
+
+const shellInitScript = `# Willow shell integration
+# Add to your .bashrc or .zshrc:
+#   eval "$(willow shell-init)"
+
+alias ww='willow'
+
+# Create a worktree and cd into it
+wwn() {
+  local dir
+  dir="$(willow new "$@" --cd)" || return
+  cd "$dir" || return
+}
+
+# Navigate to an existing worktree
+wwg() {
+  local dir
+  dir="$(willow pwd "$@")" || return
+  cd "$dir" || return
+}
+`
+
+func shellInitCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "shell-init",
+		Usage: "Print shell integration script",
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			fmt.Print(shellInitScript)
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ww shell-init` command that prints a shell integration script
- Usage: `eval "$(willow shell-init)"` in `.bashrc` / `.zshrc`
- Provides:
  - `ww` — alias for `willow`
  - `wwn [args]` — create a worktree and `cd` into it
  - `wwg [args]` — navigate to an existing worktree

## Test plan

- [x] `willow shell-init` prints valid POSIX shell script
- [x] All existing tests pass