### PR TITLE
🔧 chore(deployment): add CI workflows and goreleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./... -count=1 -v

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ go.work.sum
 
 # env file
 .env
+
+# Build output
+bin/
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+version: 2
+
+builds:
+  - main: ./cmd/willow
+    binary: willow
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/iamrajjoshi/willow/internal/cli.version={{.Version}}
+
+archives:
+  - format: tar.gz
+    name_template: "willow_{{ .Os }}_{{ .Arch }}"
+
+brews:
+  - repository:
+      owner: iamrajjoshi
+      name: homebrew-tap
+    name: willow
+    homepage: https://github.com/iamrajjoshi/willow
+    description: A simple, opinionated git worktree manager
+    license: MIT
+    install: |
+      bin.install "willow"
+    test: |
+      system "#{bin}/willow", "--version"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
## Summary

- Add GitHub Actions test workflow (macOS + Linux) for PRs and main pushes
- Add goreleaser config for cross-platform releases (darwin + linux, amd64 + arm64)
- Add release workflow triggered by version tags (`v*`)
- Created `iamrajjoshi/homebrew-tap` repo for homebrew distribution
- Add `bin/` and `dist/` to .gitignore

## Release workflow

After merging, to create a release:
```bash
git tag v0.1.0
git push origin v0.1.0
```

Users can then install with:
```bash
brew install iamrajjoshi/tap/willow
```

## Setup required

Add a GitHub personal access token with `repo` scope as `HOMEBREW_TAP_GITHUB_TOKEN` in the willow repo's Actions secrets. This lets goreleaser push the formula to the homebrew-tap repo.