### PR TITLE
fix(release): use HOMEBREW_TAP_GITHUB_TOKEN for tap repo push

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,7 @@ brews:
   - repository:
       owner: iamrajjoshi
       name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     name: willow
     homepage: https://github.com/iamrajjoshi/willow
     description: A simple, opinionated git worktree manager


### PR DESCRIPTION
The default GITHUB_TOKEN can't push to a different repo. Pass the explicit `HOMEBREW_TAP_GITHUB_TOKEN` to goreleaser's brew config.

After merging, add the secret and re-tag to trigger the release.