### PR TITLE
Add shell tab completion for bash, zsh, and fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,21 @@ go install github.com/iamrajjoshi/willow/cmd/willow@latest
 
 ### Shell integration
 
-Add to your `.bashrc` or `.zshrc`:
+Add to your shell config:
 
 ```bash
+# .bashrc or .zshrc
 eval "$(willow shell-init)"
+
+# fish (~/.config/fish/config.fish)
+willow shell-init | source
 ```
 
-This gives you:
+The shell is auto-detected from `$SHELL`. This gives you:
 - `ww` — alias for `willow`
 - `wwn <branch>` — create a worktree and `cd` into it
 - `wwg <branch>` — `cd` into an existing worktree
+- Tab completion for commands, flags, and worktree branch names
 
 ## Quick start
 
@@ -122,6 +127,7 @@ Run a command in a worktree's directory.
 ```bash
 ww run auth-refactor -- npm test
 ww run main -- git pull
+ww run --all -- git pull              # run across all worktrees
 ```
 
 ### `ww prune [flags]`

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -30,9 +30,10 @@ func (f Flags) NewUI() *ui.UI {
 
 func NewApp() *cli.Command {
 	return &cli.Command{
-		Name:    "willow",
-		Usage:   "A simple, opinionated git worktree manager",
-		Version: version,
+		Name:                  "willow",
+		Usage:                 "A simple, opinionated git worktree manager",
+		Version:               version,
+		EnableShellCompletion: true,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "C",

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -23,6 +23,7 @@ func rmCmd() *cli.Command {
 				UsageText: "<branch-or-name>",
 			},
 		},
+		ShellComplete: completeWorktrees,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "force",

--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -3,37 +3,163 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/urfave/cli/v3"
 )
 
-const shellInitScript = `# Willow shell integration
-# Add to your .bashrc or .zshrc:
+const bashInitScript = `# Willow shell integration
+# Add to your .bashrc:
 #   eval "$(willow shell-init)"
 
 alias ww='willow'
 
-# Create a worktree and cd into it
 wwn() {
   local dir
   dir="$(willow new "$@" --cd)" || return
   cd "$dir" || return
 }
 
-# Navigate to an existing worktree
 wwg() {
   local dir
   dir="$(willow pwd "$@")" || return
   cd "$dir" || return
 }
+
+# Tab completion
+__willow_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+__willow_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base words
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
+    else
+      __willow_init_completion -n "=:" || return
+    fi
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="${words[*]} ${cur} --generate-shell-completion"
+    else
+      requestComp="${words[*]} --generate-shell-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F __willow_bash_autocomplete willow
+complete -o bashdefault -o default -o nospace -F __willow_bash_autocomplete ww
 `
+
+const zshInitScript = `# Willow shell integration
+# Add to your .zshrc:
+#   eval "$(willow shell-init)"
+
+alias ww='willow'
+
+wwn() {
+  local dir
+  dir="$(willow new "$@" --cd)" || return
+  cd "$dir" || return
+}
+
+wwg() {
+  local dir
+  dir="$(willow pwd "$@")" || return
+  cd "$dir" || return
+}
+
+# Tab completion
+_willow() {
+  local -a opts
+  local current
+  current=${words[-1]}
+  if [[ "$current" == "-"* ]]; then
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${current} --generate-shell-completion)}")
+  else
+    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")
+  fi
+
+  if [[ "${opts[1]}" != "" ]]; then
+    _describe 'values' opts
+  else
+    _files
+  fi
+}
+
+compdef _willow willow
+compdef _willow ww
+
+if [ "$funcstack[1]" = "_willow" ]; then
+  _willow
+fi
+`
+
+const fishInitScript = `# Willow shell integration
+# Add to your config.fish:
+#   willow shell-init | source
+
+alias ww='willow'
+
+function wwn
+  set -l dir (willow new $argv --cd)
+  or return
+  cd $dir
+end
+
+function wwg
+  set -l dir (willow pwd $argv)
+  or return
+  cd $dir
+end
+
+# Tab completion
+function __fish_willow_complete
+  set -l tokens (commandline -opc)
+  set -l cur (commandline -ct)
+  if string match -q -- '-*' $cur
+    $tokens $cur --generate-shell-completion 2>/dev/null
+  else
+    $tokens --generate-shell-completion 2>/dev/null
+  end
+end
+
+complete -c willow -f -a '(__fish_willow_complete)'
+complete -c ww -w willow
+`
+
+func detectShell() string {
+	shell := filepath.Base(os.Getenv("SHELL"))
+	switch shell {
+	case "bash", "zsh", "fish":
+		return shell
+	default:
+		return "bash"
+	}
+}
 
 func shellInitCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "shell-init",
 		Usage: "Print shell integration script",
 		Action: func(_ context.Context, cmd *cli.Command) error {
-			fmt.Print(shellInitScript)
+			shell := detectShell()
+			switch shell {
+			case "zsh":
+				fmt.Print(zshInitScript)
+			case "fish":
+				fmt.Print(fishInitScript)
+			default:
+				fmt.Print(bashInitScript)
+			}
 			return nil
 		},
 	}


### PR DESCRIPTION
## Summary
- `shell-init` now auto-detects bash/zsh/fish from `$SHELL` and emits the appropriate completion script
- Commands that accept `<branch-or-name>` (`pwd`, `rm`) complete with worktree branch names
- Enables urfave/cli's `EnableShellCompletion` for dynamic `--generate-shell-completion` support
- README updated with fish instructions and `run --all` documentation

## Changes
- `app.go` — `EnableShellCompletion: true` on root command
- `shellinit.go` — per-shell scripts (bash, zsh, fish) with completion registration
- `pwd.go` — shared `completeWorktrees` ShellComplete function
- `rm.go` — wired to `completeWorktrees`
- `README.md` — fish shell-init instructions, tab completion mention, `run --all` example

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (31 tests)
- [ ] `eval "$(willow shell-init)"` in zsh, verify `ww<tab>` completes commands
- [ ] `ww rm <tab>` completes with branch names in a willow repo
- [ ] `ww pwd <tab>` completes with branch names
- [ ] Verify fish: `willow shell-init | source` + completion works