### PR TITLE
✨ feat(cli): willow-aware context detection & repo-scoped commands

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1,10 +1,26 @@
 package cli
 
 import (
+	"fmt"
+
+	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/urfave/cli/v3"
 )
+
+var errNotWillowRepo = fmt.Errorf("not inside a willow-managed repo\n\nRun this command from a worktree under ~/.willow, or use 'ww ls' to see your repos.")
+
+func requireWillowRepo(g *git.Git) (string, error) {
+	bareDir, err := g.BareRepoDir()
+	if err != nil {
+		return "", errNotWillowRepo
+	}
+	if !config.IsWillowRepo(bareDir) {
+		return "", errNotWillowRepo
+	}
+	return bareDir, nil
+}
 
 var version = "dev"
 

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -155,7 +155,7 @@ func configSet(cmd *cli.Command, g *git.Git, u *ui.UI, key, value string) error 
 	if cmd.Bool("global") {
 		configPath = config.GlobalConfigPath()
 	} else {
-		bareDir, err := g.BareRepoDir()
+		bareDir, err := requireWillowRepo(g)
 		if err != nil {
 			return fmt.Errorf("not inside a willow-managed repo (use --global for global config)")
 		}
@@ -189,7 +189,7 @@ func configEdit(cmd *cli.Command, g *git.Git) error {
 	if cmd.Bool("global") {
 		configPath = config.GlobalConfigPath()
 	} else {
-		bareDir, err := g.BareRepoDir()
+		bareDir, err := requireWillowRepo(g)
 		if err != nil {
 			return fmt.Errorf("not inside a willow-managed repo (use --global for global config)")
 		}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -38,7 +38,7 @@ func initCmd() *cli.Command {
 			if cmd.Bool("global") {
 				configPath = config.GlobalConfigPath()
 			} else {
-				bareDir, err = g.BareRepoDir()
+				bareDir, err = requireWillowRepo(g)
 				if err != nil {
 					return fmt.Errorf("not inside a willow-managed repo (use --global for global config)")
 				}

--- a/internal/cli/prune.go
+++ b/internal/cli/prune.go
@@ -28,7 +28,7 @@ func pruneCmd() *cli.Command {
 			g := flags.NewGit()
 			u := flags.NewUI()
 
-			bareDir, err := g.BareRepoDir()
+			bareDir, err := requireWillowRepo(g)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/pwd.go
+++ b/internal/cli/pwd.go
@@ -30,7 +30,7 @@ func pwdCmd() *cli.Command {
 				return fmt.Errorf("branch or worktree name is required\n\nUsage: ww pwd <branch-or-name>")
 			}
 
-			bareDir, err := g.BareRepoDir()
+			bareDir, err := requireWillowRepo(g)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -50,7 +50,7 @@ func rmCmd() *cli.Command {
 				return fmt.Errorf("branch or worktree name is required\n\nUsage: ww rm <branch-or-name> [flags]")
 			}
 
-			bareDir, err := g.BareRepoDir()
+			bareDir, err := requireWillowRepo(g)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -32,7 +32,7 @@ func runCmd() *cli.Command {
 				return fmt.Errorf("usage: ww run <branch-or-name> -- <command...>\n       ww run --all -- <command...>")
 			}
 
-			bareDir, err := g.BareRepoDir()
+			bareDir, err := requireWillowRepo(g)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -27,6 +27,8 @@ wwg() {
   cd "$dir" || return
 }
 
+www() { cd ~/.willow/worktrees || return; }
+
 # Tab completion
 __willow_init_completion() {
   COMPREPLY=()
@@ -77,6 +79,8 @@ wwg() {
   cd "$dir" || return
 }
 
+www() { cd ~/.willow/worktrees || return; }
+
 # Tab completion
 _willow() {
   local -a opts
@@ -119,6 +123,10 @@ function wwg
   set -l dir (willow pwd $argv)
   or return
   cd $dir
+end
+
+function www
+  cd ~/.willow/worktrees; or return
 end
 
 # Tab completion


### PR DESCRIPTION
## Summary

- **Repo-scoped commands**: All commands (`new`, `ls`, `rm`, `pwd`, `run`, `prune`, `init`, `config`) are now scoped to `~/.willow`-managed repos. Running them from a non-willow git repo shows a clear error instead of confusingly operating on that repo's worktrees.
- **Context-aware `ww ls`**: Lists repos with worktree counts when outside willow, lists worktrees when inside a willow repo, and accepts an optional `[repo]` positional arg to target a specific repo from anywhere.
- **`--repo` flag on `ww new`**: Create worktrees in any willow-managed repo without `cd`'ing there first (`ww new fix-bug --repo backend`).
- **`www` shell alias**: Quick `cd ~/.willow/worktrees` via shell-init (bash, zsh, fish).
- **Shell completions**: Tab completion for repo names on `ww ls`.
- **README update**: Added full example workflow (clone → init → new → commit/push → ls → rm) and documented all new flags/behavior.

## Test plan

- [x] `go build` compiles cleanly
- [x] `go vet ./...` passes
- [x] `go test ./...` — all existing tests pass
- [ ] `ww clone <repo>` then `ww ls` from inside worktree shows worktrees
- [ ] `ww ls` from outside willow lists all repos with counts
- [ ] `ww ls <repo-name>` lists that repo's worktrees from anywhere
- [ ] `ww new branch --repo <name>` creates worktree from anywhere
- [ ] `ww new branch` from non-willow repo errors with helpful message
- [ ] `ww rm`, `ww pwd`, `ww run`, `ww prune` error clearly from non-willow repo
- [ ] `willow shell-init` output includes `www` alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)