### PR TITLE
🐛 Auto cd after removing current worktree

### DIFF
--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -13,7 +13,18 @@ const bashInitScript = `# Willow shell integration
 # Add to your .bashrc:
 #   eval "$(willow shell-init)"
 
-alias ww='willow'
+ww() {
+  if [ "$1" = "rm" ]; then
+    local cwd="$PWD"
+    command willow "$@"
+    local ret=$?
+    if [ $ret -eq 0 ] && ! [ -d "$cwd" ]; then
+      cd "${cwd%/*}" 2>/dev/null || cd ~/.willow/worktrees 2>/dev/null || true
+    fi
+    return $ret
+  fi
+  command willow "$@"
+}
 
 wwn() {
   local dir
@@ -65,7 +76,18 @@ const zshInitScript = `# Willow shell integration
 # Add to your .zshrc:
 #   eval "$(willow shell-init)"
 
-alias ww='willow'
+ww() {
+  if [ "$1" = "rm" ]; then
+    local cwd="$PWD"
+    command willow "$@"
+    local ret=$?
+    if [ $ret -eq 0 ] && ! [ -d "$cwd" ]; then
+      cd "${cwd%/*}" 2>/dev/null || cd ~/.willow/worktrees 2>/dev/null || true
+    fi
+    return $ret
+  fi
+  command willow "$@"
+}
 
 wwn() {
   local dir
@@ -111,7 +133,20 @@ const fishInitScript = `# Willow shell integration
 # Add to your config.fish:
 #   willow shell-init | source
 
-alias ww='willow'
+function ww
+  if test (count $argv) -gt 0; and test "$argv[1]" = "rm"
+    set -l cwd $PWD
+    command willow $argv
+    set -l ret $status
+    if test $ret -eq 0; and not test -d "$cwd"
+      cd (string replace -r '/[^/]+$' '' "$cwd") 2>/dev/null
+        or cd ~/.willow/worktrees 2>/dev/null
+        or true
+    end
+    return $ret
+  end
+  command willow $argv
+end
 
 function wwn
   set -l dir (willow new $argv --cd)


### PR DESCRIPTION
## Summary

- When `ww rm` removes the worktree you're currently in, the shell was left stranded in a deleted directory
- The `ww` shell function (bash, zsh, fish) now detects this and automatically cds to `~/.willow/worktrees/<repo>/`
- If you're removing a worktree you're NOT in, behavior is unchanged

The approach: `ww` is now a function instead of a simple alias. For `rm`, it saves `$PWD` before removal, then checks if the directory still exists after. If not, it cds to the parent (`${cwd%/*}`), which is the repo's worktrees folder.

## Test plan

- [x] `go build` and `go test ./...` pass
- [x] `ww rm` from inside the removed worktree → lands in `~/.willow/worktrees/<repo>/`
- [x] `ww rm` from a different worktree → cwd unchanged
- [x] All other `ww` commands pass through normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)