### PR TITLE
✨ feat(config): add postCheckoutHook config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Config is resolved by merging three tiers (later wins):
 {
   "baseBranch": "main",           // default base branch for new worktrees
   "branchPrefix": "alice",        // auto-prepended to branch names (e.g. alice/my-branch)
+  "postCheckoutHook": ".husky/post-checkout",  // run this hook after creating a worktree
   "setup": ["npm install"],       // run after creating a worktree
   "teardown": ["rm -rf node_modules"],  // run before removing a worktree
   "defaults": {
@@ -253,6 +254,8 @@ Config is resolved by merging three tiers (later wins):
   }
 }
 ```
+
+> **Note:** `postCheckoutHook` is needed because git resolves relative `core.hooksPath` against the bare repo directory, where hook files don't exist. This field tells willow to manually invoke the hook from the new worktree after creation.
 
 ### Merge behavior
 

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -102,6 +102,9 @@ func cloneCmd() *cli.Command {
 				return fmt.Errorf("failed to create initial worktree: %w", err)
 			}
 
+			cfg := config.Load(bareDir, wtPath)
+			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath)
+
 			u.Success(fmt.Sprintf("Cloned %s", u.Bold(name)))
 			u.Info(fmt.Sprintf("  bare repo:  %s", u.Dim(bareDir)))
 			u.Info(fmt.Sprintf("  worktree:   %s", u.Dim(wtPath)))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,11 +10,12 @@ import (
 )
 
 type Config struct {
-	BaseBranch   string   `json:"baseBranch,omitempty"`
-	BranchPrefix string   `json:"branchPrefix,omitempty"`
-	Setup        []string `json:"setup,omitempty"`
-	Teardown     []string `json:"teardown,omitempty"`
-	Defaults     Defaults `json:"defaults"`
+	BaseBranch        string   `json:"baseBranch,omitempty"`
+	BranchPrefix      string   `json:"branchPrefix,omitempty"`
+	PostCheckoutHook  string   `json:"postCheckoutHook,omitempty"`
+	Setup             []string `json:"setup,omitempty"`
+	Teardown          []string `json:"teardown,omitempty"`
+	Defaults          Defaults `json:"defaults"`
 }
 
 type Defaults struct {
@@ -147,6 +148,9 @@ func merge(base, overlay *Config) {
 	}
 	if overlay.BranchPrefix != "" {
 		base.BranchPrefix = overlay.BranchPrefix
+	}
+	if overlay.PostCheckoutHook != "" {
+		base.PostCheckoutHook = overlay.PostCheckoutHook
 	}
 	if overlay.Setup != nil {
 		base.Setup = overlay.Setup


### PR DESCRIPTION
## Summary
- Adds `postCheckoutHook` string field to willow config (all 3 tiers: global → shared → local)
- When set, willow manually invokes the specified hook script from the new worktree after `git worktree add`
- Applies to both `ww new` and `ww clone` (initial worktree creation)

## Context
Git resolves relative `core.hooksPath` against the bare repo directory, where hook files (like `.husky/post-checkout`) don't exist. This means post-checkout hooks never fire automatically for bare-clone worktrees, breaking features like node_modules caching.

## Usage
```json
{
  "postCheckoutHook": ".husky/post-checkout"
}
```

## Test plan
- [x] `go build && go test ./...` passes
- [x] Set `"postCheckoutHook": ".husky/post-checkout"` in evergreen's willow config
- [x] `ww new test-branch --repo evergreen` — verified hook fires and runs `worktree_init`