### PR TITLE
✨ feat(cli): resolve repo context from worktrees directory

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -82,6 +82,9 @@ func configCmd() *cli.Command {
 
 func configList(g *git.Git, u *ui.UI) error {
 	bareDir, _ := g.BareRepoDir()
+	if bareDir == "" {
+		bareDir, _ = resolveRepoFromCwd()
+	}
 	worktreeRoot, _ := g.WorktreeRoot()
 
 	type tier struct {
@@ -138,6 +141,9 @@ func configGet(g *git.Git, u *ui.UI, key string) error {
 	}
 
 	bareDir, _ := g.BareRepoDir()
+	if bareDir == "" {
+		bareDir, _ = resolveRepoFromCwd()
+	}
 	worktreeRoot, _ := g.WorktreeRoot()
 	cfg := config.Load(bareDir, worktreeRoot)
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -49,9 +49,12 @@ func lsCmd() *cli.Command {
 				return listWorktrees(flags, cmd, &git.Git{Dir: bareDir, Verbose: g.Verbose})
 			}
 
-			// Try to detect the current repo
+			// Try to detect the current repo (git context or worktrees dir)
 			bareDir, err := g.BareRepoDir()
 			if err == nil && config.IsWillowRepo(bareDir) {
+				return listWorktrees(flags, cmd, &git.Git{Dir: bareDir, Verbose: g.Verbose})
+			}
+			if bareDir, ok := resolveRepoFromCwd(); ok {
 				return listWorktrees(flags, cmd, &git.Git{Dir: bareDir, Verbose: g.Verbose})
 			}
 

--- a/internal/cli/pwd.go
+++ b/internal/cli/pwd.go
@@ -63,7 +63,11 @@ func completeWorktrees(ctx context.Context, cmd *cli.Command) {
 	g := &git.Git{}
 	bareDir, err := g.BareRepoDir()
 	if err != nil {
-		return
+		if dir, ok := resolveRepoFromCwd(); ok {
+			bareDir = dir
+		} else {
+			return
+		}
 	}
 	repoGit := &git.Git{Dir: bareDir}
 	wts, err := worktree.List(repoGit)


### PR DESCRIPTION
## Summary
- Adds `ResolveRepoFromDir` helper that maps `~/.willow/worktrees/<name>/` to `~/.willow/repos/<name>.git`
- Updates `requireWillowRepo` (used by `rm`, `run`, `prune`, `pwd`, `init`, `config set/edit`) to fall back to this resolution
- Updates `ls`, `config list`, `config get`, and tab completion to also use the fallback

## Context
Previously, commands only worked from inside a specific worktree (where `git rev-parse --git-common-dir` succeeds). Running `ww ls` from `~/.willow/worktrees/evergreen/` would fall through to listing all repos instead of showing that repo's worktrees. This was unintuitive since users often `cd` into the repo's worktrees directory to browse branches.

## Test plan
- [x] `go build && go test ./...` passes
- [x] `ww ls` from `~/.willow/worktrees/evergreen/` lists evergreen's worktrees
- [x] `ww ls` from `/tmp` still shows the repo list