### PR TITLE
🐛 bug(various fixes): Improve error handling, UX, and robustness

### DIFF
--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -16,6 +16,7 @@ import (
 var configKeys = []string{
 	"baseBranch",
 	"branchPrefix",
+	"postCheckoutHook",
 	"setup",
 	"teardown",
 	"defaults.fetch",
@@ -237,6 +238,10 @@ func getFieldValue(cfg *config.Config, key string) (string, bool) {
 		if cfg.BranchPrefix != "" {
 			return cfg.BranchPrefix, true
 		}
+	case "postCheckoutHook":
+		if cfg.PostCheckoutHook != "" {
+			return cfg.PostCheckoutHook, true
+		}
 	case "setup":
 		if cfg.Setup != nil {
 			return strings.Join(cfg.Setup, ", "), true
@@ -263,6 +268,8 @@ func setFieldValue(cfg *config.Config, key, value string) error {
 		cfg.BaseBranch = value
 	case "branchPrefix":
 		cfg.BranchPrefix = value
+	case "postCheckoutHook":
+		cfg.PostCheckoutHook = value
 	case "setup":
 		cfg.Setup = splitCommands(value)
 	case "teardown":

--- a/internal/cli/pwd_test.go
+++ b/internal/cli/pwd_test.go
@@ -9,9 +9,9 @@ import (
 
 var testWorktrees = []worktree.Worktree{
 	{Branch: "main", Path: "/home/user/.willow/worktrees/repo/main"},
-	{Branch: "feature/auth", Path: "/home/user/.willow/worktrees/repo/featureauth"},
-	{Branch: "feature/payments", Path: "/home/user/.willow/worktrees/repo/featurepayments"},
-	{Branch: "alice/bugfix", Path: "/home/user/.willow/worktrees/repo/alicebugfix"},
+	{Branch: "feature/auth", Path: "/home/user/.willow/worktrees/repo/feature-auth"},
+	{Branch: "feature/payments", Path: "/home/user/.willow/worktrees/repo/feature-payments"},
+	{Branch: "alice/bugfix", Path: "/home/user/.willow/worktrees/repo/alice-bugfix"},
 }
 
 func TestFindWorktree_ExactBranch(t *testing.T) {
@@ -35,7 +35,7 @@ func TestFindWorktree_SubstringBranch(t *testing.T) {
 }
 
 func TestFindWorktree_DirectorySuffix(t *testing.T) {
-	wt, err := findWorktree(testWorktrees, "featureauth")
+	wt, err := findWorktree(testWorktrees, "feature-auth")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -65,12 +65,21 @@ func TestFindWorktree_NotFound(t *testing.T) {
 }
 
 func TestFindWorktree_ExactMatchTakesPriority(t *testing.T) {
-	// "main" matches both as an exact branch and as a substring of other branches
 	wt, err := findWorktree(testWorktrees, "main")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if wt.Branch != "main" {
 		t.Errorf("Branch = %q, want %q (exact match should win)", wt.Branch, "main")
+	}
+}
+
+func TestPickWorktree_EmptyList(t *testing.T) {
+	err := pickWorktree(nil)
+	if err == nil {
+		t.Fatal("expected error for empty worktree list")
+	}
+	if !strings.Contains(err.Error(), "no worktrees found") {
+		t.Errorf("error = %q, want it to contain 'no worktrees found'", err.Error())
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -73,11 +74,16 @@ func runCmd() *cli.Command {
 			}
 
 			if runAll {
+				var failed []string
 				for _, wt := range filtered {
 					u.Info(fmt.Sprintf("==> %s", u.Bold(wt.Branch)))
 					if err := execIn(wt.Path, cmdArgs); err != nil {
 						u.Warn(fmt.Sprintf("command failed in %s: %v", wt.Branch, err))
+						failed = append(failed, wt.Branch)
 					}
+				}
+				if len(failed) > 0 {
+					return fmt.Errorf("command failed in %d/%d worktrees: %s", len(failed), len(filtered), strings.Join(failed, ", "))
 				}
 				return nil
 			}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -73,8 +73,11 @@ func (g *Git) IsDirty() (bool, error) {
 func (g *Git) HasUnpushedCommits() (bool, error) {
 	out, err := g.Run("rev-list", "--count", "@{upstream}..HEAD")
 	if err != nil {
-		// No upstream set — treat as unpushed
-		return true, nil
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "no upstream") || strings.Contains(errMsg, "upstream") {
+			return true, nil
+		}
+		return false, err
 	}
 	return strings.TrimSpace(out) != "0", nil
 }


### PR DESCRIPTION
## Summary

- **Fix silent post-checkout hook errors** — `runPostCheckoutHook` now warns via `ui.Warn` when the hook fails instead of silently swallowing the error
- **Fix `HasUnpushedCommits` swallowing all errors** — only treats "no upstream" as unpushed; real git errors (network, permission, corruption) are now propagated
- **Fix branch name collision from slash stripping** — `feature/auth` now creates directory `feature-auth` instead of `featureauth`, preventing collisions with a branch literally named `featureauth`
- **Add cleanup on partial clone failure** — if any step after the bare clone fails (fetch, config, worktree creation), both `bareDir` and `worktreesDir` are cleaned up
- **Add interactive worktree picker for `pwd`** — when called with no argument, shows a numbered list and prompts for selection (also makes `wwg` with no args work interactively)
- **Expose `postCheckoutHook` in `ww config` CLI** — now visible in `--list`, gettable and settable via `ww config postCheckoutHook <path>`
- **Improve `run --all` result aggregation** — tracks failures and returns a summary error like `command failed in 2/5 worktrees: main, payments`

Also verified:
- Error wrapping already uses `%w` consistently (no `%v` found)
- Shell completion is correctly using `--generate-shell-completion` per urfave/cli/v3 API

## Test plan

- [x] All 34 existing + new tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] Manual verification: `ww config --list` shows `postCheckoutHook`
- [x] Manual verification: `--generate-shell-completion` returns all subcommands
- [x] Manual verification: shell-init detects bash/zsh correctly
- [x] Integration test for slashed branch directory naming (`TestNew_SlashedBranchDirName`)
- [x] Integration test for postCheckoutHook config set (`TestConfig_PostCheckoutHook`)
- [x] Unit test for empty worktree picker (`TestPickWorktree_EmptyList`)