### PR TITLE
✨ feat(cli): add --trace flag for performance debugging and remove --no-color

### DIFF
--- a/cmd/willow/main.go
+++ b/cmd/willow/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	root := cli.NewApp()
 	if err := root.Run(context.Background(), os.Args); err != nil {
-		u := &ui.UI{NoColor: root.Bool("no-color")}
+		u := &ui.UI{}
 		u.Errorf("%v", err)
 		os.Exit(1)
 	}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -37,13 +37,13 @@ var version = "dev"
 
 type Flags struct {
 	Verbose bool
-	NoColor bool
+	Trace   bool
 }
 
 func parseFlags(cmd *cli.Command) Flags {
 	return Flags{
 		Verbose: cmd.Root().Bool("verbose"),
-		NoColor: cmd.Root().Bool("no-color"),
+		Trace:   cmd.Root().Bool("trace"),
 	}
 }
 
@@ -52,7 +52,7 @@ func (f Flags) NewGit() *git.Git {
 }
 
 func (f Flags) NewUI() *ui.UI {
-	return &ui.UI{NoColor: f.NoColor}
+	return &ui.UI{}
 }
 
 func NewApp() *cli.Command {
@@ -72,8 +72,9 @@ func NewApp() *cli.Command {
 				Usage: "Show git commands being executed",
 			},
 			&cli.BoolFlag{
-				Name:  "no-color",
-				Usage: "Disable colored output",
+				Name:    "trace",
+				Usage:   "Print timing trace to stderr for performance debugging",
+				Sources: cli.EnvVars("WILLOW_TRACE"),
 			},
 		},
 		Commands: []*cli.Command{

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -7,9 +7,11 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/urfave/cli/v3"
 )
 
@@ -35,6 +37,7 @@ func cloneCmd() *cli.Command {
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
+			tr := trace.New(flags.Trace)
 			g := flags.NewGit()
 			u := flags.NewUI()
 
@@ -74,9 +77,11 @@ func cloneCmd() *cli.Command {
 
 			// Bare clone
 			u.Info(fmt.Sprintf("Cloning %s into %s...", url, u.Bold(bareDir)))
+			t := time.Now()
 			if _, err := g.Run("clone", "--bare", url, bareDir); err != nil {
 				return fmt.Errorf("failed to clone repository: %w", err)
 			}
+			tr.Step("git clone --bare", t)
 
 			// If anything below fails, clean up the partial clone
 			cleanup := func() {
@@ -93,10 +98,12 @@ func cloneCmd() *cli.Command {
 			}
 
 			u.Info("Fetching latest from origin...")
+			t = time.Now()
 			if _, err := repoGit.Run("fetch", "origin"); err != nil {
 				cleanup()
 				return fmt.Errorf("failed to fetch from origin: %w", err)
 			}
+			tr.Step("git fetch origin", t)
 
 			defaultBranch, err := repoGit.DefaultBranch()
 			if err != nil {
@@ -107,13 +114,19 @@ func cloneCmd() *cli.Command {
 			// Create the initial worktree on the default branch
 			wtPath := filepath.Join(worktreesDir, defaultBranch)
 			u.Info(fmt.Sprintf("Creating worktree %s at %s...", u.Bold(defaultBranch), wtPath))
+			t = time.Now()
 			if _, err := repoGit.Run("worktree", "add", wtPath, defaultBranch); err != nil {
 				cleanup()
 				return fmt.Errorf("failed to create initial worktree: %w", err)
 			}
+			tr.Step("git worktree add", t)
 
+			t = time.Now()
 			cfg := config.Load(bareDir)
 			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
+			tr.Step("post-checkout hook", t)
+
+			tr.Total()
 
 			u.Success(fmt.Sprintf("Cloned %s", u.Bold(name)))
 			u.Info(fmt.Sprintf("  bare repo:  %s", u.Dim(bareDir)))

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -7,9 +7,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/urfave/cli/v3"
 )
@@ -101,6 +103,7 @@ func newCmd() *cli.Command {
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
+			tr := trace.New(flags.Trace)
 			g := flags.NewGit()
 			u := flags.NewUI()
 			cdOnly := cmd.Bool("cd")
@@ -112,6 +115,7 @@ func newCmd() *cli.Command {
 
 			var bareDir string
 			var err error
+			t := time.Now()
 			if repoFlag := cmd.String("repo"); repoFlag != "" {
 				bareDir, err = config.ResolveRepo(repoFlag)
 				if err != nil {
@@ -123,7 +127,11 @@ func newCmd() *cli.Command {
 					return err
 				}
 			}
+			tr.Step("resolve repo", t)
+
+			t = time.Now()
 			cfg := config.Load(bareDir)
+			tr.Step("load config", t)
 
 			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
 			repoName := repoNameFromDir(bareDir)
@@ -134,6 +142,7 @@ func newCmd() *cli.Command {
 			}
 
 			// Resolve base branch: flag → config → auto-detect
+			t = time.Now()
 			baseBranch := cmd.String("base")
 			if baseBranch == "" {
 				baseBranch = cfg.BaseBranch
@@ -144,6 +153,7 @@ func newCmd() *cli.Command {
 					return fmt.Errorf("failed to detect default branch (use --base to specify): %w", err)
 				}
 			}
+			tr.Step("resolve base branch", t)
 
 			// Fetch latest from remote (config default, --no-fetch overrides)
 			shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch")
@@ -151,14 +161,17 @@ func newCmd() *cli.Command {
 				if !cdOnly {
 					u.Info(fmt.Sprintf("Fetching %s from origin...", u.Bold(baseBranch)))
 				}
+				t = time.Now()
 				if _, err := repoGit.Run("fetch", "origin", baseBranch); err != nil {
 					return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
 				}
+				tr.Step("git fetch", t)
 			}
 
 			dirName := strings.ReplaceAll(branch, "/", "-")
 			wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
 
+			t = time.Now()
 			if cmd.Bool("existing") {
 				if !cdOnly {
 					u.Info(fmt.Sprintf("Creating worktree for existing branch %s...", u.Bold(branch)))
@@ -174,23 +187,32 @@ func newCmd() *cli.Command {
 					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			}
+			tr.Step("git worktree add", t)
 
+			t = time.Now()
 			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
+			tr.Step("post-checkout hook", t)
 
+			t = time.Now()
 			if *cfg.Defaults.AutoSetupRemote {
 				wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
 				if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
 					return fmt.Errorf("failed to configure push.autoSetupRemote: %w", err)
 				}
 			}
+			tr.Step("auto setup remote", t)
 
 			// Run setup hooks
+			t = time.Now()
 			if len(cfg.Setup) > 0 && !cdOnly {
 				u.Info("Running setup hooks...")
 				if err := runHooks(cfg.Setup, wtPath, u); err != nil {
 					return err
 				}
 			}
+			tr.Step("setup hooks", t)
+
+			tr.Total()
 
 			if cdOnly {
 				fmt.Println(wtPath)

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -1,0 +1,55 @@
+package trace
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+type Tracer struct {
+	enabled bool
+	start   time.Time
+	steps   []step
+}
+
+type step struct {
+	label    string
+	duration time.Duration
+}
+
+func New(enabled bool) *Tracer {
+	return &Tracer{
+		enabled: enabled,
+		start:   time.Now(),
+	}
+}
+
+// Step records a completed step and prints its duration.
+func (t *Tracer) Step(label string, start time.Time) {
+	if !t.enabled {
+		return
+	}
+	d := time.Since(start)
+	t.steps = append(t.steps, step{label: label, duration: d})
+	fmt.Fprintf(os.Stderr, "[trace] %-25s %s\n", label, formatDuration(d))
+}
+
+// Total prints the total elapsed time since the tracer was created.
+func (t *Tracer) Total() {
+	if !t.enabled {
+		return
+	}
+	d := time.Since(t.start)
+	fmt.Fprintf(os.Stderr, "[trace] %-25s %s\n", "TOTAL", formatDuration(d))
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Millisecond:
+		return fmt.Sprintf("%.0fµs", float64(d.Microseconds()))
+	case d < time.Second:
+		return fmt.Sprintf("%.1fms", float64(d.Microseconds())/1000)
+	default:
+		return fmt.Sprintf("%.2fs", d.Seconds())
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -15,9 +15,7 @@ const (
 	cyan   = "\033[36m"
 )
 
-type UI struct {
-	NoColor bool
-}
+type UI struct{}
 
 func (u *UI) Success(msg string) {
 	fmt.Printf("%s %s\n", u.Green("✔"), msg)
@@ -36,43 +34,25 @@ func (u *UI) Errorf(format string, args ...any) {
 }
 
 func (u *UI) Bold(s string) string {
-	if u.NoColor {
-		return s
-	}
 	return bold + s + reset
 }
 
 func (u *UI) Green(s string) string {
-	if u.NoColor {
-		return s
-	}
 	return green + s + reset
 }
 
 func (u *UI) Yellow(s string) string {
-	if u.NoColor {
-		return s
-	}
 	return yellow + s + reset
 }
 
 func (u *UI) Red(s string) string {
-	if u.NoColor {
-		return s
-	}
 	return red + s + reset
 }
 
 func (u *UI) Cyan(s string) string {
-	if u.NoColor {
-		return s
-	}
 	return cyan + s + reset
 }
 
 func (u *UI) Dim(s string) string {
-	if u.NoColor {
-		return s
-	}
 	return dim + s + reset
 }


### PR DESCRIPTION
## Description of the change

- Adds `--trace` / `WILLOW_TRACE=1` flag that prints per-step timing to stderr, so users can share trace output when reporting slowness
- Instruments `new` and `clone` commands with trace steps (resolve repo, load config, git fetch, worktree add, post-checkout hook, setup hooks)
- Removes `--no-color` flag — the world needs color

Example output:
```
$ ww --trace new my-branch
[trace] resolve repo              15.7ms
[trace] load config               462µs
[trace] resolve base branch       14.0ms
[trace] git fetch                 4.08s
[trace] git worktree add          6.47s
[trace] post-checkout hook        7.23s
[trace] auto setup remote         17.3ms
[trace] setup hooks               0µs
[trace] TOTAL                     17.83s
```

## Test plan
- Manual: verified `--trace` prints timing on evergreen repo, silent without flag
- `go test ./...` passes