### PR TITLE
🔧 chore(website): custom domain, force-dark, consolidate .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ go.work.sum
 # Build output
 bin/
 dist/
+
+# Website
+website/node_modules/
+website/docs/.vitepress/dist/
+website/docs/.vitepress/cache/

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Requires Go 1.25+ and [fzf](https://github.com/junegunn/fzf).
 
 ## Website
 
-The [docs site](https://iamrajjoshi.github.io/willow/) is built with [VitePress](https://vitepress.dev/).
+The [docs site](https://getwillow.dev) is built with [VitePress](https://vitepress.dev/).
 
 ```bash
 cd website

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,3 +1,0 @@
-node_modules/
-docs/.vitepress/dist/
-docs/.vitepress/cache/

--- a/website/docs/.vitepress/config.mts
+++ b/website/docs/.vitepress/config.mts
@@ -6,8 +6,9 @@ const commitHash = execSync('git rev-parse --short HEAD').toString().trim()
 export default defineConfig({
   title: 'willow',
   description: 'A git worktree manager built for AI agent workflows.',
-  appearance: 'dark',
+  appearance: 'force-dark',
   cleanUrls: true,
+  sitemap: { hostname: 'https://getwillow.dev' },
 
   head: [
     ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
@@ -15,6 +16,8 @@ export default defineConfig({
     ['meta', { property: 'og:title', content: 'willow — Git worktree manager for AI agents' }],
     ['meta', { property: 'og:description', content: 'Spin up isolated worktrees for Claude Code sessions. Switch between them instantly with fzf. See which agents are busy, waiting, or idle.' }],
     ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:url', content: 'https://getwillow.dev' }],
+    ['link', { rel: 'canonical', href: 'https://getwillow.dev' }],
   ],
 
   themeConfig: {

--- a/website/docs/public/CNAME
+++ b/website/docs/public/CNAME
@@ -1,0 +1,1 @@
+getwillow.dev


### PR DESCRIPTION
## Description of the change

- Add `CNAME` file for `getwillow.dev` custom domain
- Set `appearance: 'force-dark'` to lock dark mode and hide toggle
- Add sitemap, `og:url`, canonical link for `getwillow.dev`
- Update README docs link to `https://getwillow.dev`
- Consolidate `website/.gitignore` into root `.gitignore`

## Test plan

- `pnpm build` succeeds
- Light mode no longer accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)