### PR TITLE
✨ feat(trace): add Start/done API and migrate all commands

### DIFF
--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
@@ -77,11 +76,11 @@ func cloneCmd() *cli.Command {
 
 			// Bare clone
 			u.Info(fmt.Sprintf("Cloning %s into %s...", url, u.Bold(bareDir)))
-			t := time.Now()
+			done := tr.Start("git clone --bare")
 			if _, err := g.Run("clone", "--bare", url, bareDir); err != nil {
 				return fmt.Errorf("failed to clone repository: %w", err)
 			}
-			tr.Step("git clone --bare", t)
+			done()
 
 			// If anything below fails, clean up the partial clone
 			cleanup := func() {
@@ -98,12 +97,12 @@ func cloneCmd() *cli.Command {
 			}
 
 			u.Info("Fetching latest from origin...")
-			t = time.Now()
+			done = tr.Start("git fetch origin")
 			if _, err := repoGit.Run("fetch", "origin"); err != nil {
 				cleanup()
 				return fmt.Errorf("failed to fetch from origin: %w", err)
 			}
-			tr.Step("git fetch origin", t)
+			done()
 
 			defaultBranch, err := repoGit.DefaultBranch()
 			if err != nil {
@@ -114,17 +113,17 @@ func cloneCmd() *cli.Command {
 			// Create the initial worktree on the default branch
 			wtPath := filepath.Join(worktreesDir, defaultBranch)
 			u.Info(fmt.Sprintf("Creating worktree %s at %s...", u.Bold(defaultBranch), wtPath))
-			t = time.Now()
+			done = tr.Start("git worktree add")
 			if _, err := repoGit.Run("worktree", "add", wtPath, defaultBranch); err != nil {
 				cleanup()
 				return fmt.Errorf("failed to create initial worktree: %w", err)
 			}
-			tr.Step("git worktree add", t)
+			done()
 
-			t = time.Now()
+			done = tr.Start("post-checkout hook")
 			cfg := config.Load(bareDir)
 			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
-			tr.Step("post-checkout hook", t)
+			done()
 
 			tr.Total()
 
@@ -145,4 +144,3 @@ func repoNameFromURL(url string) string {
 	name := path.Base(url)
 	return strings.TrimSuffix(name, ".git")
 }
-

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
@@ -115,7 +114,7 @@ func newCmd() *cli.Command {
 
 			var bareDir string
 			var err error
-			t := time.Now()
+			done := tr.Start("resolve repo")
 			if repoFlag := cmd.String("repo"); repoFlag != "" {
 				bareDir, err = config.ResolveRepo(repoFlag)
 				if err != nil {
@@ -127,11 +126,11 @@ func newCmd() *cli.Command {
 					return err
 				}
 			}
-			tr.Step("resolve repo", t)
+			done()
 
-			t = time.Now()
+			done = tr.Start("load config")
 			cfg := config.Load(bareDir)
-			tr.Step("load config", t)
+			done()
 
 			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
 			repoName := repoNameFromDir(bareDir)
@@ -142,7 +141,7 @@ func newCmd() *cli.Command {
 			}
 
 			// Resolve base branch: flag → config → auto-detect
-			t = time.Now()
+			done = tr.Start("resolve base branch")
 			baseBranch := cmd.String("base")
 			if baseBranch == "" {
 				baseBranch = cfg.BaseBranch
@@ -153,7 +152,7 @@ func newCmd() *cli.Command {
 					return fmt.Errorf("failed to detect default branch (use --base to specify): %w", err)
 				}
 			}
-			tr.Step("resolve base branch", t)
+			done()
 
 			// Fetch latest from remote (config default, --no-fetch overrides)
 			shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch")
@@ -161,17 +160,17 @@ func newCmd() *cli.Command {
 				if !cdOnly {
 					u.Info(fmt.Sprintf("Fetching %s from origin...", u.Bold(baseBranch)))
 				}
-				t = time.Now()
+				done = tr.Start("git fetch")
 				if _, err := repoGit.Run("fetch", "origin", baseBranch); err != nil {
 					return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
 				}
-				tr.Step("git fetch", t)
+				done()
 			}
 
 			dirName := strings.ReplaceAll(branch, "/", "-")
 			wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
 
-			t = time.Now()
+			done = tr.Start("git worktree add")
 			if cmd.Bool("existing") {
 				if !cdOnly {
 					u.Info(fmt.Sprintf("Creating worktree for existing branch %s...", u.Bold(branch)))
@@ -187,30 +186,30 @@ func newCmd() *cli.Command {
 					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			}
-			tr.Step("git worktree add", t)
+			done()
 
-			t = time.Now()
+			done = tr.Start("post-checkout hook")
 			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
-			tr.Step("post-checkout hook", t)
+			done()
 
-			t = time.Now()
+			done = tr.Start("auto setup remote")
 			if *cfg.Defaults.AutoSetupRemote {
 				wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
 				if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
 					return fmt.Errorf("failed to configure push.autoSetupRemote: %w", err)
 				}
 			}
-			tr.Step("auto setup remote", t)
+			done()
 
 			// Run setup hooks
-			t = time.Now()
+			done = tr.Start("setup hooks")
 			if len(cfg.Setup) > 0 && !cdOnly {
 				u.Info("Running setup hooks...")
 				if err := runHooks(cfg.Setup, wtPath, u); err != nil {
 					return err
 				}
 			}
-			tr.Step("setup hooks", t)
+			done()
 
 			tr.Total()
 

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -24,14 +24,20 @@ func New(enabled bool) *Tracer {
 	}
 }
 
-// Step records a completed step and prints its duration.
-func (t *Tracer) Step(label string, start time.Time) {
+var noop = func() {}
+
+// Start begins timing a step and returns a function that records its duration.
+// When tracing is disabled, returns a no-op with zero allocations.
+func (t *Tracer) Start(label string) func() {
 	if !t.enabled {
-		return
+		return noop
 	}
-	d := time.Since(start)
-	t.steps = append(t.steps, step{label: label, duration: d})
-	fmt.Fprintf(os.Stderr, "[trace] %-25s %s\n", label, formatDuration(d))
+	start := time.Now()
+	return func() {
+		d := time.Since(start)
+		t.steps = append(t.steps, step{label: label, duration: d})
+		fmt.Fprintf(os.Stderr, "[trace] %-25s %s\n", label, formatDuration(d))
+	}
 }
 
 // Total prints the total elapsed time since the tracer was created.


### PR DESCRIPTION
## Description of the change

Replace the verbose `t = time.Now()` / `tr.Step("label", t)` tracing pattern with a cleaner `done := tr.Start("label")` / `done()` API. When tracing is disabled, returns a package-level `noop` (zero allocations).

Migrated `clone` and `new` commands to the new API.

## Test plan

- Manual: `ww --trace new` and `ww --trace clone` still print correct trace output
- Unit tests pass: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)