### PR TITLE
⚡ perf(rm): instant removal via move-to-trash + background delete

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -86,6 +86,7 @@ func NewApp() *cli.Command {
 			statusCmd(),
 			setupCmd(),
 			shellInitCmd(),
+			gcCmd(),
 		},
 	}
 }

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
@@ -77,11 +76,11 @@ func cloneCmd() *cli.Command {
 
 			// Bare clone
 			u.Info(fmt.Sprintf("Cloning %s into %s...", url, u.Bold(bareDir)))
-			t := time.Now()
+			done := tr.Start("git clone --bare")
 			if _, err := g.Run("clone", "--bare", url, bareDir); err != nil {
 				return fmt.Errorf("failed to clone repository: %w", err)
 			}
-			tr.Step("git clone --bare", t)
+			done()
 
 			// If anything below fails, clean up the partial clone
 			cleanup := func() {
@@ -98,12 +97,12 @@ func cloneCmd() *cli.Command {
 			}
 
 			u.Info("Fetching latest from origin...")
-			t = time.Now()
+			done = tr.Start("git fetch origin")
 			if _, err := repoGit.Run("fetch", "origin"); err != nil {
 				cleanup()
 				return fmt.Errorf("failed to fetch from origin: %w", err)
 			}
-			tr.Step("git fetch origin", t)
+			done()
 
 			defaultBranch, err := repoGit.DefaultBranch()
 			if err != nil {
@@ -114,17 +113,17 @@ func cloneCmd() *cli.Command {
 			// Create the initial worktree on the default branch
 			wtPath := filepath.Join(worktreesDir, defaultBranch)
 			u.Info(fmt.Sprintf("Creating worktree %s at %s...", u.Bold(defaultBranch), wtPath))
-			t = time.Now()
+			done = tr.Start("git worktree add")
 			if _, err := repoGit.Run("worktree", "add", wtPath, defaultBranch); err != nil {
 				cleanup()
 				return fmt.Errorf("failed to create initial worktree: %w", err)
 			}
-			tr.Step("git worktree add", t)
+			done()
 
-			t = time.Now()
+			done = tr.Start("post-checkout hook")
 			cfg := config.Load(bareDir)
 			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
-			tr.Step("post-checkout hook", t)
+			done()
 
 			tr.Total()
 
@@ -145,4 +144,3 @@ func repoNameFromURL(url string) string {
 	name := path.Base(url)
 	return strings.TrimSuffix(name, ".git")
 }
-

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/urfave/cli/v3"
+)
+
+func gcCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "gc",
+		Usage: "Clean up leftover trash from removed worktrees",
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			u := parseFlags(cmd).NewUI()
+
+			trashDir := config.TrashDir()
+			entries, err := os.ReadDir(trashDir)
+			if err != nil {
+				if os.IsNotExist(err) {
+					u.Info("Nothing to clean up.")
+					return nil
+				}
+				return fmt.Errorf("failed to read trash dir: %w", err)
+			}
+
+			if len(entries) == 0 {
+				u.Info("Nothing to clean up.")
+				return nil
+			}
+
+			for _, e := range entries {
+				path := trashDir + "/" + e.Name()
+				if err := os.RemoveAll(path); err != nil {
+					u.Warn(fmt.Sprintf("Failed to remove %s: %v", e.Name(), err))
+				}
+			}
+
+			u.Success(fmt.Sprintf("Cleaned up %d trash entries", len(entries)))
+			return nil
+		},
+	}
+}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
@@ -115,7 +114,7 @@ func newCmd() *cli.Command {
 
 			var bareDir string
 			var err error
-			t := time.Now()
+			done := tr.Start("resolve repo")
 			if repoFlag := cmd.String("repo"); repoFlag != "" {
 				bareDir, err = config.ResolveRepo(repoFlag)
 				if err != nil {
@@ -127,11 +126,11 @@ func newCmd() *cli.Command {
 					return err
 				}
 			}
-			tr.Step("resolve repo", t)
+			done()
 
-			t = time.Now()
+			done = tr.Start("load config")
 			cfg := config.Load(bareDir)
-			tr.Step("load config", t)
+			done()
 
 			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
 			repoName := repoNameFromDir(bareDir)
@@ -142,7 +141,7 @@ func newCmd() *cli.Command {
 			}
 
 			// Resolve base branch: flag → config → auto-detect
-			t = time.Now()
+			done = tr.Start("resolve base branch")
 			baseBranch := cmd.String("base")
 			if baseBranch == "" {
 				baseBranch = cfg.BaseBranch
@@ -153,7 +152,7 @@ func newCmd() *cli.Command {
 					return fmt.Errorf("failed to detect default branch (use --base to specify): %w", err)
 				}
 			}
-			tr.Step("resolve base branch", t)
+			done()
 
 			// Fetch latest from remote (config default, --no-fetch overrides)
 			shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch")
@@ -161,17 +160,17 @@ func newCmd() *cli.Command {
 				if !cdOnly {
 					u.Info(fmt.Sprintf("Fetching %s from origin...", u.Bold(baseBranch)))
 				}
-				t = time.Now()
+				done = tr.Start("git fetch")
 				if _, err := repoGit.Run("fetch", "origin", baseBranch); err != nil {
 					return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
 				}
-				tr.Step("git fetch", t)
+				done()
 			}
 
 			dirName := strings.ReplaceAll(branch, "/", "-")
 			wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
 
-			t = time.Now()
+			done = tr.Start("git worktree add")
 			if cmd.Bool("existing") {
 				if !cdOnly {
 					u.Info(fmt.Sprintf("Creating worktree for existing branch %s...", u.Bold(branch)))
@@ -187,30 +186,30 @@ func newCmd() *cli.Command {
 					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			}
-			tr.Step("git worktree add", t)
+			done()
 
-			t = time.Now()
+			done = tr.Start("post-checkout hook")
 			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
-			tr.Step("post-checkout hook", t)
+			done()
 
-			t = time.Now()
+			done = tr.Start("auto setup remote")
 			if *cfg.Defaults.AutoSetupRemote {
 				wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
 				if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
 					return fmt.Errorf("failed to configure push.autoSetupRemote: %w", err)
 				}
 			}
-			tr.Step("auto setup remote", t)
+			done()
 
 			// Run setup hooks
-			t = time.Now()
+			done = tr.Start("setup hooks")
 			if len(cfg.Setup) > 0 && !cdOnly {
 				u.Info("Running setup hooks...")
 				if err := runHooks(cfg.Setup, wtPath, u); err != nil {
 					return err
 				}
 			}
-			tr.Step("setup hooks", t)
+			done()
 
 			tr.Total()
 

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -5,12 +5,16 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
@@ -53,9 +57,11 @@ func rmCmd() *cli.Command {
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
+			tr := trace.New(flags.Trace)
 			g := flags.NewGit()
 			u := flags.NewUI()
 
+			done := tr.Start("resolve repo")
 			var bareDir string
 			var err error
 			if repoFlag := cmd.String("repo"); repoFlag != "" {
@@ -69,20 +75,23 @@ func rmCmd() *cli.Command {
 					return err
 				}
 			}
+			done()
 
+			done = tr.Start("list worktrees")
 			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
 			worktrees, err := worktree.List(repoGit)
 			if err != nil {
 				return fmt.Errorf("failed to list worktrees: %w", err)
 			}
+			done()
 
 			filtered := filterBareWorktrees(worktrees)
 
+			done = tr.Start("resolve target")
 			target := cmd.StringArg("branch")
 			var wt *worktree.Worktree
 
 			if target == "" {
-				// No argument: launch fzf picker
 				repoName := repoNameFromDir(bareDir)
 				selectedPath, err := fzfPickWorktree(filtered, repoName)
 				if err != nil {
@@ -91,7 +100,6 @@ func rmCmd() *cli.Command {
 				if selectedPath == "" {
 					return nil
 				}
-				// Find the worktree matching the selected path
 				for i := range filtered {
 					if filtered[i].Path == selectedPath {
 						wt = &filtered[i]
@@ -107,11 +115,13 @@ func rmCmd() *cli.Command {
 					return err
 				}
 			}
+			done()
 
 			force := cmd.Bool("force")
 			wtGit := &git.Git{Dir: wt.Path, Verbose: g.Verbose}
 
 			if !force {
+				done = tr.Start("check dirty")
 				dirty, err := wtGit.IsDirty()
 				if err != nil {
 					return err
@@ -119,7 +129,9 @@ func rmCmd() *cli.Command {
 				if dirty {
 					u.Warn(fmt.Sprintf("Worktree %s has uncommitted changes", u.Bold(wt.Branch)))
 				}
+				done()
 
+				done = tr.Start("check unpushed")
 				unpushed, err := wtGit.HasUnpushedCommits()
 				if err != nil {
 					return err
@@ -127,6 +139,7 @@ func rmCmd() *cli.Command {
 				if unpushed {
 					u.Warn(fmt.Sprintf("Worktree %s has unpushed commits", u.Bold(wt.Branch)))
 				}
+				done()
 
 				if (dirty || unpushed) && !cmd.Bool("yes") {
 					if !confirm("Remove anyway?") {
@@ -141,42 +154,76 @@ func rmCmd() *cli.Command {
 				}
 			}
 
-			// Run teardown hooks before removal
+			done = tr.Start("load config")
 			cfg := config.Load(bareDir)
+			done()
+
 			if len(cfg.Teardown) > 0 {
+				done = tr.Start("teardown hooks")
 				u.Info("Running teardown hooks...")
 				if err := runHooks(cfg.Teardown, wt.Path, u); err != nil {
 					return err
 				}
+				done()
 			}
 
-			if _, err := repoGit.Run("worktree", "remove", "--force", wt.Path); err != nil {
-				return fmt.Errorf("failed to remove worktree: %w", err)
+			// Move worktree to trash instead of blocking on rm -rf.
+			// 1) Remove the git worktree admin dir so git no longer tracks it.
+			// 2) Rename the worktree dir into ~/.willow/trash/<id> (instant on same FS).
+			// 3) Spawn a detached rm -rf on the trash entry so the user isn't blocked.
+			done = tr.Start("remove worktree")
+			adminDir := filepath.Join(bareDir, "worktrees", filepath.Base(wt.Path))
+			if err := os.RemoveAll(adminDir); err != nil {
+				return fmt.Errorf("failed to remove worktree admin dir: %w", err)
 			}
 
+			trashDir := config.TrashDir()
+			if err := os.MkdirAll(trashDir, 0o755); err != nil {
+				return fmt.Errorf("failed to create trash dir: %w", err)
+			}
+
+			trashDest := filepath.Join(trashDir, fmt.Sprintf("%d-%s", time.Now().UnixNano(), filepath.Base(wt.Path)))
+			if err := os.Rename(wt.Path, trashDest); err != nil {
+				// Rename can fail across filesystems; fall back to synchronous removal.
+				if removeErr := os.RemoveAll(wt.Path); removeErr != nil {
+					return fmt.Errorf("failed to remove worktree: %w", removeErr)
+				}
+			} else {
+				bgRm := exec.Command("rm", "-rf", trashDest)
+				bgRm.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+				_ = bgRm.Start()
+			}
+			done()
+
+			done = tr.Start("git branch -D")
 			if !cmd.Bool("keep-branch") {
 				if _, err := repoGit.Run("branch", "-D", wt.Branch); err != nil {
 					u.Warn(fmt.Sprintf("Failed to delete branch %s: %v", wt.Branch, err))
 				}
 			}
+			done()
 
-			// Clean up status file
+			done = tr.Start("cleanup status")
 			repoName := repoNameFromDir(bareDir)
 			wtDir := filepath.Base(wt.Path)
 			statusFile := filepath.Join(claude.StatusDir(), repoName, wtDir+".json")
 			os.Remove(statusFile)
+			done()
 
 			u.Success(fmt.Sprintf("Removed worktree %s", u.Bold(wt.Branch)))
 
 			if cmd.Bool("prune") {
+				done = tr.Start("git worktree prune")
 				u.Info("Pruning stale worktrees...")
 				if _, err := repoGit.Run("worktree", "prune"); err != nil {
 					u.Warn(fmt.Sprintf("Prune failed: %v", err))
 				} else {
 					u.Success("Pruned stale worktrees")
 				}
+				done()
 			}
 
+			tr.Total()
 			return nil
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,10 @@ func WorktreesDir() string {
 	return filepath.Join(WillowHome(), "worktrees")
 }
 
+func TrashDir() string {
+	return filepath.Join(WillowHome(), "trash")
+}
+
 func GlobalConfigPath() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".config", "willow", "config.json")

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -24,14 +24,20 @@ func New(enabled bool) *Tracer {
 	}
 }
 
-// Step records a completed step and prints its duration.
-func (t *Tracer) Step(label string, start time.Time) {
+var noop = func() {}
+
+// Start begins timing a step and returns a function that records its duration.
+// When tracing is disabled, returns a no-op with zero allocations.
+func (t *Tracer) Start(label string) func() {
 	if !t.enabled {
-		return
+		return noop
 	}
-	d := time.Since(start)
-	t.steps = append(t.steps, step{label: label, duration: d})
-	fmt.Fprintf(os.Stderr, "[trace] %-25s %s\n", label, formatDuration(d))
+	start := time.Now()
+	return func() {
+		d := time.Since(start)
+		t.steps = append(t.steps, step{label: label, duration: d})
+		fmt.Fprintf(os.Stderr, "[trace] %-25s %s\n", label, formatDuration(d))
+	}
 }
 
 // Total prints the total elapsed time since the tracer was created.


### PR DESCRIPTION
## Description of the change

Stacked on #39.

`ww rm` was taking ~23s on large repos (e.g. evergreen with a 2.8GB worktree / 239K files). 93% of the time was spent in `git worktree remove --force`, which internally just does `rm -rf`.

Replaces the blocking removal with a three-step approach:
1. Remove git worktree admin dir (`$bare/worktrees/<name>/`) — instant
2. Rename worktree to `~/.willow/trash/<timestamp>-<name>` — instant (same filesystem)
3. Spawn a detached `rm -rf` in the background so the user isn't blocked

Also adds:
- `ww gc` command to clean up any leftover trash entries
- `config.TrashDir()` helper
- Full trace instrumentation for all `rm` steps

Falls back to synchronous `os.RemoveAll` if rename fails (cross-filesystem edge case).

**Before:** 23s → **After:** 50ms (~460x speedup)

## Test plan

- Manual: tested `ww --trace rm` on 2.8GB evergreen worktree — completes in 50ms
- Verified background `rm -rf` process runs detached (`ps aux`)
- Verified `git worktree list` no longer shows removed worktree
- Verified `ww gc` cleans up trash entries
- Unit tests pass: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)