### PR TITLE
✨ feat(dashboard): add live dashboard, unread tracking, multi-agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ Running multiple Claude Code sessions on the same repo means constant context-sw
 │       └── payments/             # another agent running here
 └── status/
     └── myrepo/
-        ├── auth-refactor.json    # {"status": "BUSY", ...}
-        └── payments.json         # {"status": "WAIT", ...}
+        ├── auth-refactor/
+        │   └── <session_id>.json   # {"status": "BUSY", ...}
+        └── payments/
+            └── <session_id>.json   # {"status": "WAIT", ...}
 ```
 
 ## Install
@@ -99,7 +101,7 @@ eval "$(willow shell-init --tab-title)"
 ww cc-setup
 ```
 
-Installs hooks into `~/.claude/settings.json` that write agent status (`BUSY` / `DONE` / `WAIT` / `IDLE`) to `~/.willow/status/`. This powers the status column in `ww ls`, `ww sw`, and `ww status`.
+Installs hooks into `~/.claude/settings.json` that write per-session agent status (`BUSY` / `DONE` / `WAIT` / `IDLE`) to `~/.willow/status/`. Supports multiple Claude sessions per worktree. This powers the status column in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`.
 
 ## Quick start
 
@@ -202,13 +204,32 @@ List worktrees with status.
 
 ### `ww status`
 
-Rich view of Claude Code agent status.
+Rich view of Claude Code agent status. Shows per-session rows when multiple agents run in the same worktree, with unread indicators (`●`) for completed sessions you haven't reviewed.
 
 ![ww status](screenshots/demo-status.gif)
 
 | Flag | Description |
 |------|-------------|
 | `--json` | JSON output |
+
+### `ww dashboard` (alias: `dash`, `d`)
+
+Live-refreshing TUI showing all Claude Code sessions across all repos. Includes diff stats, unread counts, and per-session activity.
+
+```bash
+ww dashboard          # default 2s refresh
+ww dash -i 5          # 5s refresh interval
+```
+
+```
+willow dashboard          3 repos | 5 agents | 2 unread
+
+  STATUS  REPO        BRANCH              DIFF           AGE
+  ────────────────────────────────────────────────────────────
+  🤖 BUSY   evergreen   auth-refactor       3f +42 -12     2m
+  ✅ DONE●  evergreen   payments            8f +100 -23   12m
+  ⏳ WAIT   willow      dashboard           4f +200 -0     1m
+```
 
 ### `ww cc-setup`
 
@@ -234,7 +255,7 @@ After running `ww cc-setup`, Claude Code automatically reports its state:
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Status appears in `ww ls`, `ww sw`, and `ww status`. Stale `BUSY`/`DONE` status (>5 min) automatically degrades to `IDLE`.
+Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. Stale `BUSY`/`DONE` status (>5 min) automatically degrades to `IDLE`. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
 
 ## Configuration
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -182,20 +182,56 @@ ww status [options]
 |---|---|---|
 | `--json` | Output as JSON | `false` |
 
-Rich view of Claude Code agent status across all worktrees:
+Rich view of Claude Code agent status across all worktrees. Shows per-session rows when multiple Claude Code sessions run in the same worktree:
 
 ```
-myrepo (4 worktrees, 2 agents active)
+myrepo (4 worktrees, 3 sessions active, 1 unread)
 
-  🤖 auth-refactor          BUSY   2m ago
-  ⏳ payments               WAIT   30s ago
-  🟡 main                   IDLE   1h ago
-     old-feature            --
+  🤖 auth-refactor          BUSY    2m ago
+  🤖 auth-refactor          BUSY    5m ago     <- second session, same worktree
+  ✅ payments               DONE●   12m ago
+  🟡 main                   IDLE    30m ago
 ```
+
+The `●` indicator marks DONE sessions that haven't been reviewed yet (see [Unread tracking](#unread-tracking)).
 
 ---
 
-### 2.7 `ww cc-setup` — Install Claude Code hooks
+### 2.7 `ww dashboard` — Live global dashboard
+
+```
+ww dashboard [options]
+```
+
+| Alias | `ww dash`, `ww d` |
+|---|---|
+| `--interval, -i` | Refresh interval in seconds (default: 2) |
+
+Live-refreshing TUI showing all Claude Code sessions across all repos. Renders in an alternate screen buffer with ANSI cursor positioning — no flicker.
+
+```
+willow dashboard          3 repos | 5 agents | 2 unread
+
+  STATUS  REPO        BRANCH              DIFF           AGE
+  ────────────────────────────────────────────────────────────
+  🤖 BUSY   evergreen   auth-refactor       3f +42 -12     2m
+  🤖 BUSY   evergreen   auth-refactor       3f +18 -3      5m
+  ✅ DONE●  evergreen   payments            8f +100 -23   12m
+  ⏳ WAIT   willow      dashboard           4f +200 -0     1m
+  🟡 IDLE   willow      main                --            30m
+```
+
+**Data per tick:**
+- All repos via `config.ListRepos()`
+- Worktrees + sessions per repo
+- Diff stats (`git diff --shortstat`) with 10s cache TTL
+- Unread counts
+
+Press Ctrl-C to exit.
+
+---
+
+### 2.8 `ww cc-setup` — Install Claude Code hooks
 
 ```
 ww cc-setup
@@ -208,16 +244,18 @@ One-time setup to install Claude Code hooks for status tracking.
 2. Installs a Claude Code hook script at `~/.willow/hooks/claude-status-hook.sh`
 3. Adds hook configuration to `~/.claude/settings.json` (user-level, works for all projects)
 
-The hook fires on `PostToolUse` and `Stop` events, writing status to `~/.willow/status/<repo>/<worktree>.json`:
-- Tool use -> `BUSY`
-- `AskUserQuestion` tool -> `WAIT`
-- Stop event -> `IDLE`
+The hook fires on 5 events (`UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `Notification`), writing per-session status to `~/.willow/status/<repo>/<worktree>/<session_id>.json`:
+- `UserPromptSubmit` -> `BUSY`
+- `PreToolUse` -> `BUSY` (with tool name for dashboard activity)
+- `PostToolUse` + `AskUserQuestion` -> `WAIT`, otherwise `BUSY`
+- `Stop` -> `DONE`
+- `Notification` -> `WAIT` (won't overwrite `DONE`)
 
-**Status file location:** `~/.willow/status/<repo-name>/<worktree-dir-name>.json`
+**Status file location:** `~/.willow/status/<repo-name>/<worktree-dir-name>/<session_id>.json`
 
 ---
 
-### 2.8 `ww shell-init` — Shell integration
+### 2.9 `ww shell-init` — Shell integration
 
 ```bash
 eval "$(willow shell-init)"
@@ -240,6 +278,7 @@ This provides:
 | `ww n` | `ww new` |
 | `ww l` | `ww ls` |
 | `ww s` | `ww status` |
+| `ww dash` / `ww d` | `ww dashboard` |
 
 ---
 
@@ -286,8 +325,11 @@ The local config lives inside the bare repo directory, so it's private to your m
 │       └── payments/
 ├── status/                      # Claude Code agent status (created by ww cc-setup)
 │   └── myrepo/
-│       ├── main.json
-│       └── auth-refactor.json
+│       ├── main/
+│       │   ├── <session_id>.json
+│       │   └── .lastread        # unread tracking marker
+│       └── auth-refactor/
+│           └── <session_id>.json
 └── hooks/                       # Hook scripts (created by ww cc-setup)
     └── claude-status-hook.sh
 ```
@@ -309,7 +351,8 @@ COMMANDS
   rm [branch]     Remove a worktree and its branch
   ls              List worktrees (alias: l)
   status          Show Claude Code agent status (alias: s)
-  setup           Install Claude Code hooks for status tracking
+  dashboard       Live global dashboard (alias: dash, d)
+  cc-setup        Install Claude Code hooks for status tracking
   shell-init      Print shell integration script
   help [command]  Show help for a command
   version         Print version
@@ -359,10 +402,39 @@ claude
 ww status
 ```
 
+### Multiple agents in the same worktree
+
+Multiple Claude Code sessions in the same worktree are tracked separately. Each session writes its own `<session_id>.json` file.
+
+```bash
+# Open two Claude sessions in the same worktree
+ww status
+# Shows both sessions:
+#   🤖 auth-refactor  BUSY   2m ago
+#   🤖 auth-refactor  BUSY   5m ago
+```
+
+### Live monitoring with dashboard
+
+```bash
+ww dashboard    # live TUI across all repos
+ww dash -i 5   # refresh every 5 seconds
+```
+
 ### Switching between worktrees
 
 ```bash
 ww sw    # fzf picker with agent status, cd's into selected worktree
+         # automatically marks sessions as "read" on switch
+```
+
+### Unread tracking {#unread-tracking}
+
+When a Claude session finishes (DONE), it's marked as "unread" until you switch to that worktree via `ww sw`. Unread sessions show a `●` indicator:
+
+```
+  ✅ payments    DONE●   12m ago    <- unread
+  ✅ payments    DONE    12m ago    <- already reviewed
 ```
 
 ### Quick cleanup

--- a/internal/claude/hook.go
+++ b/internal/claude/hook.go
@@ -22,11 +22,22 @@ func claudeSettingsPath() string {
 	return filepath.Join(home, ".claude", "settings.json")
 }
 
+// hookEvents lists all Claude Code hook events the willow hook should register for.
+var hookEvents = []string{
+	"UserPromptSubmit",
+	"PreToolUse",
+	"PostToolUse",
+	"Stop",
+	"Notification",
+}
+
 // HookScript returns the shell script content for the Claude status hook.
+// It reads stdin JSON to extract session_id, hook_event_name, and tool_name,
+// and writes per-session status files to ~/.willow/status/<repo>/<worktree>/<session_id>.json.
 func HookScript() string {
 	return `#!/usr/bin/env bash
 # Willow Claude Code status hook
-# Writes agent status to ~/.willow/status/<repo>/<worktree>.json
+# Writes agent status to ~/.willow/status/<repo>/<worktree>/<session_id>.json
 
 set -euo pipefail
 
@@ -63,28 +74,67 @@ if [ -z "$REPO_NAME" ] || [ -z "$WT_NAME" ]; then
   exit 0
 fi
 
-# Determine status from the hook event
-TOOL_NAME="${CLAUDE_TOOL_NAME:-}"
-HOOK_EVENT="${CLAUDE_HOOK_EVENT:-}"
-STATUS="BUSY"
+# Read stdin JSON once
+INPUT="$(cat)"
 
-if [ "$HOOK_EVENT" = "Stop" ]; then
-  STATUS="DONE"
-elif [ "$TOOL_NAME" = "AskUserQuestion" ]; then
-  STATUS="WAIT"
+# Parse fields from stdin JSON using sed
+SESSION_ID="$(echo "$INPUT" | sed -n 's/.*"session_id" *: *"\([^"]*\)".*/\1/p' | head -1)"
+HOOK_EVENT="$(echo "$INPUT" | sed -n 's/.*"hook_event_name" *: *"\([^"]*\)".*/\1/p' | head -1)"
+TOOL_NAME="$(echo "$INPUT" | sed -n 's/.*"tool_name" *: *"\([^"]*\)".*/\1/p' | head -1)"
+
+if [ -z "$SESSION_ID" ]; then
+  exit 0
 fi
 
+# Determine status from the hook event
+STATUS="BUSY"
+TOOL_FIELD=""
+
+case "$HOOK_EVENT" in
+  UserPromptSubmit)
+    STATUS="BUSY"
+    ;;
+  PreToolUse)
+    STATUS="BUSY"
+    if [ -n "$TOOL_NAME" ]; then
+      TOOL_FIELD="\"tool\":\"$TOOL_NAME\","
+    fi
+    ;;
+  PostToolUse)
+    if [ "$TOOL_NAME" = "AskUserQuestion" ]; then
+      STATUS="WAIT"
+    else
+      STATUS="BUSY"
+    fi
+    ;;
+  Stop)
+    STATUS="DONE"
+    ;;
+  Notification)
+    # Don't overwrite DONE — only set WAIT if not already DONE
+    DEST_DIR="$STATUS_DIR/$REPO_NAME/$WT_NAME"
+    DEST_FILE="$DEST_DIR/$SESSION_ID.json"
+    if [ -f "$DEST_FILE" ]; then
+      CURRENT="$(sed -n 's/.*"status" *: *"\([^"]*\)".*/\1/p' "$DEST_FILE" | head -1)"
+      if [ "$CURRENT" = "DONE" ]; then
+        exit 0
+      fi
+    fi
+    STATUS="WAIT"
+    ;;
+esac
+
 # Write status file
-mkdir -p "$STATUS_DIR/$REPO_NAME"
-cat > "$STATUS_DIR/$REPO_NAME/$WT_NAME.json" <<STATUSEOF
-{"status":"$STATUS","timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","worktree":"$WT_NAME"}
+DEST_DIR="$STATUS_DIR/$REPO_NAME/$WT_NAME"
+mkdir -p "$DEST_DIR"
+cat > "$DEST_DIR/$SESSION_ID.json" <<STATUSEOF
+{"status":"$STATUS",${TOOL_FIELD}"session_id":"$SESSION_ID","timestamp":"$(date -u +%Y-%m-%dT%H:%M:%SZ)","worktree":"$WT_NAME"}
 STATUSEOF
 `
 }
 
 // Install creates the hook script and adds it to ~/.claude/settings.json.
 func Install() error {
-	// Create hook script
 	hookPath := HookScriptPath()
 	if err := os.MkdirAll(filepath.Dir(hookPath), 0o755); err != nil {
 		return fmt.Errorf("failed to create hooks directory: %w", err)
@@ -93,12 +143,10 @@ func Install() error {
 		return fmt.Errorf("failed to write hook script: %w", err)
 	}
 
-	// Create status directory
 	if err := os.MkdirAll(StatusDir(), 0o755); err != nil {
 		return fmt.Errorf("failed to create status directory: %w", err)
 	}
 
-	// Add hook to Claude settings
 	if err := addHookToSettings(hookPath); err != nil {
 		return fmt.Errorf("failed to update Claude settings: %w", err)
 	}
@@ -106,7 +154,8 @@ func Install() error {
 	return nil
 }
 
-// IsInstalled checks if the hook is already configured in ~/.claude/settings.json.
+// IsInstalled checks if the hook is already configured in ~/.claude/settings.json
+// for all required hook events.
 func IsInstalled() bool {
 	settings, err := readClaudeSettings()
 	if err != nil {
@@ -119,7 +168,7 @@ func IsInstalled() bool {
 	}
 
 	hookPath := HookScriptPath()
-	for _, event := range []string{"PostToolUse", "Stop"} {
+	for _, event := range hookEvents {
 		if !eventHasHook(hooksMap, event, hookPath) {
 			return false
 		}
@@ -192,7 +241,7 @@ func addHookToSettings(hookPath string) error {
 		},
 	}
 
-	for _, event := range []string{"PostToolUse", "Stop"} {
+	for _, event := range hookEvents {
 		if eventHasHook(hooksMap, event, hookPath) {
 			continue
 		}

--- a/internal/claude/status.go
+++ b/internal/claude/status.go
@@ -2,10 +2,10 @@ package claude
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -25,24 +25,100 @@ type WorktreeStatus struct {
 	Worktree  string    `json:"worktree,omitempty"`
 }
 
+type SessionStatus struct {
+	Status    Status    `json:"status"`
+	SessionID string    `json:"session_id"`
+	Tool      string    `json:"tool,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+	Worktree  string    `json:"worktree,omitempty"`
+}
+
 func StatusDir() string {
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".willow", "status")
 }
 
-func statusFilePath(repoName, worktreeDir string) string {
-	return filepath.Join(StatusDir(), repoName, worktreeDir+".json")
+// ReadAllSessions reads all session status files from the directory-based layout:
+// ~/.willow/status/<repo>/<worktree>/*.json
+func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
+	dir := filepath.Join(StatusDir(), repoName, worktreeDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	var sessions []*SessionStatus
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var ss SessionStatus
+		if err := json.Unmarshal(data, &ss); err != nil {
+			continue
+		}
+		sessions = append(sessions, &ss)
+	}
+	return sessions
 }
 
-// ReadStatus reads the status file for a worktree.
-// Returns StatusOffline if the file doesn't exist or can't be read.
+// ReadStatus reads the aggregate status for a worktree.
+// It checks the new directory-based layout first, then falls back to the legacy
+// single-file layout. Returns the highest-priority status across all sessions.
 func ReadStatus(repoName, worktreeDir string) *WorktreeStatus {
-	path := statusFilePath(repoName, worktreeDir)
+	sessions := ReadAllSessions(repoName, worktreeDir)
+	if len(sessions) > 0 {
+		return aggregateStatus(sessions)
+	}
+
+	// Legacy single-file fallback
+	return readLegacyStatus(repoName, worktreeDir)
+}
+
+func aggregateStatus(sessions []*SessionStatus) *WorktreeStatus {
+	best := &WorktreeStatus{Status: StatusOffline}
+	for _, ss := range sessions {
+		effective := effectiveStatus(ss.Status, ss.Timestamp)
+		if statusPriority(effective) < statusPriority(best.Status) {
+			best = &WorktreeStatus{
+				Status:    effective,
+				Timestamp: ss.Timestamp,
+				Worktree:  ss.Worktree,
+			}
+		}
+	}
+	return best
+}
+
+func effectiveStatus(s Status, ts time.Time) Status {
+	if (s == StatusBusy || s == StatusDone || s == StatusWait) && time.Since(ts) > 5*time.Minute {
+		return StatusIdle
+	}
+	return s
+}
+
+func statusPriority(s Status) int {
+	switch s {
+	case StatusBusy:
+		return 0
+	case StatusWait:
+		return 1
+	case StatusDone:
+		return 2
+	case StatusIdle:
+		return 3
+	default:
+		return 4
+	}
+}
+
+func readLegacyStatus(repoName, worktreeDir string) *WorktreeStatus {
+	path := filepath.Join(StatusDir(), repoName, worktreeDir+".json")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return &WorktreeStatus{Status: StatusOffline}
-		}
 		return &WorktreeStatus{Status: StatusOffline}
 	}
 
@@ -51,12 +127,35 @@ func ReadStatus(repoName, worktreeDir string) *WorktreeStatus {
 		return &WorktreeStatus{Status: StatusOffline}
 	}
 
-	// Consider stale BUSY/DONE (>5 minutes) as IDLE
-	if (ws.Status == StatusBusy || ws.Status == StatusDone) && time.Since(ws.Timestamp) > 5*time.Minute {
-		ws.Status = StatusIdle
+	ws.Status = effectiveStatus(ws.Status, ws.Timestamp)
+	return &ws
+}
+
+// CleanStaleSessions removes session files older than 2 hours.
+func CleanStaleSessions(repoName, worktreeDir string) {
+	dir := filepath.Join(StatusDir(), repoName, worktreeDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
 	}
 
-	return &ws
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var ss SessionStatus
+		if err := json.Unmarshal(data, &ss); err != nil {
+			os.Remove(filepath.Join(dir, e.Name()))
+			continue
+		}
+		if time.Since(ss.Timestamp) > 2*time.Hour {
+			os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
 }
 
 // StatusIcon returns the emoji icon for a status.
@@ -96,4 +195,12 @@ func TimeSince(t time.Time) string {
 	default:
 		return fmt.Sprintf("%dd ago", int(d.Hours()/24))
 	}
+}
+
+// RemoveStatusDir removes the entire session directory for a worktree.
+func RemoveStatusDir(repoName, worktreeDir string) {
+	dir := filepath.Join(StatusDir(), repoName, worktreeDir)
+	os.RemoveAll(dir)
+	// Also remove legacy single file if present
+	os.Remove(filepath.Join(StatusDir(), repoName, worktreeDir+".json"))
 }

--- a/internal/claude/status_test.go
+++ b/internal/claude/status_test.go
@@ -15,7 +15,7 @@ func TestReadStatus_MissingFile(t *testing.T) {
 	}
 }
 
-func TestReadStatus_ValidFile(t *testing.T) {
+func TestReadStatus_LegacyFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -97,6 +97,109 @@ func TestReadStatus_InvalidJSON(t *testing.T) {
 	got := ReadStatus(repoName, wtName)
 	if got.Status != StatusOffline {
 		t.Errorf("Status = %q, want %q", got.Status, StatusOffline)
+	}
+}
+
+func TestReadAllSessions_MultipleSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "feature-auth"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	now := time.Now().UTC()
+	sessions := []SessionStatus{
+		{Status: StatusBusy, SessionID: "sess-1", Timestamp: now, Worktree: wtName},
+		{Status: StatusDone, SessionID: "sess-2", Timestamp: now.Add(-1 * time.Minute), Worktree: wtName},
+	}
+	for _, ss := range sessions {
+		data, _ := json.Marshal(ss)
+		os.WriteFile(filepath.Join(sessDir, ss.SessionID+".json"), data, 0o644)
+	}
+
+	got := ReadAllSessions(repoName, wtName)
+	if len(got) != 2 {
+		t.Fatalf("ReadAllSessions returned %d sessions, want 2", len(got))
+	}
+}
+
+func TestReadAllSessions_EmptyDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	sessDir := filepath.Join(home, ".willow", "status", "myrepo", "empty-wt")
+	os.MkdirAll(sessDir, 0o755)
+
+	got := ReadAllSessions("myrepo", "empty-wt")
+	if len(got) != 0 {
+		t.Errorf("ReadAllSessions returned %d sessions, want 0", len(got))
+	}
+}
+
+func TestReadAllSessions_NoDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := ReadAllSessions("nonexistent", "nope")
+	if got != nil {
+		t.Errorf("ReadAllSessions returned %v, want nil", got)
+	}
+}
+
+func TestReadStatus_AggregatesBusyOverDone(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "multi"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	now := time.Now().UTC()
+	for _, ss := range []SessionStatus{
+		{Status: StatusDone, SessionID: "s1", Timestamp: now},
+		{Status: StatusBusy, SessionID: "s2", Timestamp: now},
+	} {
+		data, _ := json.Marshal(ss)
+		os.WriteFile(filepath.Join(sessDir, ss.SessionID+".json"), data, 0o644)
+	}
+
+	got := ReadStatus(repoName, wtName)
+	if got.Status != StatusBusy {
+		t.Errorf("aggregate Status = %q, want %q (BUSY should win)", got.Status, StatusBusy)
+	}
+}
+
+func TestCleanStaleSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "cleanup"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	stale := SessionStatus{Status: StatusDone, SessionID: "old", Timestamp: time.Now().UTC().Add(-3 * time.Hour)}
+	fresh := SessionStatus{Status: StatusBusy, SessionID: "new", Timestamp: time.Now().UTC()}
+
+	for _, ss := range []SessionStatus{stale, fresh} {
+		data, _ := json.Marshal(ss)
+		os.WriteFile(filepath.Join(sessDir, ss.SessionID+".json"), data, 0o644)
+	}
+
+	CleanStaleSessions(repoName, wtName)
+
+	entries, _ := os.ReadDir(sessDir)
+	jsonFiles := 0
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".json" {
+			jsonFiles++
+		}
+	}
+	if jsonFiles != 1 {
+		t.Errorf("after cleanup: %d json files, want 1", jsonFiles)
 	}
 }
 

--- a/internal/claude/unread.go
+++ b/internal/claude/unread.go
@@ -1,0 +1,51 @@
+package claude
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func lastReadPath(repoName, worktreeDir string) string {
+	return filepath.Join(StatusDir(), repoName, worktreeDir, ".lastread")
+}
+
+func lastReadTime(repoName, worktreeDir string) time.Time {
+	data, err := os.ReadFile(lastReadPath(repoName, worktreeDir))
+	if err != nil {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, strings.TrimSpace(string(data)))
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+// MarkRead writes the current time to the .lastread marker file.
+func MarkRead(repoName, worktreeDir string) error {
+	path := lastReadPath(repoName, worktreeDir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(time.Now().UTC().Format(time.RFC3339)+"\n"), 0o644)
+}
+
+// IsUnread returns true if any DONE session has a timestamp after the .lastread marker.
+func IsUnread(repoName, worktreeDir string) bool {
+	return UnreadCount(repoName, worktreeDir) > 0
+}
+
+// UnreadCount returns the number of DONE sessions whose timestamp is after .lastread.
+func UnreadCount(repoName, worktreeDir string) int {
+	lr := lastReadTime(repoName, worktreeDir)
+	sessions := ReadAllSessions(repoName, worktreeDir)
+	count := 0
+	for _, ss := range sessions {
+		if ss.Status == StatusDone && (lr.IsZero() || ss.Timestamp.After(lr)) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/claude/unread_test.go
+++ b/internal/claude/unread_test.go
@@ -1,0 +1,80 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestUnreadCount_NoDoneSessionsReturnsZero(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "wt1"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	ss := SessionStatus{Status: StatusBusy, SessionID: "s1", Timestamp: time.Now().UTC()}
+	data, _ := json.Marshal(ss)
+	os.WriteFile(filepath.Join(sessDir, "s1.json"), data, 0o644)
+
+	if got := UnreadCount(repoName, wtName); got != 0 {
+		t.Errorf("UnreadCount = %d, want 0", got)
+	}
+}
+
+func TestUnreadCount_DoneSessionIsUnread(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "wt2"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	ss := SessionStatus{Status: StatusDone, SessionID: "s1", Timestamp: time.Now().UTC()}
+	data, _ := json.Marshal(ss)
+	os.WriteFile(filepath.Join(sessDir, "s1.json"), data, 0o644)
+
+	if got := UnreadCount(repoName, wtName); got != 1 {
+		t.Errorf("UnreadCount = %d, want 1", got)
+	}
+	if !IsUnread(repoName, wtName) {
+		t.Error("IsUnread = false, want true")
+	}
+}
+
+func TestMarkRead_ClearsUnread(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "wt3"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	past := time.Now().UTC().Add(-1 * time.Minute)
+	ss := SessionStatus{Status: StatusDone, SessionID: "s1", Timestamp: past}
+	data, _ := json.Marshal(ss)
+	os.WriteFile(filepath.Join(sessDir, "s1.json"), data, 0o644)
+
+	if err := MarkRead(repoName, wtName); err != nil {
+		t.Fatalf("MarkRead error: %v", err)
+	}
+
+	if got := UnreadCount(repoName, wtName); got != 0 {
+		t.Errorf("UnreadCount after MarkRead = %d, want 0", got)
+	}
+}
+
+func TestIsUnread_NoSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if IsUnread("empty", "nope") {
+		t.Error("IsUnread = true for nonexistent dir, want false")
+	}
+}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -84,6 +84,7 @@ func NewApp() *cli.Command {
 			rmCmd(),
 			lsCmd(),
 			statusCmd(),
+			dashboardCmd(),
 			setupCmd(),
 			shellInitCmd(),
 			gcCmd(),

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"context"
+	"time"
+
+	"github.com/iamrajjoshi/willow/internal/dashboard"
+	"github.com/urfave/cli/v3"
+)
+
+func dashboardCmd() *cli.Command {
+	return &cli.Command{
+		Name:    "dashboard",
+		Aliases: []string{"dash", "d"},
+		Usage:   "Live overview of all Claude Code sessions across repos",
+		Flags: []cli.Flag{
+			&cli.IntFlag{
+				Name:    "interval",
+				Aliases: []string{"i"},
+				Usage:   "Refresh interval in seconds",
+				Value:   2,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			interval := time.Duration(cmd.Int("interval")) * time.Second
+			return dashboard.Run(ctx, dashboard.Config{
+				RefreshInterval: interval,
+			})
+		},
+	}
+}

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -185,7 +185,9 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string) {
 		wtDir := filepath.Base(wt.Path)
 		ws := claude.ReadStatus(repoName, wtDir)
 		statusLabel := claude.StatusLabel(ws.Status)
-		// Build the line with padding first, then apply Dim to the dimmed parts
+		if ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir) {
+			statusLabel += "\u25CF" // ●
+		}
 		pathPadded := fmt.Sprintf("%-*s", pathW, wt.Path)
 		agePadded := fmt.Sprintf("%*s", ageW, age)
 		line := fmt.Sprintf("  %-*s  %-*s  %s  %s", branchW, wt.Branch, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -206,8 +206,7 @@ func rmCmd() *cli.Command {
 			done = tr.Start("cleanup status")
 			repoName := repoNameFromDir(bareDir)
 			wtDir := filepath.Base(wt.Path)
-			statusFile := filepath.Join(claude.StatusDir(), repoName, wtDir+".json")
-			os.Remove(statusFile)
+			claude.RemoveStatusDir(repoName, wtDir)
 			done()
 
 			u.Success(fmt.Sprintf("Removed worktree %s", u.Bold(wt.Branch)))

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -43,32 +43,62 @@ func statusCmd() *cli.Command {
 			filtered := filterBareWorktrees(worktrees)
 			repoName := repoNameFromDir(bareDir)
 
-			type statusEntry struct {
+			type sessionEntry struct {
 				Branch    string `json:"branch"`
+				SessionID string `json:"session_id,omitempty"`
 				Status    string `json:"status"`
 				Timestamp string `json:"timestamp,omitempty"`
+				Unread    bool   `json:"unread,omitempty"`
 				Path      string `json:"path"`
 			}
 
-			var entries []statusEntry
+			var entries []sessionEntry
 			activeCount := 0
+			totalUnread := 0
 
 			for _, wt := range filtered {
 				wtDir := filepath.Base(wt.Path)
-				ws := claude.ReadStatus(repoName, wtDir)
-
-				entry := statusEntry{
-					Branch: wt.Branch,
-					Status: string(ws.Status),
-					Path:   wt.Path,
+				sessions := claude.ReadAllSessions(repoName, wtDir)
+				unread := claude.IsUnread(repoName, wtDir)
+				if unread {
+					totalUnread++
 				}
-				if !ws.Timestamp.IsZero() {
-					entry.Timestamp = claude.TimeSince(ws.Timestamp)
-				}
-				entries = append(entries, entry)
 
-				if ws.Status == claude.StatusBusy || ws.Status == claude.StatusDone || ws.Status == claude.StatusWait {
-					activeCount++
+				if len(sessions) > 0 {
+					for _, ss := range sessions {
+						entry := sessionEntry{
+							Branch:    wt.Branch,
+							SessionID: ss.SessionID,
+							Status:    string(ss.Status),
+							Path:      wt.Path,
+						}
+						if !ss.Timestamp.IsZero() {
+							entry.Timestamp = claude.TimeSince(ss.Timestamp)
+						}
+						if ss.Status == claude.StatusDone && unread {
+							entry.Unread = true
+						}
+						entries = append(entries, entry)
+
+						if ss.Status == claude.StatusBusy || ss.Status == claude.StatusDone || ss.Status == claude.StatusWait {
+							activeCount++
+						}
+					}
+				} else {
+					ws := claude.ReadStatus(repoName, wtDir)
+					entry := sessionEntry{
+						Branch: wt.Branch,
+						Status: string(ws.Status),
+						Path:   wt.Path,
+					}
+					if !ws.Timestamp.IsZero() {
+						entry.Timestamp = claude.TimeSince(ws.Timestamp)
+					}
+					entries = append(entries, entry)
+
+					if ws.Status == claude.StatusBusy || ws.Status == claude.StatusDone || ws.Status == claude.StatusWait {
+						activeCount++
+					}
 				}
 			}
 
@@ -78,8 +108,13 @@ func statusCmd() *cli.Command {
 				return enc.Encode(entries)
 			}
 
-			u.Info(fmt.Sprintf("%s (\U0001F333 %d worktrees, \U0001F916 %d active)\n",
-				u.Bold(repoName), len(filtered), activeCount))
+			headerParts := fmt.Sprintf("%s (\U0001F333 %d worktrees, \U0001F916 %d active",
+				u.Bold(repoName), len(filtered), activeCount)
+			if totalUnread > 0 {
+				headerParts += fmt.Sprintf(", %d unread", totalUnread)
+			}
+			headerParts += ")\n"
+			u.Info(headerParts)
 
 			branchW := 0
 			for _, e := range entries {
@@ -90,13 +125,17 @@ func statusCmd() *cli.Command {
 
 			for _, e := range entries {
 				icon := claude.StatusIcon(claude.Status(e.Status))
+				label := e.Status
+				if e.Unread {
+					label += "\u25CF" // ●
+				}
 				var line string
 				if e.Timestamp != "" {
-					line = fmt.Sprintf("  %s %-*s  %-4s  %s",
-						icon, branchW, e.Branch, e.Status, u.Dim(e.Timestamp))
+					line = fmt.Sprintf("  %s %-*s  %-6s  %s",
+						icon, branchW, e.Branch, label, u.Dim(e.Timestamp))
 				} else {
 					line = fmt.Sprintf("  %s %-*s  %s",
-						icon, branchW, e.Branch, e.Status)
+						icon, branchW, e.Branch, label)
 				}
 				u.Info(line)
 			}

--- a/internal/cli/sw.go
+++ b/internal/cli/sw.go
@@ -47,6 +47,10 @@ func swCmd() *cli.Command {
 				return nil
 			}
 
+			// Mark sessions as read when switching to a worktree
+			wtDir := filepath.Base(selected)
+			claude.MarkRead(repoName, wtDir)
+
 			fmt.Println(selected)
 			return nil
 		},

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -1,0 +1,336 @@
+package dashboard
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/ui"
+	"github.com/iamrajjoshi/willow/internal/worktree"
+)
+
+type Config struct {
+	RefreshInterval time.Duration
+}
+
+type session struct {
+	Repo      string
+	Branch    string
+	SessionID string
+	Status    claude.Status
+	Tool      string
+	DiffStats string
+	Age       string
+	Unread    bool
+}
+
+type summary struct {
+	Repos   int
+	Agents  int
+	Unread  int
+}
+
+type cachedDiff struct {
+	stats string
+	at    time.Time
+}
+
+var (
+	diffCache   = map[string]cachedDiff{}
+	diffCacheMu sync.Mutex
+	diffCacheTTL = 10 * time.Second
+)
+
+func Run(ctx context.Context, cfg Config) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Enter alternate screen, hide cursor
+	fmt.Print(ui.AltScreenOn())
+	fmt.Print(ui.HideCursor())
+
+	defer func() {
+		fmt.Print(ui.ShowCursor())
+		fmt.Print(ui.AltScreenOff())
+	}()
+
+	// Handle SIGWINCH for terminal resize
+	winchCh := make(chan os.Signal, 1)
+	signal.Notify(winchCh, syscall.SIGWINCH)
+
+	cols := termWidth()
+	ticker := time.NewTicker(cfg.RefreshInterval)
+	defer ticker.Stop()
+
+	// Initial render
+	renderTick(cols)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-sigCh:
+			return nil
+		case <-winchCh:
+			cols = termWidth()
+		case <-ticker.C:
+			renderTick(cols)
+		}
+	}
+}
+
+func renderTick(cols int) {
+	sessions, sum := collectData()
+	output := render(sessions, sum, cols)
+	fmt.Print(ui.CursorHome())
+	fmt.Print(output)
+	fmt.Print(ui.ClearToEnd())
+}
+
+func collectData() ([]session, summary) {
+	repos, err := config.ListRepos()
+	if err != nil {
+		return nil, summary{}
+	}
+
+	var sessions []session
+	sum := summary{Repos: len(repos)}
+
+	for _, repoName := range repos {
+		bareDir, err := config.ResolveRepo(repoName)
+		if err != nil {
+			continue
+		}
+
+		repoGit := &git.Git{Dir: bareDir}
+		wts, err := worktree.List(repoGit)
+		if err != nil {
+			continue
+		}
+
+		cfg := config.Load(bareDir)
+
+		for _, wt := range wts {
+			if wt.IsBare {
+				continue
+			}
+			wtDir := filepath.Base(wt.Path)
+			allSessions := claude.ReadAllSessions(repoName, wtDir)
+			unread := claude.IsUnread(repoName, wtDir)
+
+			if unread {
+				sum.Unread++
+			}
+
+			baseBranch := cfg.BaseBranch
+			if baseBranch == "" {
+				baseBranch = "main"
+			}
+
+			diff := getDiffStats(wt.Path, baseBranch)
+
+			if len(allSessions) > 0 {
+				for _, ss := range allSessions {
+					s := session{
+						Repo:      repoName,
+						Branch:    wt.Branch,
+						SessionID: ss.SessionID,
+						Status:    ss.Status,
+						Tool:      ss.Tool,
+						DiffStats: diff,
+						Age:       claude.TimeSince(ss.Timestamp),
+						Unread:    ss.Status == claude.StatusDone && unread,
+					}
+					sessions = append(sessions, s)
+					if ss.Status == claude.StatusBusy || ss.Status == claude.StatusWait || ss.Status == claude.StatusDone {
+						sum.Agents++
+					}
+				}
+			} else {
+				ws := claude.ReadStatus(repoName, wtDir)
+				if ws.Status == claude.StatusOffline || ws.Status == claude.StatusIdle {
+					continue
+				}
+				s := session{
+					Repo:      repoName,
+					Branch:    wt.Branch,
+					Status:    ws.Status,
+					DiffStats: diff,
+					Age:       claude.TimeSince(ws.Timestamp),
+					Unread:    ws.Status == claude.StatusDone && unread,
+				}
+				sessions = append(sessions, s)
+				sum.Agents++
+			}
+		}
+	}
+
+	return sessions, sum
+}
+
+func render(sessions []session, sum summary, width int) string {
+	var b strings.Builder
+	u := &ui.UI{}
+
+	header := fmt.Sprintf("willow dashboard          %d repos | %d agents | %d unread",
+		sum.Repos, sum.Agents, sum.Unread)
+	b.WriteString(u.Bold(header))
+	b.WriteString("\n\n")
+
+	if len(sessions) == 0 {
+		b.WriteString(u.Dim("  No active sessions. Claude agents will appear here when running."))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	// Calculate column widths
+	repoW := len("REPO")
+	branchW := len("BRANCH")
+	diffW := len("DIFF")
+	for _, s := range sessions {
+		if len(s.Repo) > repoW {
+			repoW = len(s.Repo)
+		}
+		if len(s.Branch) > branchW {
+			branchW = len(s.Branch)
+		}
+		if len(s.DiffStats) > diffW {
+			diffW = len(s.DiffStats)
+		}
+	}
+
+	// Header row
+	headerLine := fmt.Sprintf("  %-8s  %-*s  %-*s  %-*s  %s",
+		"STATUS", repoW, "REPO", branchW, "BRANCH", diffW, "DIFF", "AGE")
+	b.WriteString(u.Bold(headerLine))
+	b.WriteString("\n")
+
+	// Separator
+	sepLen := 8 + repoW + branchW + diffW + 20
+	if sepLen > width && width > 0 {
+		sepLen = width - 2
+	}
+	b.WriteString("  ")
+	b.WriteString(u.Dim(strings.Repeat("\u2500", sepLen)))
+	b.WriteString("\n")
+
+	// Rows
+	for _, s := range sessions {
+		icon := claude.StatusIcon(s.Status)
+		label := string(s.Status)
+		if s.Unread {
+			label += "\u25CF" // ●
+		}
+
+		activity := ""
+		if s.Status == claude.StatusBusy && s.Tool != "" {
+			activity = u.Dim(fmt.Sprintf(" (%s)", s.Tool))
+		}
+
+		line := fmt.Sprintf("  %s %-6s%-*s  %-*s  %-*s  %s",
+			icon, label+activity,
+			repoW, s.Repo,
+			branchW, s.Branch,
+			diffW, s.DiffStats,
+			u.Dim(s.Age))
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func getDiffStats(wtPath, baseBranch string) string {
+	diffCacheMu.Lock()
+	if cached, ok := diffCache[wtPath]; ok && time.Since(cached.at) < diffCacheTTL {
+		diffCacheMu.Unlock()
+		return cached.stats
+	}
+	diffCacheMu.Unlock()
+
+	g := &git.Git{Dir: wtPath}
+	out, err := g.Run("diff", "--shortstat", fmt.Sprintf("origin/%s...HEAD", baseBranch))
+	if err != nil {
+		return "--"
+	}
+
+	stats := parseShortstat(out)
+
+	diffCacheMu.Lock()
+	diffCache[wtPath] = cachedDiff{stats: stats, at: time.Now()}
+	diffCacheMu.Unlock()
+
+	return stats
+}
+
+func parseShortstat(out string) string {
+	if out == "" {
+		return "--"
+	}
+	// "3 files changed, 42 insertions(+), 12 deletions(-)"
+	parts := strings.Split(out, ",")
+	files := ""
+	ins := ""
+	del := ""
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		fields := strings.Fields(p)
+		if len(fields) >= 2 {
+			switch {
+			case strings.Contains(p, "file"):
+				files = fields[0] + "f"
+			case strings.Contains(p, "insertion"):
+				ins = "+" + fields[0]
+			case strings.Contains(p, "deletion"):
+				del = "-" + fields[0]
+			}
+		}
+	}
+	result := files
+	if ins != "" {
+		result += " " + ins
+	}
+	if del != "" {
+		result += " " + del
+	}
+	if result == "" {
+		return "--"
+	}
+	return result
+}
+
+func termWidth() int {
+	// Use /dev/tty so stty works even when stdin is piped
+	cmd := exec.Command("stty", "size")
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		return 120
+	}
+	defer tty.Close()
+	cmd.Stdin = tty
+	out, err := cmd.Output()
+	if err != nil {
+		return 120
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) >= 2 {
+		if w, err := strconv.Atoi(fields[1]); err == nil {
+			return w
+		}
+	}
+	return 120
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -56,3 +56,11 @@ func (u *UI) Cyan(s string) string {
 func (u *UI) Dim(s string) string {
 	return dim + s + reset
 }
+
+// ANSI terminal control sequences for TUI rendering
+func CursorHome() string    { return "\033[H" }
+func ClearToEnd() string    { return "\033[J" }
+func HideCursor() string    { return "\033[?25l" }
+func ShowCursor() string    { return "\033[?25h" }
+func AltScreenOn() string   { return "\033[?1049h" }
+func AltScreenOff() string  { return "\033[?1049l" }

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -101,20 +101,49 @@ When run outside a willow repo, lists all repos and their worktree counts.
 
 ## `ww status`
 
-Rich view of Claude Code agent status across all worktrees.
+Rich view of Claude Code agent status across all worktrees. Shows per-session rows when multiple Claude sessions run in the same worktree.
 
 ```
-myrepo (4 worktrees, 2 agents active)
+myrepo (4 worktrees, 3 sessions active, 1 unread)
 
-  🤖 auth-refactor          BUSY   2m ago
-  ⏳ payments               WAIT   30s ago
-  🟡 main                   IDLE   1h ago
+  🤖 auth-refactor          BUSY    2m ago
+  🤖 auth-refactor          BUSY    5m ago
+  ✅ payments               DONE●   12m ago
+  🟡 main                   IDLE    1h ago
      old-feature            --
 ```
+
+The `●` indicator marks completed sessions you haven't reviewed yet. Switching to a worktree via `ww sw` marks it as read.
 
 | Flag | Description |
 |------|-------------|
 | `--json` | JSON output |
+
+## `ww dashboard` (alias: `dash`, `d`)
+
+Live-refreshing TUI showing all Claude Code sessions across all repos. Renders in an alternate screen buffer with no flicker.
+
+```bash
+ww dashboard          # default 2s refresh
+ww dash -i 5          # 5s refresh interval
+```
+
+```
+willow dashboard          3 repos | 5 agents | 2 unread
+
+  STATUS  REPO        BRANCH              DIFF           AGE
+  ────────────────────────────────────────────────────────────
+  🤖 BUSY   evergreen   auth-refactor       3f +42 -12     2m
+  🤖 BUSY   evergreen   auth-refactor       3f +18 -3      5m
+  ✅ DONE●  evergreen   payments            8f +100 -23   12m
+  ⏳ WAIT   willow      dashboard           4f +200 -0     1m
+```
+
+| Flag | Description |
+|------|-------------|
+| `-i, --interval` | Refresh interval in seconds (default: 2) |
+
+Press `Ctrl-C` to exit.
 
 ## `ww cc-setup`
 
@@ -124,7 +153,7 @@ One-time hook installation for Claude Code status tracking.
 2. Installs a hook script at `~/.willow/hooks/claude-status-hook.sh`
 3. Adds hook configuration to `~/.claude/settings.json`
 
-The hook fires on `PostToolUse` and `Stop` events, writing status to `~/.willow/status/<repo>/<worktree>.json`.
+The hook fires on 5 events (`UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `Notification`), writing per-session status to `~/.willow/status/<repo>/<worktree>/<session_id>.json`. Multiple Claude sessions in the same worktree are tracked independently.
 
 ## `ww shell-init [flags]`
 
@@ -152,7 +181,7 @@ After running `ww cc-setup`, Claude Code automatically reports its state:
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Stale `BUSY`/`DONE` status (>5 min) automatically degrades to `IDLE`.
+Stale `BUSY`/`DONE` status (>5 min) automatically degrades to `IDLE`. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
 
 ## Aliases
 
@@ -161,6 +190,7 @@ Stale `BUSY`/`DONE` status (>5 min) automatically degrades to `IDLE`.
 | `ww n` | `ww new` |
 | `ww l` | `ww ls` |
 | `ww s` | `ww status` |
+| `ww dash` / `ww d` | `ww dashboard` |
 
 ## Global flags
 

--- a/website/docs/guide/index.md
+++ b/website/docs/guide/index.md
@@ -60,7 +60,7 @@ Each tab shows `repo/branch` (e.g. `myrepo/auth-refactor`) when inside a willow 
 ww cc-setup
 ```
 
-Installs hooks into `~/.claude/settings.json` that write agent status (`BUSY` / `DONE` / `WAIT` / `IDLE`) to `~/.willow/status/`. This powers the status column in `ww ls`, `ww sw`, and `ww status`.
+Installs hooks into `~/.claude/settings.json` that write per-session agent status (`BUSY` / `DONE` / `WAIT` / `IDLE`) to `~/.willow/status/`. Supports multiple Claude sessions per worktree. This powers the status column in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`.
 
 ## Quick start
 
@@ -83,6 +83,9 @@ ww sw
 
 # Check on all agents
 ww status
+
+# Live dashboard across all repos
+ww dashboard
 
 # Clean up when done
 ww rm auth-refactor


### PR DESCRIPTION
## Description of the change

Adds three interconnected features for managing multiple Claude Code agents:

1. **Multi-agent per worktree** — Status files move from `<worktree>.json` to `<worktree>/<session_id>.json` directory layout. Multiple Claude sessions in the same worktree are tracked independently. Hook modernization: 5 events (UserPromptSubmit, PreToolUse, PostToolUse, Stop, Notification) with stdin JSON parsing.

2. **Unread tracking** — Completed sessions (DONE) show a `●` indicator until you switch to that worktree via `ww sw`. Uses a `.lastread` marker file for clean separation from session files.

3. **`ww dashboard`** — Live-refreshing TUI across all repos. Alt screen buffer, ANSI cursor positioning, diff stats with 10s cache, configurable refresh interval. Aliases: `dash`, `d`.

## Test plan

- Unit tests for `ReadAllSessions`, aggregate status, stale cleanup, unread tracking (`go test ./...`)
- Manual hook simulation: verified all 5 event types write correct status
- Manual multi-session: two sessions in same worktree both appear in `ww status`
- Manual unread flow: DONE● appears, clears after `ww sw` / `.lastread` write
- Manual dashboard: renders in alt screen, refreshes, shows summary
- Verified `ww ls`, `ww sw`, `ww rm`, `ww status` all work with new directory layout
- Website builds clean (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)