### PR TITLE
:sparkles: feat(rm): multi-select worktree removal and drop confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by
 
 ### `ww rm [branch] [flags]`
 
-Remove a worktree. Without arguments, opens fzf picker.
+Remove a worktree. Without arguments, opens fzf picker with multi-select (TAB to toggle, Ctrl-A to select all).
 
 ```bash
 ww rm auth-refactor              # direct removal
@@ -188,7 +188,6 @@ ww rm auth-refactor --prune      # also run git worktree prune
 |------|-------------|
 | `-f, --force` | Skip safety checks |
 | `--keep-branch` | Keep the local branch |
-| `-y, --yes` | Skip confirmation |
 | `--prune` | Run `git worktree prune` after |
 
 ### `ww ls [repo]`

--- a/SPEC.md
+++ b/SPEC.md
@@ -123,18 +123,16 @@ ww rm [branch] [options]
 |---|---|---|
 | `-f, --force` | Skip safety checks (uncommitted changes, unpushed commits) | `false` |
 | `--keep-branch` | Remove the worktree directory but keep the local branch | `false` |
-| `-y, --yes` | Skip confirmation prompt | `false` |
 | `-r, --repo <name>` | Target a willow-managed repo by name | Auto-detected |
 | `--prune` | Run `git worktree prune` after removal | `false` |
 
-**With argument:** Direct removal with safety checks and confirmation.
+**With argument:** Direct removal with safety warnings (no confirmation).
 
-**Without argument:** Launches fzf picker (same list as `ww sw` with Claude status). User selects, then existing safety checks + confirmation apply.
+**Without argument:** Launches fzf picker with multi-select (TAB to toggle, Ctrl-A to select all). Selected worktrees are removed in sequence.
 
 **Safety checks (unless `--force`):**
 - Warns if there are uncommitted changes
 - Warns if there are unpushed commits
-- Prompts for confirmation
 
 **Examples:**
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -224,7 +224,7 @@ func TestRm_RemovesWorktreeAndBranch(t *testing.T) {
 		t.Fatalf("new failed: %v", err)
 	}
 
-	if err := runApp("rm", "to-remove", "--yes"); err != nil {
+	if err := runApp("rm", "to-remove"); err != nil {
 		t.Fatalf("rm failed: %v", err)
 	}
 
@@ -259,7 +259,7 @@ func TestRm_KeepBranch(t *testing.T) {
 		t.Fatalf("new failed: %v", err)
 	}
 
-	if err := runApp("rm", "keep-me", "--yes", "--keep-branch"); err != nil {
+	if err := runApp("rm", "keep-me", "--keep-branch"); err != nil {
 		t.Fatalf("rm --keep-branch failed: %v", err)
 	}
 

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -1,13 +1,11 @@
 package cli
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/trace"
+	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
@@ -39,11 +38,6 @@ func rmCmd() *cli.Command {
 			&cli.BoolFlag{
 				Name:  "keep-branch",
 				Usage: "Remove worktree but keep the local branch",
-			},
-			&cli.BoolFlag{
-				Name:    "yes",
-				Aliases: []string{"y"},
-				Usage:   "Skip confirmation prompt",
 			},
 			&cli.StringFlag{
 				Name:    "repo",
@@ -87,129 +81,51 @@ func rmCmd() *cli.Command {
 
 			filtered := filterBareWorktrees(worktrees)
 
-			done = tr.Start("resolve target")
+			done = tr.Start("resolve targets")
 			target := cmd.StringArg("branch")
-			var wt *worktree.Worktree
+			var targets []worktree.Worktree
 
 			if target == "" {
 				repoName := repoNameFromDir(bareDir)
-				selectedPath, err := fzfPickWorktree(filtered, repoName)
+				selectedPaths, err := fzfPickWorktrees(filtered, repoName)
 				if err != nil {
 					return err
 				}
-				if selectedPath == "" {
+				if selectedPaths == nil {
 					return nil
 				}
-				for i := range filtered {
-					if filtered[i].Path == selectedPath {
-						wt = &filtered[i]
-						break
+				for _, sp := range selectedPaths {
+					for i := range filtered {
+						if filtered[i].Path == sp {
+							targets = append(targets, filtered[i])
+							break
+						}
 					}
 				}
-				if wt == nil {
-					return fmt.Errorf("selected worktree not found")
+				if len(targets) == 0 {
+					return fmt.Errorf("selected worktrees not found")
 				}
 			} else {
-				wt, err = findWorktree(filtered, target)
+				wt, err := findWorktree(filtered, target)
 				if err != nil {
 					return err
 				}
+				targets = []worktree.Worktree{*wt}
 			}
 			done()
 
 			force := cmd.Bool("force")
-			wtGit := &git.Git{Dir: wt.Path, Verbose: g.Verbose}
-
-			if !force {
-				done = tr.Start("check dirty")
-				dirty, err := wtGit.IsDirty()
-				if err != nil {
-					return err
-				}
-				if dirty {
-					u.Warn(fmt.Sprintf("Worktree %s has uncommitted changes", u.Bold(wt.Branch)))
-				}
-				done()
-
-				done = tr.Start("check unpushed")
-				unpushed, err := wtGit.HasUnpushedCommits()
-				if err != nil {
-					return err
-				}
-				if unpushed {
-					u.Warn(fmt.Sprintf("Worktree %s has unpushed commits", u.Bold(wt.Branch)))
-				}
-				done()
-
-				if (dirty || unpushed) && !cmd.Bool("yes") {
-					if !confirm("Remove anyway?") {
-						u.Info("Aborted.")
-						return nil
-					}
-				} else if !cmd.Bool("yes") {
-					if !confirm(fmt.Sprintf("Remove worktree %s?", wt.Branch)) {
-						u.Info("Aborted.")
-						return nil
-					}
-				}
-			}
+			keepBranch := cmd.Bool("keep-branch")
 
 			done = tr.Start("load config")
 			cfg := config.Load(bareDir)
 			done()
 
-			if len(cfg.Teardown) > 0 {
-				done = tr.Start("teardown hooks")
-				u.Info("Running teardown hooks...")
-				if err := runHooks(cfg.Teardown, wt.Path, u); err != nil {
+			for _, wt := range targets {
+				if err := removeWorktree(tr, u, repoGit, &wt, bareDir, cfg, force, keepBranch, g.Verbose); err != nil {
 					return err
 				}
-				done()
 			}
-
-			// Move worktree to trash instead of blocking on rm -rf.
-			// 1) Remove the git worktree admin dir so git no longer tracks it.
-			// 2) Rename the worktree dir into ~/.willow/trash/<id> (instant on same FS).
-			// 3) Spawn a detached rm -rf on the trash entry so the user isn't blocked.
-			done = tr.Start("remove worktree")
-			adminDir := filepath.Join(bareDir, "worktrees", filepath.Base(wt.Path))
-			if err := os.RemoveAll(adminDir); err != nil {
-				return fmt.Errorf("failed to remove worktree admin dir: %w", err)
-			}
-
-			trashDir := config.TrashDir()
-			if err := os.MkdirAll(trashDir, 0o755); err != nil {
-				return fmt.Errorf("failed to create trash dir: %w", err)
-			}
-
-			trashDest := filepath.Join(trashDir, fmt.Sprintf("%d-%s", time.Now().UnixNano(), filepath.Base(wt.Path)))
-			if err := os.Rename(wt.Path, trashDest); err != nil {
-				// Rename can fail across filesystems; fall back to synchronous removal.
-				if removeErr := os.RemoveAll(wt.Path); removeErr != nil {
-					return fmt.Errorf("failed to remove worktree: %w", removeErr)
-				}
-			} else {
-				bgRm := exec.Command("rm", "-rf", trashDest)
-				bgRm.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-				_ = bgRm.Start()
-			}
-			done()
-
-			done = tr.Start("git branch -D")
-			if !cmd.Bool("keep-branch") {
-				if _, err := repoGit.Run("branch", "-D", wt.Branch); err != nil {
-					u.Warn(fmt.Sprintf("Failed to delete branch %s: %v", wt.Branch, err))
-				}
-			}
-			done()
-
-			done = tr.Start("cleanup status")
-			repoName := repoNameFromDir(bareDir)
-			wtDir := filepath.Base(wt.Path)
-			claude.RemoveStatusDir(repoName, wtDir)
-			done()
-
-			u.Success(fmt.Sprintf("Removed worktree %s", u.Bold(wt.Branch)))
 
 			if cmd.Bool("prune") {
 				done = tr.Start("git worktree prune")
@@ -228,12 +144,77 @@ func rmCmd() *cli.Command {
 	}
 }
 
-func confirm(prompt string) bool {
-	fmt.Fprintf(os.Stderr, "%s [y/N] ", prompt)
-	scanner := bufio.NewScanner(os.Stdin)
-	if scanner.Scan() {
-		answer := strings.ToLower(strings.TrimSpace(scanner.Text()))
-		return answer == "y" || answer == "yes"
+func removeWorktree(tr *trace.Tracer, u *ui.UI, repoGit *git.Git, wt *worktree.Worktree, bareDir string, cfg *config.Config, force, keepBranch, verbose bool) error {
+	wtGit := &git.Git{Dir: wt.Path, Verbose: verbose}
+
+	if !force {
+		done := tr.Start("check dirty " + wt.Branch)
+		dirty, err := wtGit.IsDirty()
+		if err != nil {
+			return err
+		}
+		if dirty {
+			u.Warn(fmt.Sprintf("Worktree %s has uncommitted changes", u.Bold(wt.Branch)))
+		}
+		done()
+
+		done = tr.Start("check unpushed " + wt.Branch)
+		unpushed, err := wtGit.HasUnpushedCommits()
+		if err != nil {
+			return err
+		}
+		if unpushed {
+			u.Warn(fmt.Sprintf("Worktree %s has unpushed commits", u.Bold(wt.Branch)))
+		}
+		done()
 	}
-	return false
+
+	if len(cfg.Teardown) > 0 {
+		done := tr.Start("teardown hooks " + wt.Branch)
+		u.Info(fmt.Sprintf("Running teardown hooks for %s...", u.Bold(wt.Branch)))
+		if err := runHooks(cfg.Teardown, wt.Path, u); err != nil {
+			return err
+		}
+		done()
+	}
+
+	done := tr.Start("remove worktree " + wt.Branch)
+	adminDir := filepath.Join(bareDir, "worktrees", filepath.Base(wt.Path))
+	if err := os.RemoveAll(adminDir); err != nil {
+		return fmt.Errorf("failed to remove worktree admin dir: %w", err)
+	}
+
+	trashDir := config.TrashDir()
+	if err := os.MkdirAll(trashDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create trash dir: %w", err)
+	}
+
+	trashDest := filepath.Join(trashDir, fmt.Sprintf("%d-%s", time.Now().UnixNano(), filepath.Base(wt.Path)))
+	if err := os.Rename(wt.Path, trashDest); err != nil {
+		if removeErr := os.RemoveAll(wt.Path); removeErr != nil {
+			return fmt.Errorf("failed to remove worktree: %w", removeErr)
+		}
+	} else {
+		bgRm := exec.Command("rm", "-rf", trashDest)
+		bgRm.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		_ = bgRm.Start()
+	}
+	done()
+
+	done = tr.Start("git branch -D " + wt.Branch)
+	if !keepBranch {
+		if _, err := repoGit.Run("branch", "-D", wt.Branch); err != nil {
+			u.Warn(fmt.Sprintf("Failed to delete branch %s: %v", wt.Branch, err))
+		}
+	}
+	done()
+
+	done = tr.Start("cleanup status " + wt.Branch)
+	repoName := repoNameFromDir(bareDir)
+	wtDir := filepath.Base(wt.Path)
+	claude.RemoveStatusDir(repoName, wtDir)
+	done()
+
+	u.Success(fmt.Sprintf("Removed worktree %s", u.Bold(wt.Branch)))
+	return nil
 }

--- a/internal/cli/sw.go
+++ b/internal/cli/sw.go
@@ -62,7 +62,7 @@ type worktreeWithStatus struct {
 	status *claude.WorktreeStatus
 }
 
-func fzfPickWorktree(worktrees []worktree.Worktree, repoName string) (string, error) {
+func buildWorktreeLines(worktrees []worktree.Worktree, repoName string) []string {
 	items := make([]worktreeWithStatus, len(worktrees))
 	for i, wt := range worktrees {
 		wtDir := filepath.Base(wt.Path)
@@ -72,7 +72,6 @@ func fzfPickWorktree(worktrees []worktree.Worktree, repoName string) (string, er
 		}
 	}
 
-	// Sort: BUSY first, then WAIT, then IDLE, then OFFLINE
 	sort.SliceStable(items, func(i, j int) bool {
 		return statusOrder(items[i].status.Status) < statusOrder(items[j].status.Status)
 	})
@@ -97,6 +96,11 @@ func fzfPickWorktree(worktrees []worktree.Worktree, repoName string) (string, er
 		)
 		lines = append(lines, line)
 	}
+	return lines
+}
+
+func fzfPickWorktree(worktrees []worktree.Worktree, repoName string) (string, error) {
+	lines := buildWorktreeLines(worktrees, repoName)
 
 	selected, err := fzf.Run(lines,
 		fzf.WithAnsi(),
@@ -111,6 +115,28 @@ func fzfPickWorktree(worktrees []worktree.Worktree, repoName string) (string, er
 	}
 
 	return extractPathFromLine(selected), nil
+}
+
+func fzfPickWorktrees(worktrees []worktree.Worktree, repoName string) ([]string, error) {
+	lines := buildWorktreeLines(worktrees, repoName)
+
+	selected, err := fzf.RunMulti(lines,
+		fzf.WithAnsi(),
+		fzf.WithReverse(),
+		fzf.WithHeader("Select worktrees (TAB to multi-select)"),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if selected == nil {
+		return nil, nil
+	}
+
+	paths := make([]string, len(selected))
+	for i, line := range selected {
+		paths[i] = extractPathFromLine(line)
+	}
+	return paths, nil
 }
 
 func extractPathFromLine(line string) string {

--- a/internal/fzf/fzf.go
+++ b/internal/fzf/fzf.go
@@ -27,19 +27,8 @@ func WithReverse() Option {
 	return func(c *config) { c.reverse = true }
 }
 
-// Run launches fzf with the given lines and returns the selected line.
-// Returns empty string and nil error if user cancelled (Esc/Ctrl-C).
-func Run(lines []string, opts ...Option) (string, error) {
-	if _, err := exec.LookPath("fzf"); err != nil {
-		return "", fmt.Errorf("fzf is required but not found in PATH\n\nInstall it: https://github.com/junegunn/fzf#installation")
-	}
-
-	cfg := &config{}
-	for _, o := range opts {
-		o(cfg)
-	}
-
-	args := []string{"--no-multi"}
+func buildArgs(cfg *config) []string {
+	var args []string
 	if cfg.ansi {
 		args = append(args, "--ansi")
 	}
@@ -49,6 +38,36 @@ func Run(lines []string, opts ...Option) (string, error) {
 	if cfg.header != "" {
 		args = append(args, "--header", cfg.header)
 	}
+	return args
+}
+
+func requireFzf() error {
+	if _, err := exec.LookPath("fzf"); err != nil {
+		return fmt.Errorf("fzf is required but not found in PATH\n\nInstall it: https://github.com/junegunn/fzf#installation")
+	}
+	return nil
+}
+
+func isCancelled(err error) bool {
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		return exitErr.ExitCode() == 130 || exitErr.ExitCode() == 1
+	}
+	return false
+}
+
+// Run launches fzf with the given lines and returns the selected line.
+// Returns empty string and nil error if user cancelled (Esc/Ctrl-C).
+func Run(lines []string, opts ...Option) (string, error) {
+	if err := requireFzf(); err != nil {
+		return "", err
+	}
+
+	cfg := &config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	args := append([]string{"--no-multi"}, buildArgs(cfg)...)
 
 	cmd := exec.Command("fzf", args...)
 	cmd.Stdin = strings.NewReader(strings.Join(lines, "\n"))
@@ -56,14 +75,45 @@ func Run(lines []string, opts ...Option) (string, error) {
 
 	out, err := cmd.Output()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			// fzf returns 130 on Ctrl-C, 1 on no match
-			if exitErr.ExitCode() == 130 || exitErr.ExitCode() == 1 {
-				return "", nil
-			}
+		if isCancelled(err) {
+			return "", nil
 		}
 		return "", fmt.Errorf("fzf failed: %w", err)
 	}
 
 	return strings.TrimSpace(string(out)), nil
+}
+
+// RunMulti launches fzf with multi-select enabled (TAB to toggle, Ctrl-A to select all).
+// Returns nil, nil on cancel (Esc/Ctrl-C).
+func RunMulti(lines []string, opts ...Option) ([]string, error) {
+	if err := requireFzf(); err != nil {
+		return nil, err
+	}
+
+	cfg := &config{}
+	for _, o := range opts {
+		o(cfg)
+	}
+
+	args := append([]string{"--multi", "--bind=ctrl-a:select-all"}, buildArgs(cfg)...)
+
+	cmd := exec.Command("fzf", args...)
+	cmd.Stdin = strings.NewReader(strings.Join(lines, "\n"))
+	cmd.Stderr = os.Stderr
+
+	out, err := cmd.Output()
+	if err != nil {
+		if isCancelled(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("fzf failed: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return nil, nil
+	}
+
+	return strings.Split(raw, "\n"), nil
 }

--- a/screenshots/demo-workflow.tape
+++ b/screenshots/demo-workflow.tape
@@ -34,7 +34,7 @@ Sleep 300ms
 Enter
 Sleep 2s
 
-Type "willow rm feature/auth --yes"
+Type "willow rm feature/auth"
 Sleep 300ms
 Enter
 Sleep 2s

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -59,7 +59,7 @@ Active agents sorted first, offline sorted last. Requires [fzf](https://github.c
 
 ## `ww rm [branch] [flags]`
 
-Remove a worktree. Without arguments, opens fzf picker.
+Remove a worktree. Without arguments, opens fzf picker with multi-select (TAB to toggle, Ctrl-A to select all).
 
 ```bash
 ww rm auth-refactor              # direct removal
@@ -72,13 +72,11 @@ ww rm auth-refactor --prune      # also run git worktree prune
 |------|-------------|---------|
 | `-f, --force` | Skip safety checks | `false` |
 | `--keep-branch` | Keep the local branch | `false` |
-| `-y, --yes` | Skip confirmation | `false` |
 | `--prune` | Run `git worktree prune` after | `false` |
 
 **Safety checks** (unless `--force`):
 - Warns if there are uncommitted changes
 - Warns if there are unpushed commits
-- Prompts for confirmation
 
 ## `ww ls [repo]`
 


### PR DESCRIPTION
## Description of the change

`ww rm` now supports multi-select via fzf (TAB to toggle, Ctrl-A to select all) and no longer prompts for y/N confirmation. The `--yes` flag is removed entirely.

- Added `fzf.RunMulti()` with `--multi` and `--bind=ctrl-a:select-all`
- Extracted `buildWorktreeLines()` helper from `fzfPickWorktree()`, added `fzfPickWorktrees()` for the rm command
- Removed `--yes` flag, `confirm()` function, and `bufio` import
- Extracted `removeWorktree()` helper to loop over selected worktrees
- `--prune` runs once after all removals

## Test plan

Unit tests updated (removed `--yes` from test invocations), `go test ./...` passes. Manual testing: `ww rm` opens fzf with multi-select, `ww rm <branch>` removes directly without confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)