### PR TITLE
🎨 style(website): display all feature cards on one row

### DIFF
--- a/website/docs/.vitepress/theme/style/custom.css
+++ b/website/docs/.vitepress/theme/style/custom.css
@@ -43,6 +43,13 @@ html {
   color: var(--willow-neon-cyan) !important;
 }
 
+/* Feature grid — 5 columns so all cards fit on one row */
+@media (min-width: 960px) {
+  .VPFeatures .item.grid-4 {
+    width: calc(100% / 5);
+  }
+}
+
 /* Nav glass effect */
 .VPNav {
   backdrop-filter: blur(12px) !important;


### PR DESCRIPTION
## Description of the change

Override VitePress's default `grid-4` layout to use 5 columns at `960px+`, so all 5 feature cards (AI-Agent Optimized, Live Status Tracking, fzf-Powered Switching, Native Tmux Integration, Git-Native) display on a single row without the 5th card wrapping to a new line.

## Test plan

- `cd website && npm run dev` → homepage shows all 5 cards on one row at desktop width

🤖 Generated with [Claude Code](https://claude.com/claude-code)