### PR TITLE
🐛 fix(tmux,claude): stale BUSY status and picker flag parsing

### DIFF
--- a/internal/claude/status.go
+++ b/internal/claude/status.go
@@ -17,6 +17,9 @@ const (
 	StatusWait    Status = "WAIT"
 	StatusIdle    Status = "IDLE"
 	StatusOffline Status = "--"
+
+	staleTimeout   = 2 * time.Minute
+	cleanupTimeout = 30 * time.Minute
 )
 
 type WorktreeStatus struct {
@@ -41,6 +44,8 @@ func StatusDir() string {
 // ReadAllSessions reads all session status files from the directory-based layout:
 // ~/.willow/status/<repo>/<worktree>/*.json
 func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
+	CleanStaleSessions(repoName, worktreeDir)
+
 	dir := filepath.Join(StatusDir(), repoName, worktreeDir)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -94,7 +99,7 @@ func aggregateStatus(sessions []*SessionStatus) *WorktreeStatus {
 }
 
 func EffectiveStatus(s Status, ts time.Time) Status {
-	if (s == StatusBusy || s == StatusDone || s == StatusWait) && time.Since(ts) > 5*time.Minute {
+	if (s == StatusBusy || s == StatusDone || s == StatusWait) && time.Since(ts) > staleTimeout {
 		return StatusIdle
 	}
 	return s
@@ -131,7 +136,7 @@ func readLegacyStatus(repoName, worktreeDir string) *WorktreeStatus {
 	return &ws
 }
 
-// CleanStaleSessions removes session files older than 2 hours.
+// CleanStaleSessions removes session files older than 30 minutes.
 func CleanStaleSessions(repoName, worktreeDir string) {
 	dir := filepath.Join(StatusDir(), repoName, worktreeDir)
 	entries, err := os.ReadDir(dir)
@@ -152,7 +157,7 @@ func CleanStaleSessions(repoName, worktreeDir string) {
 			os.Remove(filepath.Join(dir, e.Name()))
 			continue
 		}
-		if time.Since(ss.Timestamp) > 2*time.Hour {
+		if time.Since(ss.Timestamp) > cleanupTimeout {
 			os.Remove(filepath.Join(dir, e.Name()))
 		}
 	}

--- a/internal/claude/status_test.go
+++ b/internal/claude/status_test.go
@@ -181,7 +181,7 @@ func TestCleanStaleSessions(t *testing.T) {
 	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
 	os.MkdirAll(sessDir, 0o755)
 
-	stale := SessionStatus{Status: StatusDone, SessionID: "old", Timestamp: time.Now().UTC().Add(-3 * time.Hour)}
+	stale := SessionStatus{Status: StatusDone, SessionID: "old", Timestamp: time.Now().UTC().Add(-1 * time.Hour)}
 	fresh := SessionStatus{Status: StatusBusy, SessionID: "new", Timestamp: time.Now().UTC()}
 
 	for _, ss := range []SessionStatus{stale, fresh} {

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -75,8 +75,8 @@ func tmuxPickCmd() *cli.Command {
 					}
 				}
 
-				previewCmd := fmt.Sprintf("%s tmux preview {}", self)
-				reloadCmd := fmt.Sprintf("sleep 2 && %s tmux list", self)
+				previewCmd := fmt.Sprintf("%s tmux preview -- {}", self)
+				reloadCmd := fmt.Sprintf("%s tmux list", self)
 				if repoFilter != "" {
 					reloadCmd += fmt.Sprintf(" --repo %s", repoFilter)
 				}
@@ -193,7 +193,7 @@ func tmuxPickNew(self, query, repoFilter string, items []tmux.PickerItem) error 
 		return err
 	}
 
-	args := []string{"new", query, "--cd", "--repo", repo}
+	args := []string{"new", "--cd", "--repo", repo, "--", query}
 
 	cmd := exec.Command(self, args...)
 	cmd.Stderr = os.Stderr
@@ -230,6 +230,10 @@ func resolveRepo(repoFilter string, items []tmux.PickerItem) (string, error) {
 	repos, err := config.ListRepos()
 	if err != nil || len(repos) == 0 {
 		return "", fmt.Errorf("no repos found — run 'ww clone' first")
+	}
+
+	if len(repos) == 1 {
+		return repos[0], nil
 	}
 
 	currentRepo := ""

--- a/internal/fzf/fzf.go
+++ b/internal/fzf/fzf.go
@@ -159,7 +159,7 @@ func RunExpect(lines []string, opts ...Option) (*ExpectResult, error) {
 	}
 
 	results, code, err := runFzf(lines, []string{"--no-multi"}, cfg)
-	if code == fzflib.ExitInterrupt || code == fzflib.ExitNoMatch {
+	if code == fzflib.ExitInterrupt {
 		return nil, nil
 	}
 	if err != nil {


### PR DESCRIPTION
## Description of the change

Fixes two bugs in the tmux picker:
1. **Stale BUSY status** — crashed Claude sessions leave lingering `.json` files. Reduced staleness threshold (5min→2min), cleanup threshold (2hr→30min), and added opportunistic GC in `ReadAllSessions`.
2. **Picker flag parsing** — the offline status `--` in ANSI-stripped picker lines was being interpreted as a CLI flag by urfave/cli. Added `--` separators in preview and new-worktree commands. Also fixed Ctrl-N closing the picker when the query has no matches.

## Test plan

- Unit tests updated and passing (`go test ./internal/claude/...`)
- Manual testing: picker preview, Ctrl-N new worktree, stale status cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)