### PR TITLE
✨ feat(tmux): show progress and close picker on Ctrl-N

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -157,12 +157,17 @@ func newCmd() *cli.Command {
 			// Fetch latest from remote (config default, --no-fetch overrides)
 			shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch")
 			if shouldFetch {
-				if !cdOnly {
-					u.Info(fmt.Sprintf("Fetching %s from origin...", u.Bold(baseBranch)))
-				}
 				done = tr.Start("git fetch")
-				if _, err := repoGit.Run("fetch", "origin", baseBranch); err != nil {
-					return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Fetching %s from origin...\n", baseBranch)
+					if _, err := repoGit.RunStream(os.Stderr, "fetch", "--progress", "origin", baseBranch); err != nil {
+						return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
+					}
+				} else {
+					u.Info(fmt.Sprintf("Fetching %s from origin...", u.Bold(baseBranch)))
+					if _, err := repoGit.Run("fetch", "origin", baseBranch); err != nil {
+						return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
+					}
 				}
 				done()
 			}
@@ -172,18 +177,28 @@ func newCmd() *cli.Command {
 
 			done = tr.Start("git worktree add")
 			if cmd.Bool("existing") {
-				if !cdOnly {
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Creating worktree for existing branch %s...\n", branch)
+					if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, branch); err != nil {
+						return fmt.Errorf("failed to create worktree: %w", err)
+					}
+				} else {
 					u.Info(fmt.Sprintf("Creating worktree for existing branch %s...", u.Bold(branch)))
-				}
-				if _, err := repoGit.Run("worktree", "add", wtPath, branch); err != nil {
-					return fmt.Errorf("failed to create worktree: %w", err)
+					if _, err := repoGit.Run("worktree", "add", wtPath, branch); err != nil {
+						return fmt.Errorf("failed to create worktree: %w", err)
+					}
 				}
 			} else {
-				if !cdOnly {
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Creating worktree %s from %s...\n", branch, "origin/"+baseBranch)
+					if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+						return fmt.Errorf("failed to create worktree: %w", err)
+					}
+				} else {
 					u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold("origin/"+baseBranch)))
-				}
-				if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
-					return fmt.Errorf("failed to create worktree: %w", err)
+					if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+						return fmt.Errorf("failed to create worktree: %w", err)
+					}
 				}
 			}
 			done()

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -107,8 +107,9 @@ func tmuxPickCmd() *cli.Command {
 				case "ctrl-n":
 					if err := tmuxPickNew(self, result.Query, repoFilter, items); err != nil {
 						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						continue
 					}
-					continue
+					return nil
 
 				case "ctrl-d":
 					if result.Selection == "" {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,7 +1,9 @@
 package git
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,6 +34,33 @@ func (g *Git) Run(args ...string) (string, error) {
 		return "", fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, out)
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// RunStream captures stdout and returns it, while streaming stderr to the
+// given writer in real-time. Useful for commands like `git fetch --progress`
+// where progress output goes to stderr.
+func (g *Git) RunStream(stderr io.Writer, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	if g.Dir != "" {
+		cmd.Dir = g.Dir
+	}
+
+	if g.Verbose {
+		if g.Dir != "" {
+			fmt.Fprintf(os.Stderr, "$ git -C %s %s\n", g.Dir, strings.Join(args, " "))
+		} else {
+			fmt.Fprintf(os.Stderr, "$ git %s\n", strings.Join(args, " "))
+		}
+	}
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(stdout.String()), nil
 }
 
 func (g *Git) BareRepoDir() (string, error) {


### PR DESCRIPTION
## Description of the change

- **Progress visible during worktree creation**: When pressing Ctrl-N in the tmux picker, `git fetch` and `git worktree add` progress is now streamed to stderr in real-time via a new `Git.RunStream()` method (uses `--progress` flag so git shows transfer stats even when stderr isn't a TTY)
- **Picker closes on success**: After a successful Ctrl-N worktree creation, the picker returns instead of relaunching fzf — consistent with Enter (switch) behavior. On error, the picker stays open so the user can retry.

## Test plan
Manual testing in tmux: Ctrl-N with a branch name shows fetch progress and closes the picker on success; invalid branch name shows error and keeps picker open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)