### PR TITLE
✨ feat(cli): work from anywhere — sw, status, rm, ls cross-repo support

### DIFF
--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -302,3 +302,252 @@ func TestLs_ListsWorktrees(t *testing.T) {
 		t.Fatalf("ls --json failed: %v", err)
 	}
 }
+
+// --- Cross-repo integration tests ---
+
+func TestSw_WithRepoFlag(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "swrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	// Create a second worktree so there's something to switch to
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "swrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+	if err := runApp("new", "sw-target", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	// Move outside the repo
+	os.Chdir(home)
+
+	// sw -r swrepo sw-target should work (direct switch by name)
+	if err := runApp("sw", "-r", "swrepo", "sw-target"); err != nil {
+		t.Fatalf("sw -r swrepo sw-target failed: %v", err)
+	}
+}
+
+func TestSw_DirectNameFromAnywhere(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "swany"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "swany")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+	if err := runApp("new", "unique-branch", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	// Move outside repo
+	os.Chdir(home)
+
+	// Should find unique-branch across all repos
+	if err := runApp("sw", "unique-branch"); err != nil {
+		t.Fatalf("sw unique-branch from outside repo: %v", err)
+	}
+}
+
+func TestStatus_WithRepoFlag(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "strepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	// Move outside repo
+	os.Chdir(home)
+
+	// status -r strepo should work
+	if err := runApp("status", "-r", "strepo"); err != nil {
+		t.Fatalf("status -r strepo failed: %v", err)
+	}
+}
+
+func TestStatus_CrossRepoFromAnywhere(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "st1"); err != nil {
+		t.Fatalf("clone st1 failed: %v", err)
+	}
+	if err := runApp("clone", origin, "st2"); err != nil {
+		t.Fatalf("clone st2 failed: %v", err)
+	}
+
+	// Move outside repos
+	os.Chdir(home)
+
+	// status should show both repos
+	if err := runApp("status"); err != nil {
+		t.Fatalf("status from outside repo: %v", err)
+	}
+}
+
+func TestStatus_JsonCrossRepo(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "json1"); err != nil {
+		t.Fatalf("clone json1 failed: %v", err)
+	}
+	if err := runApp("clone", origin, "json2"); err != nil {
+		t.Fatalf("clone json2 failed: %v", err)
+	}
+
+	os.Chdir(home)
+
+	if err := runApp("status", "--json"); err != nil {
+		t.Fatalf("status --json from outside repo: %v", err)
+	}
+}
+
+func TestRm_WithRepoFlagFromAnywhere(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "rmrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "rmrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+	if err := runApp("new", "rm-target", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	// Move outside repo
+	os.Chdir(home)
+
+	// rm -r rmrepo rm-target should work
+	if err := runApp("rm", "-r", "rmrepo", "rm-target"); err != nil {
+		t.Fatalf("rm -r rmrepo rm-target failed: %v", err)
+	}
+
+	// Verify it was removed
+	removedDir := filepath.Join(worktreeDir, "rm-target")
+	if _, err := os.Stat(removedDir); !os.IsNotExist(err) {
+		t.Error("worktree should be removed")
+	}
+}
+
+func TestRm_CrossRepoByNameFromAnywhere(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "rmany"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "rmany")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+	if err := runApp("new", "cross-rm-branch", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	os.Chdir(home)
+
+	// Should find cross-rm-branch across repos and remove it
+	if err := runApp("rm", "cross-rm-branch"); err != nil {
+		t.Fatalf("rm cross-rm-branch from outside repo: %v", err)
+	}
+
+	removedDir := filepath.Join(worktreeDir, "cross-rm-branch")
+	if _, err := os.Stat(removedDir); !os.IsNotExist(err) {
+		t.Error("worktree should be removed")
+	}
+}
+
+func TestLs_RepoListShowsActiveUnread(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "lsrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	// Move outside repo to trigger repo list mode
+	os.Chdir(home)
+
+	// ls from outside repo should show repo list with columns (no error)
+	if err := runApp("ls"); err != nil {
+		t.Fatalf("ls from outside repo: %v", err)
+	}
+}
+
+func TestSw_ScopedToCurrentRepo(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "scoped"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "scoped")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "scoped-branch", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	// sw from inside repo should still work (scoped to current repo)
+	if err := runApp("sw", "scoped-branch"); err != nil {
+		t.Fatalf("sw scoped-branch from inside repo: %v", err)
+	}
+}
+
+func TestStatus_ScopedToCurrentRepo(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "stscoped"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "stscoped")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+
+	// status from inside repo should still be scoped
+	if err := runApp("status"); err != nil {
+		t.Fatalf("status from inside repo: %v", err)
+	}
+}
+
+func TestRm_ScopedToCurrentRepo(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "rmscoped"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "rmscoped")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+
+	if err := runApp("new", "scoped-rm", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	// rm from inside repo should be scoped
+	if err := runApp("rm", "scoped-rm"); err != nil {
+		t.Fatalf("rm scoped-rm from inside repo: %v", err)
+	}
+
+	removedDir := filepath.Join(worktreeDir, "scoped-rm")
+	if _, err := os.Stat(removedDir); !os.IsNotExist(err) {
+		t.Error("worktree should be removed")
+	}
+}

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -111,7 +111,7 @@ func printRepoList(flags Flags) error {
 		}
 	}
 
-	header := fmt.Sprintf("  %-*s  %s", nameW, "REPO", "WORKTREES")
+	header := fmt.Sprintf("  %-*s  %-9s  %-6s  %s", nameW, "REPO", "WORKTREES", "ACTIVE", "UNREAD")
 	u.Info(u.Bold(header))
 
 	for _, r := range repos {
@@ -125,12 +125,23 @@ func printRepoList(flags Flags) error {
 			continue
 		}
 		count := 0
+		activeCount := 0
+		unreadCount := 0
 		for _, wt := range wts {
-			if !wt.IsBare {
-				count++
+			if wt.IsBare {
+				continue
+			}
+			count++
+			wtDir := filepath.Base(wt.Path)
+			ws := claude.ReadStatus(r, wtDir)
+			if ws.Status == claude.StatusBusy || ws.Status == claude.StatusDone || ws.Status == claude.StatusWait {
+				activeCount++
+			}
+			if claude.IsUnread(r, wtDir) {
+				unreadCount++
 			}
 		}
-		line := fmt.Sprintf("  %-*s  %d", nameW, r, count)
+		line := fmt.Sprintf("  %-*s  %-9d  %-6d  %d", nameW, r, count, activeCount, unreadCount)
 		u.Info(line)
 	}
 	return nil

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/ui"
@@ -28,7 +29,7 @@ func rmCmd() *cli.Command {
 				UsageText: "[branch]",
 			},
 		},
-		ShellComplete: completeWorktrees,
+		ShellComplete: completeWorktreesWithFlag,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "force",
@@ -56,86 +57,134 @@ func rmCmd() *cli.Command {
 			u := flags.NewUI()
 
 			done := tr.Start("resolve repo")
-			var bareDir string
-			var err error
-			if repoFlag := cmd.String("repo"); repoFlag != "" {
-				bareDir, err = config.ResolveRepo(repoFlag)
-				if err != nil {
-					return err
-				}
-			} else {
-				bareDir, err = requireWillowRepo(g)
-				if err != nil {
-					return err
-				}
-			}
-			done()
-
-			done = tr.Start("list worktrees")
-			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
-			worktrees, err := worktree.List(repoGit)
+			repos, err := resolveRepos(g, cmd.String("repo"))
 			if err != nil {
-				return fmt.Errorf("failed to list worktrees: %w", err)
+				return err
 			}
 			done()
 
-			filtered := filterBareWorktrees(worktrees)
-
-			done = tr.Start("resolve targets")
+			multiRepo := len(repos) > 1
 			target := cmd.StringArg("branch")
-			var targets []worktree.Worktree
-
-			if target == "" {
-				repoName := repoNameFromDir(bareDir)
-				selectedPaths, err := fzfPickWorktrees(filtered, repoName)
-				if err != nil {
-					return err
-				}
-				if selectedPaths == nil {
-					return nil
-				}
-				for _, sp := range selectedPaths {
-					for i := range filtered {
-						if filtered[i].Path == sp {
-							targets = append(targets, filtered[i])
-							break
-						}
-					}
-				}
-				if len(targets) == 0 {
-					return fmt.Errorf("selected worktrees not found")
-				}
-			} else {
-				wt, err := findWorktree(filtered, target)
-				if err != nil {
-					return err
-				}
-				targets = []worktree.Worktree{*wt}
-			}
-			done()
-
 			force := cmd.Bool("force")
 			keepBranch := cmd.Bool("keep-branch")
 
-			done = tr.Start("load config")
-			cfg := config.Load(bareDir)
-			done()
+			if multiRepo {
+				done = tr.Start("collect worktrees")
+				allWts := collectAllWorktrees(repos, g.Verbose)
+				if len(allWts) == 0 {
+					return fmt.Errorf("no worktrees found")
+				}
+				done()
 
-			for _, wt := range targets {
-				if err := removeWorktree(tr, u, repoGit, &wt, bareDir, cfg, force, keepBranch, g.Verbose); err != nil {
-					return err
+				done = tr.Start("resolve targets")
+				var targets []repoWorktree
+				if target == "" {
+					lines := buildCrossRepoWorktreeLines(allWts)
+					selected, err := fzf.RunMulti(lines,
+						fzf.WithAnsi(),
+						fzf.WithReverse(),
+						fzf.WithHeader("Select worktrees (TAB to multi-select)"),
+					)
+					if err != nil {
+						return err
+					}
+					if selected == nil {
+						return nil
+					}
+					for _, line := range selected {
+						path := extractPathFromLine(line)
+						if rwt := repoWorktreeByPath(allWts, path); rwt != nil {
+							targets = append(targets, *rwt)
+						}
+					}
+					if len(targets) == 0 {
+						return fmt.Errorf("selected worktrees not found")
+					}
+				} else {
+					rwt, err := findCrossRepoWorktree(allWts, target)
+					if err != nil {
+						return err
+					}
+					targets = []repoWorktree{*rwt}
+				}
+				done()
+
+				for i := range targets {
+					repoGit := &git.Git{Dir: targets[i].Repo.BareDir, Verbose: g.Verbose}
+					cfg := config.Load(targets[i].Repo.BareDir)
+					if err := removeWorktree(tr, u, repoGit, &targets[i].Worktree, targets[i].Repo.BareDir, cfg, force, keepBranch, g.Verbose); err != nil {
+						return err
+					}
+				}
+			} else {
+				bareDir := repos[0].BareDir
+
+				done = tr.Start("list worktrees")
+				repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+				worktrees, err := worktree.List(repoGit)
+				if err != nil {
+					return fmt.Errorf("failed to list worktrees: %w", err)
+				}
+				done()
+
+				filtered := filterBareWorktrees(worktrees)
+
+				done = tr.Start("resolve targets")
+				var targets []worktree.Worktree
+
+				if target == "" {
+					repoName := repoNameFromDir(bareDir)
+					selectedPaths, err := fzfPickWorktrees(filtered, repoName)
+					if err != nil {
+						return err
+					}
+					if selectedPaths == nil {
+						return nil
+					}
+					for _, sp := range selectedPaths {
+						for i := range filtered {
+							if filtered[i].Path == sp {
+								targets = append(targets, filtered[i])
+								break
+							}
+						}
+					}
+					if len(targets) == 0 {
+						return fmt.Errorf("selected worktrees not found")
+					}
+				} else {
+					wt, err := findWorktree(filtered, target)
+					if err != nil {
+						return err
+					}
+					targets = []worktree.Worktree{*wt}
+				}
+				done()
+
+				done = tr.Start("load config")
+				cfg := config.Load(bareDir)
+				done()
+
+				repoGit2 := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+				for _, wt := range targets {
+					if err := removeWorktree(tr, u, repoGit2, &wt, bareDir, cfg, force, keepBranch, g.Verbose); err != nil {
+						return err
+					}
 				}
 			}
 
 			if cmd.Bool("prune") {
-				done = tr.Start("git worktree prune")
-				u.Info("Pruning stale worktrees...")
-				if _, err := repoGit.Run("worktree", "prune"); err != nil {
-					u.Warn(fmt.Sprintf("Prune failed: %v", err))
-				} else {
-					u.Success("Pruned stale worktrees")
+				for _, r := range repos {
+					repoGit := &git.Git{Dir: r.BareDir, Verbose: g.Verbose}
+					done = tr.Start("git worktree prune")
+					u.Info("Pruning stale worktrees...")
+					if _, err := repoGit.Run("worktree", "prune"); err != nil {
+						u.Warn(fmt.Sprintf("Prune failed: %v", err))
+					} else {
+						u.Success("Pruned stale worktrees")
+					}
+					done()
 				}
-				done()
 			}
 
 			tr.Total()

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -13,6 +13,76 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+type sessionEntry struct {
+	Repo      string `json:"repo,omitempty"`
+	Branch    string `json:"branch"`
+	SessionID string `json:"session_id,omitempty"`
+	Status    string `json:"status"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Unread    bool   `json:"unread,omitempty"`
+	Path      string `json:"path"`
+}
+
+type repoStatus struct {
+	Name          string
+	Entries       []sessionEntry
+	WorktreeCount int
+	ActiveCount   int
+	UnreadCount   int
+}
+
+func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatus {
+	rs := repoStatus{Name: repoName, WorktreeCount: len(worktrees)}
+	for _, wt := range worktrees {
+		wtDir := filepath.Base(wt.Path)
+		sessions := claude.ReadAllSessions(repoName, wtDir)
+		unread := claude.IsUnread(repoName, wtDir)
+		if unread {
+			rs.UnreadCount++
+		}
+
+		if len(sessions) > 0 {
+			for _, ss := range sessions {
+				entry := sessionEntry{
+					Repo:      repoName,
+					Branch:    wt.Branch,
+					SessionID: ss.SessionID,
+					Status:    string(ss.Status),
+					Path:      wt.Path,
+				}
+				if !ss.Timestamp.IsZero() {
+					entry.Timestamp = claude.TimeSince(ss.Timestamp)
+				}
+				if ss.Status == claude.StatusDone && unread {
+					entry.Unread = true
+				}
+				rs.Entries = append(rs.Entries, entry)
+
+				if ss.Status == claude.StatusBusy || ss.Status == claude.StatusDone || ss.Status == claude.StatusWait {
+					rs.ActiveCount++
+				}
+			}
+		} else {
+			ws := claude.ReadStatus(repoName, wtDir)
+			entry := sessionEntry{
+				Repo:   repoName,
+				Branch: wt.Branch,
+				Status: string(ws.Status),
+				Path:   wt.Path,
+			}
+			if !ws.Timestamp.IsZero() {
+				entry.Timestamp = claude.TimeSince(ws.Timestamp)
+			}
+			rs.Entries = append(rs.Entries, entry)
+
+			if ws.Status == claude.StatusBusy || ws.Status == claude.StatusDone || ws.Status == claude.StatusWait {
+				rs.ActiveCount++
+			}
+		}
+	}
+	return rs
+}
+
 func statusCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "status",
@@ -23,121 +93,78 @@ func statusCmd() *cli.Command {
 				Name:  "json",
 				Usage: "Output as JSON",
 			},
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target a willow-managed repo by name",
+			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
 			g := flags.NewGit()
 			u := flags.NewUI()
 
-			bareDir, err := requireWillowRepo(g)
+			repos, err := resolveRepos(g, cmd.String("repo"))
 			if err != nil {
 				return err
 			}
 
-			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
-			worktrees, err := worktree.List(repoGit)
-			if err != nil {
-				return fmt.Errorf("failed to list worktrees: %w", err)
-			}
-
-			filtered := filterBareWorktrees(worktrees)
-			repoName := repoNameFromDir(bareDir)
-
-			type sessionEntry struct {
-				Branch    string `json:"branch"`
-				SessionID string `json:"session_id,omitempty"`
-				Status    string `json:"status"`
-				Timestamp string `json:"timestamp,omitempty"`
-				Unread    bool   `json:"unread,omitempty"`
-				Path      string `json:"path"`
-			}
-
-			var entries []sessionEntry
-			activeCount := 0
-			totalUnread := 0
-
-			for _, wt := range filtered {
-				wtDir := filepath.Base(wt.Path)
-				sessions := claude.ReadAllSessions(repoName, wtDir)
-				unread := claude.IsUnread(repoName, wtDir)
-				if unread {
-					totalUnread++
+			var allStatuses []repoStatus
+			for _, r := range repos {
+				repoGit := &git.Git{Dir: r.BareDir, Verbose: g.Verbose}
+				wts, err := worktree.List(repoGit)
+				if err != nil {
+					continue
 				}
-
-				if len(sessions) > 0 {
-					for _, ss := range sessions {
-						entry := sessionEntry{
-							Branch:    wt.Branch,
-							SessionID: ss.SessionID,
-							Status:    string(ss.Status),
-							Path:      wt.Path,
-						}
-						if !ss.Timestamp.IsZero() {
-							entry.Timestamp = claude.TimeSince(ss.Timestamp)
-						}
-						if ss.Status == claude.StatusDone && unread {
-							entry.Unread = true
-						}
-						entries = append(entries, entry)
-
-						if ss.Status == claude.StatusBusy || ss.Status == claude.StatusDone || ss.Status == claude.StatusWait {
-							activeCount++
-						}
-					}
-				} else {
-					ws := claude.ReadStatus(repoName, wtDir)
-					entry := sessionEntry{
-						Branch: wt.Branch,
-						Status: string(ws.Status),
-						Path:   wt.Path,
-					}
-					if !ws.Timestamp.IsZero() {
-						entry.Timestamp = claude.TimeSince(ws.Timestamp)
-					}
-					entries = append(entries, entry)
-
-					if ws.Status == claude.StatusBusy || ws.Status == claude.StatusDone || ws.Status == claude.StatusWait {
-						activeCount++
-					}
-				}
+				filtered := filterBareWorktrees(wts)
+				allStatuses = append(allStatuses, collectRepoStatus(r.Name, filtered))
 			}
 
 			if cmd.Bool("json") {
+				var allEntries []sessionEntry
+				for _, rs := range allStatuses {
+					allEntries = append(allEntries, rs.Entries...)
+				}
 				enc := json.NewEncoder(os.Stdout)
 				enc.SetIndent("", "  ")
-				return enc.Encode(entries)
+				return enc.Encode(allEntries)
 			}
 
-			headerParts := fmt.Sprintf("%s (\U0001F333 %d worktrees, \U0001F916 %d active",
-				u.Bold(repoName), len(filtered), activeCount)
-			if totalUnread > 0 {
-				headerParts += fmt.Sprintf(", %d unread", totalUnread)
-			}
-			headerParts += ")\n"
-			u.Info(headerParts)
+			for i, rs := range allStatuses {
+				if i > 0 {
+					u.Info("")
+				}
+				headerParts := fmt.Sprintf("%s (\U0001F333 %d worktrees, \U0001F916 %d active",
+					u.Bold(rs.Name), rs.WorktreeCount, rs.ActiveCount)
+				if rs.UnreadCount > 0 {
+					headerParts += fmt.Sprintf(", %d unread", rs.UnreadCount)
+				}
+				headerParts += ")\n"
+				u.Info(headerParts)
 
-			branchW := 0
-			for _, e := range entries {
-				if len(e.Branch) > branchW {
-					branchW = len(e.Branch)
+				branchW := 0
+				for _, e := range rs.Entries {
+					if len(e.Branch) > branchW {
+						branchW = len(e.Branch)
+					}
 				}
-			}
 
-			for _, e := range entries {
-				icon := claude.StatusIcon(claude.Status(e.Status))
-				label := e.Status
-				if e.Unread {
-					label += "\u25CF" // ●
+				for _, e := range rs.Entries {
+					icon := claude.StatusIcon(claude.Status(e.Status))
+					label := e.Status
+					if e.Unread {
+						label += "\u25CF" // bullet
+					}
+					var line string
+					if e.Timestamp != "" {
+						line = fmt.Sprintf("  %s %-*s  %-6s  %s",
+							icon, branchW, e.Branch, label, u.Dim(e.Timestamp))
+					} else {
+						line = fmt.Sprintf("  %s %-*s  %s",
+							icon, branchW, e.Branch, label)
+					}
+					u.Info(line)
 				}
-				var line string
-				if e.Timestamp != "" {
-					line = fmt.Sprintf("  %s %-*s  %-6s  %s",
-						icon, branchW, e.Branch, label, u.Dim(e.Timestamp))
-				} else {
-					line = fmt.Sprintf("  %s %-*s  %s",
-						icon, branchW, e.Branch, label)
-				}
-				u.Info(line)
 			}
 
 			return nil

--- a/internal/cli/sw.go
+++ b/internal/cli/sw.go
@@ -18,15 +18,73 @@ func swCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "sw",
 		Usage: "Switch to a worktree (fzf picker)",
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "name",
+				UsageText: "[name]",
+			},
+		},
+		ShellComplete: completeWorktreesWithFlag,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target a willow-managed repo by name",
+			},
+		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
 			g := flags.NewGit()
 
-			bareDir, err := requireWillowRepo(g)
+			repos, err := resolveRepos(g, cmd.String("repo"))
 			if err != nil {
 				return err
 			}
 
+			multiRepo := len(repos) > 1
+			name := cmd.StringArg("name")
+
+			if name != "" {
+				allWts := collectAllWorktrees(repos, g.Verbose)
+				rwt, err := findCrossRepoWorktree(allWts, name)
+				if err != nil {
+					return err
+				}
+				wtDir := filepath.Base(rwt.Worktree.Path)
+				claude.MarkRead(rwt.Repo.Name, wtDir)
+				fmt.Println(rwt.Worktree.Path)
+				return nil
+			}
+
+			if multiRepo {
+				allWts := collectAllWorktrees(repos, g.Verbose)
+				if len(allWts) == 0 {
+					return fmt.Errorf("no worktrees found")
+				}
+
+				lines := buildCrossRepoWorktreeLines(allWts)
+				selected, err := fzf.Run(lines,
+					fzf.WithAnsi(),
+					fzf.WithReverse(),
+					fzf.WithHeader("Select worktree"),
+				)
+				if err != nil {
+					return err
+				}
+				if selected == "" {
+					return nil
+				}
+
+				path := extractPathFromLine(selected)
+				if rwt := repoWorktreeByPath(allWts, path); rwt != nil {
+					claude.MarkRead(rwt.Repo.Name, filepath.Base(path))
+				}
+				fmt.Println(path)
+				return nil
+			}
+
+			// Single repo mode
+			bareDir := repos[0].BareDir
 			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
 			worktrees, err := worktree.List(repoGit)
 			if err != nil {
@@ -38,7 +96,7 @@ func swCmd() *cli.Command {
 				return fmt.Errorf("no worktrees found")
 			}
 
-			repoName := repoNameFromDir(bareDir)
+			repoName := repos[0].Name
 			selected, err := fzfPickWorktree(filtered, repoName)
 			if err != nil {
 				return err
@@ -47,10 +105,8 @@ func swCmd() *cli.Command {
 				return nil
 			}
 
-			// Mark sessions as read when switching to a worktree
 			wtDir := filepath.Base(selected)
 			claude.MarkRead(repoName, wtDir)
-
 			fmt.Println(selected)
 			return nil
 		},
@@ -93,6 +149,49 @@ func buildWorktreeLines(worktrees []worktree.Worktree, repoName string) []string
 			statusW, label,
 			branchW, item.wt.Branch,
 			item.wt.Path,
+		)
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+func buildCrossRepoWorktreeLines(rwts []repoWorktree) []string {
+	type item struct {
+		rwt    repoWorktree
+		status *claude.WorktreeStatus
+	}
+	items := make([]item, len(rwts))
+	for i, rwt := range rwts {
+		wtDir := filepath.Base(rwt.Worktree.Path)
+		items[i] = item{
+			rwt:    rwt,
+			status: claude.ReadStatus(rwt.Repo.Name, wtDir),
+		}
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		return statusOrder(items[i].status.Status) < statusOrder(items[j].status.Status)
+	})
+
+	nameW := 0
+	statusW := 4
+	for _, it := range items {
+		display := it.rwt.Repo.Name + "/" + it.rwt.Worktree.Branch
+		if len(display) > nameW {
+			nameW = len(display)
+		}
+	}
+
+	var lines []string
+	for _, it := range items {
+		icon := claude.StatusIcon(it.status.Status)
+		label := claude.StatusLabel(it.status.Status)
+		display := it.rwt.Repo.Name + "/" + it.rwt.Worktree.Branch
+		line := fmt.Sprintf("%s %-*s  %-*s  %s",
+			icon,
+			statusW, label,
+			nameW, display,
+			it.rwt.Worktree.Path,
 		)
 		lines = append(lines, line)
 	}

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -79,3 +80,192 @@ func filterBareWorktrees(worktrees []worktree.Worktree) []worktree.Worktree {
 	}
 	return filtered
 }
+
+type repoInfo struct {
+	Name    string
+	BareDir string
+}
+
+type repoWorktree struct {
+	Repo     repoInfo
+	Worktree worktree.Worktree
+}
+
+// resolveRepos returns bare dirs to operate on.
+// Priority: -r flag > current repo > all repos.
+func resolveRepos(g *git.Git, repoFlag string) ([]repoInfo, error) {
+	if repoFlag != "" {
+		bareDir, err := config.ResolveRepo(repoFlag)
+		if err != nil {
+			return nil, err
+		}
+		return []repoInfo{{Name: repoFlag, BareDir: bareDir}}, nil
+	}
+
+	bareDir, err := requireWillowRepo(g)
+	if err == nil {
+		return []repoInfo{{Name: repoNameFromDir(bareDir), BareDir: bareDir}}, nil
+	}
+
+	repos, err := config.ListRepos()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list repos: %w", err)
+	}
+	if len(repos) == 0 {
+		return nil, fmt.Errorf("no willow-managed repos found\n\nUse 'ww clone <url>' to get started.")
+	}
+
+	var result []repoInfo
+	for _, r := range repos {
+		bd, err := config.ResolveRepo(r)
+		if err != nil {
+			continue
+		}
+		result = append(result, repoInfo{Name: r, BareDir: bd})
+	}
+	return result, nil
+}
+
+func collectAllWorktrees(repos []repoInfo, verbose bool) []repoWorktree {
+	var all []repoWorktree
+	for _, r := range repos {
+		repoGit := &git.Git{Dir: r.BareDir, Verbose: verbose}
+		wts, err := worktree.List(repoGit)
+		if err != nil {
+			continue
+		}
+		for _, wt := range filterBareWorktrees(wts) {
+			all = append(all, repoWorktree{Repo: r, Worktree: wt})
+		}
+	}
+	return all
+}
+
+func findCrossRepoWorktree(rwts []repoWorktree, target string) (*repoWorktree, error) {
+	for i := range rwts {
+		if rwts[i].Worktree.Branch == target {
+			return &rwts[i], nil
+		}
+	}
+
+	var matches []repoWorktree
+	for _, rwt := range rwts {
+		if strings.Contains(rwt.Worktree.Branch, target) || strings.HasSuffix(rwt.Worktree.Path, "/"+target) {
+			matches = append(matches, rwt)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return nil, fmt.Errorf("no worktree found matching %q", target)
+	case 1:
+		return &matches[0], nil
+	default:
+		lines := fmt.Sprintf("ambiguous match %q, could be:\n", target)
+		for _, rwt := range matches {
+			lines += fmt.Sprintf("  %s/%s  %s\n", rwt.Repo.Name, rwt.Worktree.Branch, rwt.Worktree.Path)
+		}
+		return nil, fmt.Errorf("%s", strings.TrimRight(lines, "\n"))
+	}
+}
+
+// repoWorktreeByPath looks up the repoWorktree for a given path.
+func repoWorktreeByPath(rwts []repoWorktree, path string) *repoWorktree {
+	for i := range rwts {
+		if rwts[i].Worktree.Path == path {
+			return &rwts[i]
+		}
+	}
+	return nil
+}
+
+// completeWorktreesCrossRepo provides shell completion across all repos.
+func completeWorktreesCrossRepo(ctx context.Context, cmd *cli.Command) {
+	if args := cmd.Args().Slice(); len(args) > 0 && strings.HasPrefix(args[len(args)-1], "-") {
+		cli.DefaultCompleteWithFlags(ctx, cmd)
+		return
+	}
+
+	repos, err := config.ListRepos()
+	if err != nil {
+		return
+	}
+	w := cmd.Root().Writer
+	for _, r := range repos {
+		bd, err := config.ResolveRepo(r)
+		if err != nil {
+			continue
+		}
+		repoGit := &git.Git{Dir: bd}
+		wts, err := worktree.List(repoGit)
+		if err != nil {
+			continue
+		}
+		for _, wt := range wts {
+			if !wt.IsBare {
+				fmt.Fprintln(w, wt.Branch)
+			}
+		}
+	}
+}
+
+// completeWorktreesWithFlag provides shell completion respecting -r flag, with cross-repo fallback.
+func completeWorktreesWithFlag(ctx context.Context, cmd *cli.Command) {
+	if args := cmd.Args().Slice(); len(args) > 0 && strings.HasPrefix(args[len(args)-1], "-") {
+		cli.DefaultCompleteWithFlags(ctx, cmd)
+		return
+	}
+
+	if repoFlag := cmd.String("repo"); repoFlag != "" {
+		bareDir, err := config.ResolveRepo(repoFlag)
+		if err != nil {
+			return
+		}
+		repoGit := &git.Git{Dir: bareDir}
+		wts, err := worktree.List(repoGit)
+		if err != nil {
+			return
+		}
+		w := cmd.Root().Writer
+		for _, wt := range wts {
+			if !wt.IsBare {
+				fmt.Fprintln(w, wt.Branch)
+			}
+		}
+		return
+	}
+
+	g := &git.Git{}
+	bareDir, err := g.BareRepoDir()
+	if err == nil && config.IsWillowRepo(bareDir) {
+		repoGit := &git.Git{Dir: bareDir}
+		wts, err := worktree.List(repoGit)
+		if err != nil {
+			return
+		}
+		w := cmd.Root().Writer
+		for _, wt := range wts {
+			if !wt.IsBare {
+				fmt.Fprintln(w, wt.Branch)
+			}
+		}
+		return
+	}
+	if bareDir, ok := resolveRepoFromCwd(); ok {
+		repoGit := &git.Git{Dir: bareDir}
+		wts, err := worktree.List(repoGit)
+		if err != nil {
+			return
+		}
+		w := cmd.Root().Writer
+		for _, wt := range wts {
+			if !wt.IsBare {
+				fmt.Fprintln(w, wt.Branch)
+			}
+		}
+		return
+	}
+
+	completeWorktreesCrossRepo(ctx, cmd)
+}
+

--- a/internal/cli/util_test.go
+++ b/internal/cli/util_test.go
@@ -1,9 +1,12 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
@@ -83,5 +86,238 @@ func TestFilterBareWorktrees(t *testing.T) {
 	filtered := filterBareWorktrees(worktrees)
 	if len(filtered) != 2 {
 		t.Errorf("expected 2 non-bare worktrees, got %d", len(filtered))
+	}
+}
+
+// --- Cross-repo helper tests ---
+
+var testCrossRepoWorktrees = []repoWorktree{
+	{
+		Repo:     repoInfo{Name: "alpha", BareDir: "/repos/alpha.git"},
+		Worktree: worktree.Worktree{Branch: "main", Path: "/wt/alpha/main"},
+	},
+	{
+		Repo:     repoInfo{Name: "alpha", BareDir: "/repos/alpha.git"},
+		Worktree: worktree.Worktree{Branch: "feature/auth", Path: "/wt/alpha/feature-auth"},
+	},
+	{
+		Repo:     repoInfo{Name: "beta", BareDir: "/repos/beta.git"},
+		Worktree: worktree.Worktree{Branch: "main", Path: "/wt/beta/main"},
+	},
+	{
+		Repo:     repoInfo{Name: "beta", BareDir: "/repos/beta.git"},
+		Worktree: worktree.Worktree{Branch: "feature/payments", Path: "/wt/beta/feature-payments"},
+	},
+}
+
+func TestFindCrossRepoWorktree_ExactBranch(t *testing.T) {
+	rwt, err := findCrossRepoWorktree(testCrossRepoWorktrees, "feature/auth")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rwt.Worktree.Branch != "feature/auth" {
+		t.Errorf("Branch = %q, want %q", rwt.Worktree.Branch, "feature/auth")
+	}
+	if rwt.Repo.Name != "alpha" {
+		t.Errorf("Repo = %q, want %q", rwt.Repo.Name, "alpha")
+	}
+}
+
+func TestFindCrossRepoWorktree_Substring(t *testing.T) {
+	rwt, err := findCrossRepoWorktree(testCrossRepoWorktrees, "payments")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rwt.Worktree.Branch != "feature/payments" {
+		t.Errorf("Branch = %q, want %q", rwt.Worktree.Branch, "feature/payments")
+	}
+	if rwt.Repo.Name != "beta" {
+		t.Errorf("Repo = %q, want %q", rwt.Repo.Name, "beta")
+	}
+}
+
+func TestFindCrossRepoWorktree_DirectorySuffix(t *testing.T) {
+	rwt, err := findCrossRepoWorktree(testCrossRepoWorktrees, "feature-payments")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rwt.Worktree.Branch != "feature/payments" {
+		t.Errorf("Branch = %q, want %q", rwt.Worktree.Branch, "feature/payments")
+	}
+}
+
+func TestFindCrossRepoWorktree_AmbiguousAcrossRepos(t *testing.T) {
+	_, err := findCrossRepoWorktree(testCrossRepoWorktrees, "feature")
+	if err == nil {
+		t.Fatal("expected error for ambiguous match across repos")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error = %q, want it to contain 'ambiguous'", err.Error())
+	}
+	// Should include repo/branch format in the error
+	if !strings.Contains(err.Error(), "alpha/feature/auth") {
+		t.Errorf("error should mention alpha/feature/auth, got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "beta/feature/payments") {
+		t.Errorf("error should mention beta/feature/payments, got: %s", err.Error())
+	}
+}
+
+func TestFindCrossRepoWorktree_NotFound(t *testing.T) {
+	_, err := findCrossRepoWorktree(testCrossRepoWorktrees, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for no match")
+	}
+	if !strings.Contains(err.Error(), "no worktree found") {
+		t.Errorf("error = %q, want it to contain 'no worktree found'", err.Error())
+	}
+}
+
+func TestFindCrossRepoWorktree_ExactMatchPriority(t *testing.T) {
+	// "main" exists in both repos; exact match returns the first one found
+	rwt, err := findCrossRepoWorktree(testCrossRepoWorktrees, "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rwt.Worktree.Branch != "main" {
+		t.Errorf("Branch = %q, want %q", rwt.Worktree.Branch, "main")
+	}
+}
+
+func TestRepoWorktreeByPath(t *testing.T) {
+	rwt := repoWorktreeByPath(testCrossRepoWorktrees, "/wt/beta/feature-payments")
+	if rwt == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if rwt.Repo.Name != "beta" {
+		t.Errorf("Repo = %q, want %q", rwt.Repo.Name, "beta")
+	}
+	if rwt.Worktree.Branch != "feature/payments" {
+		t.Errorf("Branch = %q, want %q", rwt.Worktree.Branch, "feature/payments")
+	}
+}
+
+func TestRepoWorktreeByPath_NotFound(t *testing.T) {
+	rwt := repoWorktreeByPath(testCrossRepoWorktrees, "/nonexistent")
+	if rwt != nil {
+		t.Error("expected nil for non-matching path")
+	}
+}
+
+func TestResolveRepos_WithRepoFlag(t *testing.T) {
+	origin := setupTestEnv(t)
+	if err := runApp("clone", origin, "flagtest"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	g := &git.Git{}
+	repos, err := resolveRepos(g, "flagtest")
+	if err != nil {
+		t.Fatalf("resolveRepos with flag: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if repos[0].Name != "flagtest" {
+		t.Errorf("Name = %q, want %q", repos[0].Name, "flagtest")
+	}
+}
+
+func TestResolveRepos_CurrentRepo(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "currepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	// cd into the worktree
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "currepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+
+	g := &git.Git{}
+	repos, err := resolveRepos(g, "")
+	if err != nil {
+		t.Fatalf("resolveRepos from worktree: %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	if repos[0].Name != "currepo" {
+		t.Errorf("Name = %q, want %q", repos[0].Name, "currepo")
+	}
+}
+
+func TestResolveRepos_AllRepos(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "repo1"); err != nil {
+		t.Fatalf("clone repo1 failed: %v", err)
+	}
+	if err := runApp("clone", origin, "repo2"); err != nil {
+		t.Fatalf("clone repo2 failed: %v", err)
+	}
+
+	// cd to home (outside any repo)
+	os.Chdir(home)
+
+	g := &git.Git{}
+	repos, err := resolveRepos(g, "")
+	if err != nil {
+		t.Fatalf("resolveRepos fallback: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	names := map[string]bool{}
+	for _, r := range repos {
+		names[r.Name] = true
+	}
+	if !names["repo1"] || !names["repo2"] {
+		t.Errorf("expected repo1 and repo2, got %v", names)
+	}
+}
+
+func TestCollectAllWorktrees(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "col1"); err != nil {
+		t.Fatalf("clone col1 failed: %v", err)
+	}
+	if err := runApp("clone", origin, "col2"); err != nil {
+		t.Fatalf("clone col2 failed: %v", err)
+	}
+
+	// Create an extra worktree in col1
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "col1")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+	if err := runApp("new", "extra-branch", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	repos := []repoInfo{
+		{Name: "col1", BareDir: filepath.Join(home, ".willow", "repos", "col1.git")},
+		{Name: "col2", BareDir: filepath.Join(home, ".willow", "repos", "col2.git")},
+	}
+	all := collectAllWorktrees(repos, false)
+	// col1 has 2 worktrees (main + extra-branch), col2 has 1 (main)
+	if len(all) != 3 {
+		t.Errorf("expected 3 worktrees total, got %d", len(all))
+	}
+
+	// Verify repo names are set
+	repoNames := map[string]int{}
+	for _, rwt := range all {
+		repoNames[rwt.Repo.Name]++
+	}
+	if repoNames["col1"] != 2 {
+		t.Errorf("expected 2 worktrees from col1, got %d", repoNames["col1"])
+	}
+	if repoNames["col2"] != 1 {
+		t.Errorf("expected 1 worktree from col2, got %d", repoNames["col2"])
 	}
 }


### PR DESCRIPTION
## Description of the change

All core commands now work from outside a willow-managed repo, eliminating the biggest daily friction point.

**`ww sw`** — accepts `-r, --repo` flag and optional `<name>` argument for direct switch. Falls back to cross-repo fzf picker with `repo/branch` display format when outside any repo.

**`ww status`** — accepts `-r, --repo` flag. Cross-repo mode shows all repos with headers. `--json` output includes `repo` field on every entry.

**`ww rm`** — falls back to cross-repo fzf multi-picker or name match when outside a repo (previously only worked with explicit `-r` flag).

**`ww ls`** — repo list now shows `ACTIVE` and `UNREAD` agent count columns.

**Shared helpers** in `util.go`: `resolveRepos()`, `collectAllWorktrees()`, `findCrossRepoWorktree()`, `buildCrossRepoWorktreeLines()` — consistent 3-tier resolution (flag → current repo → all repos) across all commands.

## Test plan

- Unit tests for all new helpers (findCrossRepoWorktree, repoWorktreeByPath, resolveRepos, collectAllWorktrees)
- Integration tests for cross-repo sw, status, rm, ls commands (both from outside and inside repos)
- Regression tests confirming scoped behavior is preserved when inside a willow repo
- Manual verification against real `~/.willow` repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)