### PR TITLE
🧪 test: increase coverage across all packages

### DIFF
--- a/internal/claude/hook_test.go
+++ b/internal/claude/hook_test.go
@@ -1,0 +1,215 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstall_CreatesHookAndSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := Install(); err != nil {
+		t.Fatalf("Install() error: %v", err)
+	}
+
+	// Hook script should exist
+	hookPath := HookScriptPath()
+	info, err := os.Stat(hookPath)
+	if err != nil {
+		t.Fatalf("hook script not created: %v", err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Error("hook script should be executable")
+	}
+
+	// Status dir should exist
+	if _, err := os.Stat(StatusDir()); err != nil {
+		t.Fatalf("status dir not created: %v", err)
+	}
+
+	// Claude settings should contain hooks
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings not created: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("invalid settings JSON: %v", err)
+	}
+	hooks, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		t.Fatal("settings should have hooks key")
+	}
+	for _, event := range hookEvents {
+		if _, ok := hooks[event]; !ok {
+			t.Errorf("missing hook event %q", event)
+		}
+	}
+}
+
+func TestIsInstalled_FalseWithNoSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if IsInstalled() {
+		t.Error("IsInstalled should be false with no settings")
+	}
+}
+
+func TestIsInstalled_TrueAfterInstall(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := Install(); err != nil {
+		t.Fatalf("Install() error: %v", err)
+	}
+
+	if !IsInstalled() {
+		t.Error("IsInstalled should be true after Install()")
+	}
+}
+
+func TestInstall_Idempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := Install(); err != nil {
+		t.Fatalf("first Install() error: %v", err)
+	}
+	if err := Install(); err != nil {
+		t.Fatalf("second Install() error: %v", err)
+	}
+
+	// Should still have exactly 1 hook per event
+	settings, err := readClaudeSettings()
+	if err != nil {
+		t.Fatalf("readClaudeSettings error: %v", err)
+	}
+	hooks := settings["hooks"].(map[string]any)
+	for _, event := range hookEvents {
+		rules, ok := hooks[event].([]any)
+		if !ok {
+			t.Fatalf("event %q is not an array", event)
+		}
+		if len(rules) != 1 {
+			t.Errorf("event %q has %d rules, want 1 (idempotent)", event, len(rules))
+		}
+	}
+}
+
+func TestEventHasHook_FlatFormat(t *testing.T) {
+	hooksMap := map[string]any{
+		"Stop": []any{
+			map[string]any{
+				"type":    "command",
+				"command": "/path/to/hook.sh",
+			},
+		},
+	}
+	if !eventHasHook(hooksMap, "Stop", "/path/to/hook.sh") {
+		t.Error("should find hook in flat format")
+	}
+	if eventHasHook(hooksMap, "Stop", "/other/hook.sh") {
+		t.Error("should not find non-matching hook")
+	}
+}
+
+func TestEventHasHook_NestedFormat(t *testing.T) {
+	hooksMap := map[string]any{
+		"Stop": []any{
+			map[string]any{
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "/path/to/hook.sh",
+					},
+				},
+			},
+		},
+	}
+	if !eventHasHook(hooksMap, "Stop", "/path/to/hook.sh") {
+		t.Error("should find hook in nested format")
+	}
+}
+
+func TestEventHasHook_MissingEvent(t *testing.T) {
+	hooksMap := map[string]any{}
+	if eventHasHook(hooksMap, "Stop", "/path/to/hook.sh") {
+		t.Error("should return false for missing event")
+	}
+}
+
+func TestReadClaudeSettings_EmptyFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	settings, err := readClaudeSettings()
+	if err != nil {
+		t.Fatalf("readClaudeSettings error: %v", err)
+	}
+	if len(settings) != 0 {
+		t.Errorf("expected empty settings, got %v", settings)
+	}
+}
+
+func TestReadClaudeSettings_InvalidJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	os.MkdirAll(filepath.Dir(settingsPath), 0o755)
+	os.WriteFile(settingsPath, []byte("{invalid"), 0o644)
+
+	_, err := readClaudeSettings()
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestRemoveStatusDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "wt1"
+
+	// Create session dir and legacy file
+	sessDir := filepath.Join(StatusDir(), repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+	os.WriteFile(filepath.Join(sessDir, "s1.json"), []byte("{}"), 0o644)
+
+	legacyFile := filepath.Join(StatusDir(), repoName, wtName+".json")
+	os.WriteFile(legacyFile, []byte("{}"), 0o644)
+
+	RemoveStatusDir(repoName, wtName)
+
+	if _, err := os.Stat(sessDir); !os.IsNotExist(err) {
+		t.Error("session dir should be removed")
+	}
+	if _, err := os.Stat(legacyFile); !os.IsNotExist(err) {
+		t.Error("legacy file should be removed")
+	}
+}
+
+func TestStatusLabel(t *testing.T) {
+	tests := []struct {
+		status Status
+		want   string
+	}{
+		{StatusBusy, "BUSY"},
+		{StatusDone, "DONE"},
+		{StatusWait, "WAIT"},
+		{StatusIdle, "IDLE"},
+		{StatusOffline, "--"},
+	}
+	for _, tt := range tests {
+		got := StatusLabel(tt.status)
+		if got != tt.want {
+			t.Errorf("StatusLabel(%q) = %q, want %q", tt.status, got, tt.want)
+		}
+	}
+}

--- a/internal/claude/status_test.go
+++ b/internal/claude/status_test.go
@@ -234,6 +234,86 @@ func TestTimeSince(t *testing.T) {
 	if got := TimeSince(time.Now().Add(-5 * time.Minute)); got != "5m ago" {
 		t.Errorf("TimeSince(5m) = %q, want '5m ago'", got)
 	}
+
+	if got := TimeSince(time.Now().Add(-3 * time.Hour)); got != "3h ago" {
+		t.Errorf("TimeSince(3h) = %q, want '3h ago'", got)
+	}
+
+	if got := TimeSince(time.Now().Add(-48 * time.Hour)); got != "2d ago" {
+		t.Errorf("TimeSince(48h) = %q, want '2d ago'", got)
+	}
+}
+
+func TestEffectiveStatus_Fresh(t *testing.T) {
+	now := time.Now()
+	if got := EffectiveStatus(StatusBusy, now); got != StatusBusy {
+		t.Errorf("fresh BUSY = %q, want BUSY", got)
+	}
+	if got := EffectiveStatus(StatusDone, now); got != StatusDone {
+		t.Errorf("fresh DONE = %q, want DONE", got)
+	}
+	if got := EffectiveStatus(StatusWait, now); got != StatusWait {
+		t.Errorf("fresh WAIT = %q, want WAIT", got)
+	}
+	if got := EffectiveStatus(StatusIdle, now); got != StatusIdle {
+		t.Errorf("fresh IDLE = %q, want IDLE", got)
+	}
+}
+
+func TestEffectiveStatus_Stale(t *testing.T) {
+	stale := time.Now().Add(-5 * time.Minute)
+	if got := EffectiveStatus(StatusBusy, stale); got != StatusIdle {
+		t.Errorf("stale BUSY = %q, want IDLE", got)
+	}
+	if got := EffectiveStatus(StatusDone, stale); got != StatusIdle {
+		t.Errorf("stale DONE = %q, want IDLE", got)
+	}
+	if got := EffectiveStatus(StatusWait, stale); got != StatusIdle {
+		t.Errorf("stale WAIT = %q, want IDLE", got)
+	}
+	// IDLE stays IDLE regardless of staleness
+	if got := EffectiveStatus(StatusIdle, stale); got != StatusIdle {
+		t.Errorf("stale IDLE = %q, want IDLE", got)
+	}
+}
+
+func TestStatusPriority_Ordering(t *testing.T) {
+	if statusPriority(StatusBusy) >= statusPriority(StatusWait) {
+		t.Error("BUSY should have higher priority than WAIT")
+	}
+	if statusPriority(StatusWait) >= statusPriority(StatusDone) {
+		t.Error("WAIT should have higher priority than DONE")
+	}
+	if statusPriority(StatusDone) >= statusPriority(StatusIdle) {
+		t.Error("DONE should have higher priority than IDLE")
+	}
+	if statusPriority(StatusIdle) >= statusPriority(StatusOffline) {
+		t.Error("IDLE should have higher priority than OFFLINE")
+	}
+}
+
+func TestReadStatus_WaitAggregation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "wait-test"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	now := time.Now().UTC()
+	for _, ss := range []SessionStatus{
+		{Status: StatusWait, SessionID: "s1", Timestamp: now},
+		{Status: StatusDone, SessionID: "s2", Timestamp: now},
+	} {
+		data, _ := json.Marshal(ss)
+		os.WriteFile(filepath.Join(sessDir, ss.SessionID+".json"), data, 0o644)
+	}
+
+	got := ReadStatus(repoName, wtName)
+	if got.Status != StatusWait {
+		t.Errorf("aggregate Status = %q, want %q (WAIT should win over DONE)", got.Status, StatusWait)
+	}
 }
 
 func TestHookScript_NotEmpty(t *testing.T) {

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -551,3 +551,93 @@ func TestRm_ScopedToCurrentRepo(t *testing.T) {
 		t.Error("worktree should be removed")
 	}
 }
+
+func TestGc_EmptyTrash(t *testing.T) {
+	setupTestEnv(t)
+
+	if err := runApp("gc"); err != nil {
+		t.Fatalf("gc failed: %v", err)
+	}
+}
+
+func TestGc_CleansTrash(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "gcrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "gcrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+
+	if err := runApp("new", "gc-branch", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+	if err := runApp("rm", "gc-branch"); err != nil {
+		t.Fatalf("rm failed: %v", err)
+	}
+
+	if err := runApp("gc"); err != nil {
+		t.Fatalf("gc failed: %v", err)
+	}
+
+	trashDir := filepath.Join(home, ".willow", "trash")
+	trashEntries, err := os.ReadDir(trashDir)
+	if err == nil && len(trashEntries) > 0 {
+		t.Errorf("trash dir should be empty after gc, has %d entries", len(trashEntries))
+	}
+}
+
+func TestNew_WithRepoFlag(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "newrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	os.Chdir(home)
+
+	if err := runApp("new", "remote-branch", "-r", "newrepo", "--no-fetch"); err != nil {
+		t.Fatalf("new -r newrepo remote-branch failed: %v", err)
+	}
+
+	newWtDir := filepath.Join(home, ".willow", "worktrees", "newrepo", "remote-branch")
+	if _, err := os.Stat(newWtDir); os.IsNotExist(err) {
+		t.Errorf("worktree not created at %s", newWtDir)
+	}
+}
+
+func TestLs_PathOnly(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "pathrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "pathrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	os.Chdir(filepath.Join(worktreeDir, entries[0].Name()))
+
+	if err := runApp("ls", "--path-only"); err != nil {
+		t.Fatalf("ls --path-only failed: %v", err)
+	}
+}
+
+func TestLs_WithRepoArg(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "lsarg"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	os.Chdir(home)
+
+	if err := runApp("ls", "lsarg"); err != nil {
+		t.Fatalf("ls lsarg failed: %v", err)
+	}
+}

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatAge(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "now"},
+		{5 * time.Minute, "5m"},
+		{90 * time.Minute, "1h"},
+		{3 * time.Hour, "3h"},
+		{36 * time.Hour, "1d"},
+		{5 * 24 * time.Hour, "5d"},
+		{14 * 24 * time.Hour, "2w"},
+		{30 * 24 * time.Hour, "4w"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := formatAge(tt.d)
+			if got != tt.want {
+				t.Errorf("formatAge(%v) = %q, want %q", tt.d, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/worktree"
+)
+
+func TestCollectRepoStatus_NoSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	wts := []worktree.Worktree{
+		{Branch: "main", Path: "/wt/repo/main"},
+		{Branch: "feature", Path: "/wt/repo/feature"},
+	}
+
+	rs := collectRepoStatus("repo", wts)
+	if rs.WorktreeCount != 2 {
+		t.Errorf("WorktreeCount = %d, want 2", rs.WorktreeCount)
+	}
+	if rs.ActiveCount != 0 {
+		t.Errorf("ActiveCount = %d, want 0", rs.ActiveCount)
+	}
+	if rs.UnreadCount != 0 {
+		t.Errorf("UnreadCount = %d, want 0", rs.UnreadCount)
+	}
+	if len(rs.Entries) != 2 {
+		t.Errorf("Entries = %d, want 2", len(rs.Entries))
+	}
+	for _, e := range rs.Entries {
+		if e.Status != string(claude.StatusOffline) {
+			t.Errorf("Entry status = %q, want %q", e.Status, claude.StatusOffline)
+		}
+	}
+}
+
+func TestCollectRepoStatus_WithSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "feature"
+
+	// Create session files
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	now := time.Now().UTC()
+	sessions := []claude.SessionStatus{
+		{Status: claude.StatusBusy, SessionID: "s1", Timestamp: now},
+		{Status: claude.StatusDone, SessionID: "s2", Timestamp: now},
+	}
+	for _, ss := range sessions {
+		data, _ := json.Marshal(ss)
+		os.WriteFile(filepath.Join(sessDir, ss.SessionID+".json"), data, 0o644)
+	}
+
+	wts := []worktree.Worktree{
+		{Branch: "feature", Path: "/wt/myrepo/" + wtName},
+	}
+
+	rs := collectRepoStatus(repoName, wts)
+	if rs.ActiveCount != 2 {
+		t.Errorf("ActiveCount = %d, want 2", rs.ActiveCount)
+	}
+	if rs.UnreadCount != 1 {
+		t.Errorf("UnreadCount = %d, want 1 (DONE session is unread)", rs.UnreadCount)
+	}
+	if len(rs.Entries) != 2 {
+		t.Errorf("Entries = %d, want 2 (one per session)", len(rs.Entries))
+	}
+}
+
+func TestCollectRepoStatus_RepoNameSet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	wts := []worktree.Worktree{
+		{Branch: "main", Path: "/wt/myrepo/main"},
+	}
+
+	rs := collectRepoStatus("myrepo", wts)
+	if rs.Name != "myrepo" {
+		t.Errorf("Name = %q, want %q", rs.Name, "myrepo")
+	}
+	if len(rs.Entries) != 1 {
+		t.Fatalf("Entries = %d, want 1", len(rs.Entries))
+	}
+	if rs.Entries[0].Repo != "myrepo" {
+		t.Errorf("Entry.Repo = %q, want %q", rs.Entries[0].Repo, "myrepo")
+	}
+	if rs.Entries[0].Branch != "main" {
+		t.Errorf("Entry.Branch = %q, want %q", rs.Entries[0].Branch, "main")
+	}
+}
+
+func TestCollectRepoStatus_UnreadMarking(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "done-wt"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	// Use a past timestamp so MarkRead (which writes "now") is strictly after it
+	past := time.Now().UTC().Add(-5 * time.Second)
+	ss := claude.SessionStatus{Status: claude.StatusDone, SessionID: "s1", Timestamp: past}
+	data, _ := json.Marshal(ss)
+	os.WriteFile(filepath.Join(sessDir, "s1.json"), data, 0o644)
+
+	wts := []worktree.Worktree{
+		{Branch: "done-branch", Path: "/wt/myrepo/" + wtName},
+	}
+
+	rs := collectRepoStatus(repoName, wts)
+	if len(rs.Entries) != 1 {
+		t.Fatalf("Entries = %d, want 1", len(rs.Entries))
+	}
+	if !rs.Entries[0].Unread {
+		t.Error("DONE session should be marked unread")
+	}
+
+	// Mark as read, then re-collect
+	claude.MarkRead(repoName, wtName)
+	rs = collectRepoStatus(repoName, wts)
+	if rs.Entries[0].Unread {
+		t.Error("DONE session should not be unread after MarkRead")
+	}
+	if rs.UnreadCount != 0 {
+		t.Errorf("UnreadCount = %d, want 0 after MarkRead", rs.UnreadCount)
+	}
+}
+
+func TestCollectRepoStatus_EmptyWorktrees(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rs := collectRepoStatus("empty", nil)
+	if rs.WorktreeCount != 0 {
+		t.Errorf("WorktreeCount = %d, want 0", rs.WorktreeCount)
+	}
+	if len(rs.Entries) != 0 {
+		t.Errorf("Entries = %d, want 0", len(rs.Entries))
+	}
+}

--- a/internal/cli/sw_test.go
+++ b/internal/cli/sw_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/worktree"
+)
+
+func TestExtractPathFromLine(t *testing.T) {
+	tests := []struct {
+		line string
+		want string
+	}{
+		{"🤖 BUSY  main  /home/user/.willow/worktrees/repo/main", "/home/user/.willow/worktrees/repo/main"},
+		{"✅ DONE  feature/auth  /wt/repo/feature-auth", "/wt/repo/feature-auth"},
+		{"🟡 IDLE  repo/branch  /some/path", "/some/path"},
+		{"", ""},
+		{"single-field", "single-field"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := extractPathFromLine(tt.line)
+			if got != tt.want {
+				t.Errorf("extractPathFromLine(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusOrder(t *testing.T) {
+	tests := []struct {
+		status claude.Status
+		want   int
+	}{
+		{claude.StatusBusy, 0},
+		{claude.StatusWait, 1},
+		{claude.StatusDone, 2},
+		{claude.StatusIdle, 3},
+		{claude.StatusOffline, 4},
+		{claude.Status("UNKNOWN"), 4},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			got := statusOrder(tt.status)
+			if got != tt.want {
+				t.Errorf("statusOrder(%q) = %d, want %d", tt.status, got, tt.want)
+			}
+		})
+	}
+
+	// Verify ordering: BUSY < WAIT < DONE < IDLE < OFFLINE
+	if statusOrder(claude.StatusBusy) >= statusOrder(claude.StatusWait) {
+		t.Error("BUSY should sort before WAIT")
+	}
+	if statusOrder(claude.StatusWait) >= statusOrder(claude.StatusDone) {
+		t.Error("WAIT should sort before DONE")
+	}
+	if statusOrder(claude.StatusDone) >= statusOrder(claude.StatusIdle) {
+		t.Error("DONE should sort before IDLE")
+	}
+}
+
+func TestBuildWorktreeLines(t *testing.T) {
+	// Use a temp HOME so claude.ReadStatus returns offline for all
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	wts := []worktree.Worktree{
+		{Branch: "main", Path: "/wt/repo/main"},
+		{Branch: "feature/auth", Path: "/wt/repo/feature-auth"},
+	}
+
+	lines := buildWorktreeLines(wts, "repo")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+	for _, line := range lines {
+		// Each line should contain a path
+		if !strings.Contains(line, "/wt/repo/") {
+			t.Errorf("line should contain path, got %q", line)
+		}
+	}
+}
+
+func TestBuildCrossRepoWorktreeLines(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rwts := []repoWorktree{
+		{
+			Repo:     repoInfo{Name: "alpha", BareDir: "/repos/alpha.git"},
+			Worktree: worktree.Worktree{Branch: "main", Path: "/wt/alpha/main"},
+		},
+		{
+			Repo:     repoInfo{Name: "beta", BareDir: "/repos/beta.git"},
+			Worktree: worktree.Worktree{Branch: "feature", Path: "/wt/beta/feature"},
+		},
+	}
+
+	lines := buildCrossRepoWorktreeLines(rwts)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(lines))
+	}
+
+	// Lines should contain repo/branch format
+	foundAlpha := false
+	foundBeta := false
+	for _, line := range lines {
+		if strings.Contains(line, "alpha/main") {
+			foundAlpha = true
+		}
+		if strings.Contains(line, "beta/feature") {
+			foundBeta = true
+		}
+		// Path should be the last field
+		path := extractPathFromLine(line)
+		if !strings.HasPrefix(path, "/wt/") {
+			t.Errorf("expected path to start with /wt/, got %q", path)
+		}
+	}
+	if !foundAlpha {
+		t.Error("expected alpha/main in lines")
+	}
+	if !foundBeta {
+		t.Error("expected beta/feature in lines")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -251,3 +251,243 @@ func TestLoad_EmptyBareDir(t *testing.T) {
 		t.Error("Defaults.Fetch should be true")
 	}
 }
+
+func TestWillowHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := WillowHome()
+	want := filepath.Join(home, ".willow")
+	if got != want {
+		t.Errorf("WillowHome() = %q, want %q", got, want)
+	}
+}
+
+func TestReposDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := ReposDir()
+	want := filepath.Join(home, ".willow", "repos")
+	if got != want {
+		t.Errorf("ReposDir() = %q, want %q", got, want)
+	}
+}
+
+func TestWorktreesDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := WorktreesDir()
+	want := filepath.Join(home, ".willow", "worktrees")
+	if got != want {
+		t.Errorf("WorktreesDir() = %q, want %q", got, want)
+	}
+}
+
+func TestTrashDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got := TrashDir()
+	want := filepath.Join(home, ".willow", "trash")
+	if got != want {
+		t.Errorf("TrashDir() = %q, want %q", got, want)
+	}
+}
+
+func TestListRepos_Empty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repos, err := ListRepos()
+	if err != nil {
+		t.Fatalf("ListRepos() error: %v", err)
+	}
+	if len(repos) != 0 {
+		t.Errorf("expected 0 repos, got %d", len(repos))
+	}
+}
+
+func TestListRepos_WithRepos(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	reposDir := filepath.Join(home, ".willow", "repos")
+	os.MkdirAll(filepath.Join(reposDir, "alpha.git"), 0o755)
+	os.MkdirAll(filepath.Join(reposDir, "beta.git"), 0o755)
+	// Non-.git dir should be ignored
+	os.MkdirAll(filepath.Join(reposDir, "notarepo"), 0o755)
+
+	repos, err := ListRepos()
+	if err != nil {
+		t.Fatalf("ListRepos() error: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	names := map[string]bool{}
+	for _, r := range repos {
+		names[r] = true
+	}
+	if !names["alpha"] || !names["beta"] {
+		t.Errorf("expected alpha and beta, got %v", names)
+	}
+}
+
+func TestResolveRepo_Found(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoDir := filepath.Join(home, ".willow", "repos", "myrepo.git")
+	os.MkdirAll(repoDir, 0o755)
+
+	got, err := ResolveRepo("myrepo")
+	if err != nil {
+		t.Fatalf("ResolveRepo error: %v", err)
+	}
+	if got != repoDir {
+		t.Errorf("ResolveRepo = %q, want %q", got, repoDir)
+	}
+}
+
+func TestResolveRepo_NotFound(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, err := ResolveRepo("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent repo")
+	}
+}
+
+func TestIsWillowRepo(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	reposDir := filepath.Join(home, ".willow", "repos")
+	repoDir := filepath.Join(reposDir, "myrepo.git")
+	os.MkdirAll(repoDir, 0o755)
+
+	if !IsWillowRepo(repoDir) {
+		t.Error("path under repos dir should be a willow repo")
+	}
+	if IsWillowRepo("/some/other/path") {
+		t.Error("arbitrary path should not be a willow repo")
+	}
+}
+
+func TestResolveRepoFromDir_InsideWorktree(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoDir := filepath.Join(home, ".willow", "repos", "myrepo.git")
+	os.MkdirAll(repoDir, 0o755)
+
+	wtDir := filepath.Join(home, ".willow", "worktrees", "myrepo", "feature-auth")
+	os.MkdirAll(wtDir, 0o755)
+
+	got, ok := ResolveRepoFromDir(wtDir)
+	if !ok {
+		t.Fatal("expected ok=true for path inside worktrees")
+	}
+	if got != repoDir {
+		t.Errorf("ResolveRepoFromDir = %q, want %q", got, repoDir)
+	}
+}
+
+func TestResolveRepoFromDir_OutsideWorktrees(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	os.MkdirAll(filepath.Join(home, ".willow", "worktrees"), 0o755)
+
+	_, ok := ResolveRepoFromDir(home)
+	if ok {
+		t.Error("expected ok=false for path outside worktrees")
+	}
+}
+
+func TestResolveRepoFromDir_WorktreesRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	os.MkdirAll(filepath.Join(home, ".willow", "worktrees"), 0o755)
+
+	_, ok := ResolveRepoFromDir(filepath.Join(home, ".willow", "worktrees"))
+	if ok {
+		t.Error("worktrees root itself should return false")
+	}
+}
+
+func TestMerge_TmuxConfig(t *testing.T) {
+	base := DefaultConfig()
+	overlay := &Config{
+		Tmux: TmuxConfig{
+			ReloadInterval: 5,
+			Notification:   BoolPtr(true),
+			NotifyCommand:  "say done",
+			Layout: []WindowSpec{
+				{Name: "editor", Panes: 2},
+			},
+		},
+	}
+
+	merge(base, overlay)
+
+	if base.Tmux.ReloadInterval != 5 {
+		t.Errorf("ReloadInterval = %d, want 5", base.Tmux.ReloadInterval)
+	}
+	if base.Tmux.Notification == nil || !*base.Tmux.Notification {
+		t.Error("Notification should be true")
+	}
+	if base.Tmux.NotifyCommand != "say done" {
+		t.Errorf("NotifyCommand = %q, want %q", base.Tmux.NotifyCommand, "say done")
+	}
+	if len(base.Tmux.Layout) != 1 || base.Tmux.Layout[0].Name != "editor" {
+		t.Errorf("Layout = %v, want [{editor 2 }]", base.Tmux.Layout)
+	}
+}
+
+func TestMerge_TmuxConfigPartial(t *testing.T) {
+	base := &Config{
+		Tmux: TmuxConfig{
+			ReloadInterval: 3,
+			NotifyCommand:  "original",
+		},
+	}
+	overlay := &Config{
+		Tmux: TmuxConfig{
+			NotifyCommand: "updated",
+		},
+	}
+
+	merge(base, overlay)
+
+	if base.Tmux.ReloadInterval != 3 {
+		t.Errorf("ReloadInterval = %d, want 3 (unchanged)", base.Tmux.ReloadInterval)
+	}
+	if base.Tmux.NotifyCommand != "updated" {
+		t.Errorf("NotifyCommand = %q, want %q", base.Tmux.NotifyCommand, "updated")
+	}
+}
+
+func TestMerge_PostCheckoutHook(t *testing.T) {
+	base := &Config{}
+	overlay := &Config{PostCheckoutHook: ".hooks/post-checkout"}
+
+	merge(base, overlay)
+
+	if base.PostCheckoutHook != ".hooks/post-checkout" {
+		t.Errorf("PostCheckoutHook = %q, want %q", base.PostCheckoutHook, ".hooks/post-checkout")
+	}
+}
+
+func TestMerge_TeardownHooks(t *testing.T) {
+	base := &Config{Teardown: []string{"cleanup.sh"}}
+	overlay := &Config{Teardown: []string{"new-cleanup.sh"}}
+
+	merge(base, overlay)
+
+	if len(base.Teardown) != 1 || base.Teardown[0] != "new-cleanup.sh" {
+		t.Errorf("Teardown = %v, want [new-cleanup.sh]", base.Teardown)
+	}
+}

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -1,0 +1,71 @@
+package trace
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNew_Disabled(t *testing.T) {
+	tr := New(false)
+	if tr.enabled {
+		t.Error("tracer should be disabled")
+	}
+}
+
+func TestNew_Enabled(t *testing.T) {
+	tr := New(true)
+	if !tr.enabled {
+		t.Error("tracer should be enabled")
+	}
+}
+
+func TestStart_DisabledReturnsNoop(t *testing.T) {
+	tr := New(false)
+	done := tr.Start("test step")
+	done() // should not panic
+	if len(tr.steps) != 0 {
+		t.Errorf("expected 0 steps when disabled, got %d", len(tr.steps))
+	}
+}
+
+func TestStart_EnabledRecordsStep(t *testing.T) {
+	tr := New(true)
+	done := tr.Start("test step")
+	time.Sleep(1 * time.Millisecond)
+	done()
+	if len(tr.steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(tr.steps))
+	}
+	if tr.steps[0].label != "test step" {
+		t.Errorf("label = %q, want %q", tr.steps[0].label, "test step")
+	}
+	if tr.steps[0].duration == 0 {
+		t.Error("duration should be > 0")
+	}
+}
+
+func TestTotal_DisabledNoOp(t *testing.T) {
+	tr := New(false)
+	tr.Total() // should not panic
+}
+
+func TestFormatDuration_Microseconds(t *testing.T) {
+	got := formatDuration(500 * time.Microsecond)
+	if got != "500µs" {
+		t.Errorf("formatDuration(500µs) = %q, want %q", got, "500µs")
+	}
+}
+
+func TestFormatDuration_Milliseconds(t *testing.T) {
+	got := formatDuration(15 * time.Millisecond)
+	if got != "15.0ms" {
+		t.Errorf("formatDuration(15ms) = %q, want %q", got, "15.0ms")
+	}
+}
+
+func TestFormatDuration_Seconds(t *testing.T) {
+	got := formatDuration(2500 * time.Millisecond)
+	if got != "2.50s" {
+		t.Errorf("formatDuration(2.5s) = %q, want %q", got, "2.50s")
+	}
+}

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,0 +1,82 @@
+package ui
+
+import "testing"
+
+func TestBold(t *testing.T) {
+	u := &UI{}
+	got := u.Bold("hello")
+	want := bold + "hello" + reset
+	if got != want {
+		t.Errorf("Bold() = %q, want %q", got, want)
+	}
+}
+
+func TestGreen(t *testing.T) {
+	u := &UI{}
+	got := u.Green("ok")
+	want := green + "ok" + reset
+	if got != want {
+		t.Errorf("Green() = %q, want %q", got, want)
+	}
+}
+
+func TestYellow(t *testing.T) {
+	u := &UI{}
+	got := u.Yellow("warn")
+	want := yellow + "warn" + reset
+	if got != want {
+		t.Errorf("Yellow() = %q, want %q", got, want)
+	}
+}
+
+func TestRed(t *testing.T) {
+	u := &UI{}
+	got := u.Red("err")
+	want := red + "err" + reset
+	if got != want {
+		t.Errorf("Red() = %q, want %q", got, want)
+	}
+}
+
+func TestCyan(t *testing.T) {
+	u := &UI{}
+	got := u.Cyan("info")
+	want := cyan + "info" + reset
+	if got != want {
+		t.Errorf("Cyan() = %q, want %q", got, want)
+	}
+}
+
+func TestDim(t *testing.T) {
+	u := &UI{}
+	got := u.Dim("faded")
+	want := dim + "faded" + reset
+	if got != want {
+		t.Errorf("Dim() = %q, want %q", got, want)
+	}
+}
+
+func TestTerminalControlSequences(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func() string
+	}{
+		{"CursorHome", CursorHome},
+		{"ClearToEnd", ClearToEnd},
+		{"HideCursor", HideCursor},
+		{"ShowCursor", ShowCursor},
+		{"AltScreenOn", AltScreenOn},
+		{"AltScreenOff", AltScreenOff},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn()
+			if got == "" {
+				t.Errorf("%s() returned empty string", tt.name)
+			}
+			if got[0] != '\033' {
+				t.Errorf("%s() should start with ESC", tt.name)
+			}
+		})
+	}
+}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,0 +1,95 @@
+package worktree
+
+import "testing"
+
+func TestParsePorcelain_SingleWorktree(t *testing.T) {
+	input := `worktree /home/user/.willow/repos/myrepo.git
+HEAD abc123
+bare
+`
+	wts := parsePorcelain(input)
+	if len(wts) != 1 {
+		t.Fatalf("expected 1 worktree, got %d", len(wts))
+	}
+	if wts[0].Path != "/home/user/.willow/repos/myrepo.git" {
+		t.Errorf("Path = %q", wts[0].Path)
+	}
+	if wts[0].Head != "abc123" {
+		t.Errorf("Head = %q", wts[0].Head)
+	}
+	if !wts[0].IsBare {
+		t.Error("IsBare should be true")
+	}
+	if wts[0].Branch != "" {
+		t.Errorf("Branch = %q, want empty for bare", wts[0].Branch)
+	}
+}
+
+func TestParsePorcelain_MultipleWorktrees(t *testing.T) {
+	input := `worktree /repos/myrepo.git
+HEAD aaa111
+bare
+
+worktree /wt/myrepo/main
+HEAD bbb222
+branch refs/heads/main
+
+worktree /wt/myrepo/feature-auth
+HEAD ccc333
+branch refs/heads/feature/auth
+`
+	wts := parsePorcelain(input)
+	if len(wts) != 3 {
+		t.Fatalf("expected 3 worktrees, got %d", len(wts))
+	}
+
+	// Bare repo
+	if !wts[0].IsBare {
+		t.Error("wt[0] should be bare")
+	}
+
+	// Main worktree
+	if wts[1].Branch != "main" {
+		t.Errorf("wt[1].Branch = %q, want %q", wts[1].Branch, "main")
+	}
+	if wts[1].Path != "/wt/myrepo/main" {
+		t.Errorf("wt[1].Path = %q", wts[1].Path)
+	}
+
+	// Feature worktree
+	if wts[2].Branch != "feature/auth" {
+		t.Errorf("wt[2].Branch = %q, want %q", wts[2].Branch, "feature/auth")
+	}
+}
+
+func TestParsePorcelain_DetachedHead(t *testing.T) {
+	input := `worktree /wt/myrepo/detached
+HEAD ddd444
+detached
+`
+	wts := parsePorcelain(input)
+	if len(wts) != 1 {
+		t.Fatalf("expected 1 worktree, got %d", len(wts))
+	}
+	if wts[0].Branch != "(detached)" {
+		t.Errorf("Branch = %q, want %q", wts[0].Branch, "(detached)")
+	}
+}
+
+func TestParsePorcelain_EmptyInput(t *testing.T) {
+	wts := parsePorcelain("")
+	if len(wts) != 0 {
+		t.Errorf("expected 0 worktrees, got %d", len(wts))
+	}
+}
+
+func TestParsePorcelain_MissingPath(t *testing.T) {
+	// A block with no "worktree " line should be skipped
+	input := `HEAD abc123
+branch refs/heads/main
+`
+	wts := parsePorcelain(input)
+	if len(wts) != 0 {
+		t.Errorf("expected 0 worktrees for block without path, got %d", len(wts))
+	}
+}


### PR DESCRIPTION
## Description of the change

Add comprehensive test coverage for previously untested packages and functions.

**New test files:** `worktree_test.go`, `trace_test.go`, `ui_test.go`, `hook_test.go`, `sw_test.go`, `ls_test.go`, `status_test.go`

**Coverage improvements:**
| Package | Before | After |
|---------|--------|-------|
| `claude` | 49% | **90%** |
| `config` | 40% | **90%** |
| `trace` | 0% | **88%** |
| `ui` | 0% | **75%** |
| `worktree` | 0% | **77%** |
| `cli` | 40% | **47%** |

## Test plan

`go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)