### PR TITLE
🔧 chore: upgrade Go to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,14 +1,16 @@
 module github.com/iamrajjoshi/willow
 
-go 1.25.0
+go 1.26.0
 
-require github.com/urfave/cli/v3 v3.6.2
+require (
+	github.com/junegunn/fzf v0.70.0
+	github.com/urfave/cli/v3 v3.6.2
+)
 
 require (
 	github.com/charlievieth/fastwalk v1.0.14 // indirect
 	github.com/gdamore/encoding v1.0.1 // indirect
 	github.com/gdamore/tcell/v2 v2.9.0 // indirect
-	github.com/junegunn/fzf v0.70.0 // indirect
 	github.com/junegunn/go-shellwords v0.0.0-20250127100254-2aa3b3277741 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect


### PR DESCRIPTION
## Description of the change

Upgrade Go from 1.25.0 to 1.26.0 in go.mod. CI workflows use `go-version-file: go.mod` so they'll pick it up automatically.

## Test plan

- `go build ./...` passes
- `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)