### PR TITLE
✨ feat(tmux): pane init commands and raw layout syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,10 @@ Config merges two tiers (local wins):
   "defaults": {
     "fetch": true,
     "autoSetupRemote": true
+  },
+  "tmux": {
+    "layout": ["split-window -h", "select-layout even-horizontal"],
+    "postWorktreeCreate": ["cd website"]
   }
 }
 ```

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -159,7 +159,7 @@ func tmuxSwCmd() *cli.Command {
 			sessName := tmux.SessionNameForWorktree(repoName, wtDir)
 			if !tmux.SessionExists(sessName) {
 				cfg := loadRepoConfig(repoName)
-				if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout); err != nil {
+				if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
 					return fmt.Errorf("failed to create session: %w", err)
 				}
 			}
@@ -180,7 +180,7 @@ func tmuxPickSwitch(selection string, items []tmux.PickerItem) error {
 	sessName := tmux.SessionNameForWorktree(item.RepoName, item.WtDirName)
 	if !tmux.SessionExists(sessName) {
 		cfg := loadRepoConfig(item.RepoName)
-		if err := tmux.NewSession(sessName, item.WtPath, cfg.Tmux.Layout); err != nil {
+		if err := tmux.NewSession(sessName, item.WtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
 			return fmt.Errorf("failed to create session: %w", err)
 		}
 	}
@@ -220,7 +220,7 @@ func tmuxPickNew(self, query, repoFilter string, items []tmux.PickerItem) error 
 	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
 	if !tmux.SessionExists(sessName) {
 		cfg := loadRepoConfig(repoName)
-		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout); err != nil {
+		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
 			return fmt.Errorf("failed to create session: %w", err)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,20 +20,13 @@ type Config struct {
 }
 
 type TmuxConfig struct {
-	ReloadInterval   int          `json:"reloadInterval,omitempty"`
-	Notification     *bool        `json:"notification,omitempty"`
-	NotifyCommand    string       `json:"notifyCommand,omitempty"`
-	NotifyWaitCommand string      `json:"notifyWaitCommand,omitempty"`
-	SwitcherPreview  *bool        `json:"switcherPreview,omitempty"`
-	Layout           []WindowSpec `json:"layout,omitempty"`
-}
-
-// WindowSpec defines a tmux window to create when starting a new session.
-// If no layout is configured, a single default window is created.
-type WindowSpec struct {
-	Name   string `json:"name"`
-	Panes  int    `json:"panes,omitempty"`
-	Layout string `json:"layout,omitempty"` // tmux layout: even-horizontal, even-vertical, main-horizontal, main-vertical, tiled
+	ReloadInterval    int          `json:"reloadInterval,omitempty"`
+	Notification      *bool        `json:"notification,omitempty"`
+	NotifyCommand     string       `json:"notifyCommand,omitempty"`
+	NotifyWaitCommand string       `json:"notifyWaitCommand,omitempty"`
+	SwitcherPreview   *bool        `json:"switcherPreview,omitempty"`
+	Layout             []string `json:"layout,omitempty"`
+	PostWorktreeCreate []string `json:"postWorktreeCreate,omitempty"`
 }
 
 type Defaults struct {
@@ -224,6 +217,9 @@ func merge(base, overlay *Config) {
 	}
 	if overlay.Tmux.Layout != nil {
 		base.Tmux.Layout = overlay.Tmux.Layout
+	}
+	if overlay.Tmux.PostWorktreeCreate != nil {
+		base.Tmux.PostWorktreeCreate = overlay.Tmux.PostWorktreeCreate
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -425,8 +425,9 @@ func TestMerge_TmuxConfig(t *testing.T) {
 			ReloadInterval: 5,
 			Notification:   BoolPtr(true),
 			NotifyCommand:  "say done",
-			Layout: []WindowSpec{
-				{Name: "editor", Panes: 2},
+			Layout: []string{
+				"split-window -h",
+				"select-layout even-horizontal",
 			},
 		},
 	}
@@ -442,8 +443,8 @@ func TestMerge_TmuxConfig(t *testing.T) {
 	if base.Tmux.NotifyCommand != "say done" {
 		t.Errorf("NotifyCommand = %q, want %q", base.Tmux.NotifyCommand, "say done")
 	}
-	if len(base.Tmux.Layout) != 1 || base.Tmux.Layout[0].Name != "editor" {
-		t.Errorf("Layout = %v, want [{editor 2 }]", base.Tmux.Layout)
+	if len(base.Tmux.Layout) != 2 || base.Tmux.Layout[0] != "split-window -h" {
+		t.Errorf("Layout = %v, want [split-window -h, select-layout even-horizontal]", base.Tmux.Layout)
 	}
 }
 
@@ -522,6 +523,28 @@ func TestMerge_NotifyWaitCommand(t *testing.T) {
 
 	if base.Tmux.NotifyWaitCommand != "updated" {
 		t.Errorf("NotifyWaitCommand = %q, want %q", base.Tmux.NotifyWaitCommand, "updated")
+	}
+}
+
+func TestMerge_PostWorktreeCreate(t *testing.T) {
+	base := &Config{Tmux: TmuxConfig{PostWorktreeCreate: []string{"cd old"}}}
+	overlay := &Config{Tmux: TmuxConfig{PostWorktreeCreate: []string{"cd website", "nvm use"}}}
+
+	merge(base, overlay)
+
+	if len(base.Tmux.PostWorktreeCreate) != 2 || base.Tmux.PostWorktreeCreate[0] != "cd website" {
+		t.Errorf("PostWorktreeCreate = %v, want [cd website, nvm use]", base.Tmux.PostWorktreeCreate)
+	}
+}
+
+func TestMerge_PostWorktreeCreate_NilDoesNotOverride(t *testing.T) {
+	base := &Config{Tmux: TmuxConfig{PostWorktreeCreate: []string{"cd website"}}}
+	overlay := &Config{}
+
+	merge(base, overlay)
+
+	if len(base.Tmux.PostWorktreeCreate) != 1 || base.Tmux.PostWorktreeCreate[0] != "cd website" {
+		t.Errorf("PostWorktreeCreate = %v, want [cd website]", base.Tmux.PostWorktreeCreate)
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/iamrajjoshi/willow/internal/config"
 )
 
 func InTmux() bool {
@@ -26,56 +24,69 @@ func SessionExists(name string) bool {
 	return err == nil
 }
 
-// NewSession creates a tmux session with windows/panes based on config layout.
-// If no layout is configured, a single default window is created.
-func NewSession(name, dir string, layout []config.WindowSpec) error {
-	if len(layout) == 0 {
-		_, err := run("new-session", "-d", "-s", name, "-c", dir)
+func SendKeys(target string, keys ...string) error {
+	args := append([]string{"send-keys", "-t", target}, keys...)
+	_, err := run(args...)
+	return err
+}
+
+// NewSession creates a tmux session and applies layout commands.
+// Layout entries are raw tmux subcommands (e.g. "split-window -h").
+// The session target (-t) and working directory (-c) are auto-injected.
+// After layout setup, postWorktreeCreate commands are sent to every pane.
+func NewSession(name, dir string, layout []string, postWorktreeCreate []string) error {
+	if _, err := run("new-session", "-d", "-s", name, "-c", dir); err != nil {
 		return err
 	}
 
-	// Create session with first window
-	firstWin := layout[0]
-	winName := firstWin.Name
-	if winName == "" {
-		winName = "main"
-	}
-	if _, err := run("new-session", "-d", "-s", name, "-n", winName, "-c", dir); err != nil {
-		return err
+	for _, cmd := range layout {
+		args := prepareLayoutCmd(strings.Fields(cmd), name, dir)
+		run(args...)
 	}
 
-	// Add panes to first window
-	createPanes(name, winName, dir, firstWin)
-
-	// Create additional windows
-	for _, spec := range layout[1:] {
-		wName := spec.Name
-		if wName == "" {
-			wName = "window"
+	for _, paneID := range listSessionPanes(name) {
+		for _, cmd := range postWorktreeCreate {
+			SendKeys(paneID, cmd, "Enter")
 		}
-		if _, err := run("new-window", "-t", name, "-n", wName, "-c", dir); err != nil {
-			continue
-		}
-		createPanes(name, wName, dir, spec)
 	}
 
-	// Select first window
-	run("select-window", "-t", name+":"+layout[0].Name)
 	return nil
 }
 
-func createPanes(session, window, dir string, spec config.WindowSpec) {
-	target := session + ":" + window
-	panes := spec.Panes
-	if panes <= 1 {
-		return
+func prepareLayoutCmd(args []string, session, dir string) []string {
+	if len(args) == 0 {
+		return args
 	}
-	for i := 1; i < panes; i++ {
-		run("split-window", "-t", target, "-c", dir)
+
+	subcmd := args[0]
+	rest := args[1:]
+
+	hasFlag := func(flag string) bool {
+		for _, a := range rest {
+			if a == flag {
+				return true
+			}
+		}
+		return false
 	}
-	if spec.Layout != "" {
-		run("select-layout", "-t", target, spec.Layout)
+
+	if !hasFlag("-t") {
+		rest = append([]string{"-t", session}, rest...)
 	}
+
+	if (subcmd == "split-window" || subcmd == "new-window") && !hasFlag("-c") {
+		rest = append(rest, "-c", dir)
+	}
+
+	return append([]string{subcmd}, rest...)
+}
+
+func listSessionPanes(session string) []string {
+	out, err := run("list-panes", "-t", session, "-s", "-F", "#{pane_id}")
+	if err != nil || out == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
 }
 
 func KillSession(name string) error {

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -48,7 +48,8 @@ The local config lives inside the bare repo directory, so it's private to your m
 | `defaults.autoSetupRemote` | `boolean` | Auto-configure remote tracking for new branches |
 | `tmux.notification` | `boolean` | Play sound on BUSY→DONE transitions (default: `true`) |
 | `tmux.notifyCommand` | `string` | Command to run for notifications (default: `afplay Glass.aiff`) |
-| `tmux.layout` | `WindowSpec[]` | Tmux window/pane layout for new sessions (see [Tmux Integration](/tmux/)) |
+| `tmux.layout` | `string[]` | Raw tmux subcommands to run after session creation (e.g. `["split-window -h", "select-layout even-horizontal"]`) |
+| `tmux.postWorktreeCreate` | `string[]` | Commands sent to every pane after session setup (e.g. `["cd website"]`) |
 
 ## Directory structure
 

--- a/website/docs/tmux/index.md
+++ b/website/docs/tmux/index.md
@@ -69,21 +69,38 @@ Set `"notification": false` to disable sound.
 
 ## Session layout
 
-By default, `willow tmux` creates a single window with one pane for each worktree session. You can customize this with the `tmux.layout` config field:
+By default, `willow tmux` creates a single window with one pane for each worktree session. You can customize this with `tmux.layout` — a list of raw tmux subcommands that run after session creation. The `-t` (target session) and `-c` (working directory) flags are auto-injected when not present.
 
 ```jsonc
 {
   "tmux": {
     "layout": [
-      { "name": "claude", "panes": 1 },
-      { "name": "dev", "panes": 4, "layout": "tiled" },
-      { "name": "scratch", "panes": 1 }
+      "split-window -h",
+      "select-layout even-horizontal"
     ]
   }
 }
 ```
 
-Each entry creates a tmux window. The `layout` field accepts any tmux layout: `even-horizontal`, `even-vertical`, `main-horizontal`, `main-vertical`, `tiled`.
+Any tmux subcommand works: `split-window`, `new-window`, `select-layout`, `resize-pane`, etc.
+
+### Pane init commands
+
+Use `tmux.postWorktreeCreate` to send shell commands to every pane after the layout is set up. These run once when a session is first created.
+
+```jsonc
+{
+  "tmux": {
+    "layout": [
+      "split-window -h",
+      "select-layout even-horizontal"
+    ],
+    "postWorktreeCreate": ["cd website"]
+  }
+}
+```
+
+This creates two side-by-side panes, each starting in the `website/` subdirectory.
 
 ## Shell integration
 


### PR DESCRIPTION
## Description of the change

- Replace bespoke `WindowSpec` struct with raw tmux subcommands for `tmux.layout` — write commands you already know (`split-window -h`, `select-layout even-horizontal`) instead of learning a custom schema
- Add `tmux.postWorktreeCreate` — shell commands sent to every pane after session creation (e.g. `cd website`)
- Auto-inject `-t` (session target) and `-c` (working directory) flags into layout commands for convenience
- Use `list-panes` with pane IDs for robust targeting regardless of `pane-base-index` or session naming

## Test plan

- Unit tests for config merge (slice override + nil preservation)
- `go test ./... -count=1 -v` all passing
- Manual: verified split + `cd website` works via `ww tmux pick`

🤖 Generated with [Claude Code](https://claude.com/claude-code)