### PR TITLE
🎨 style(website): revamp to modern minimalism design

### DIFF
--- a/website/docs/.vitepress/config.mts
+++ b/website/docs/.vitepress/config.mts
@@ -12,7 +12,7 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', href: '/favicon.svg', type: 'image/svg+xml' }],
-    ['meta', { name: 'theme-color', content: '#131318' }],
+    ['meta', { name: 'theme-color', content: '#0a0a0f' }],
     ['meta', { property: 'og:title', content: 'willow — Git worktree manager for AI agents' }],
     ['meta', { property: 'og:description', content: 'Spin up isolated worktrees for Claude Code sessions. Switch between them instantly with fzf. See which agents are busy, waiting, or idle.' }],
     ['meta', { property: 'og:type', content: 'website' }],
@@ -57,8 +57,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: `MIT | Built by <a href="https://github.com/iamrajjoshi" target="_blank">@iamrajjoshi</a>`,
-      copyright: `<a href="https://github.com/iamrajjoshi/willow/commit/${commitHash}" target="_blank">${commitHash}</a>`,
+      message: `<a href="https://github.com/iamrajjoshi/willow/blob/main/LICENSE" target="_blank">MIT</a> · <a href="https://github.com/iamrajjoshi" target="_blank">@iamrajjoshi</a> · <a href="https://github.com/iamrajjoshi/willow/commit/${commitHash}" target="_blank">${commitHash}</a>`,
     },
   },
 })

--- a/website/docs/.vitepress/theme/components/AnimatedBackground.vue
+++ b/website/docs/.vitepress/theme/components/AnimatedBackground.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="bg-canvas" aria-hidden="true">
-    <div class="bg-orb orb-cyan"></div>
-    <div class="bg-orb orb-magenta"></div>
-    <div class="bg-orb orb-blue"></div>
-    <div class="bg-orb orb-green"></div>
-    <div class="bg-orb orb-yellow"></div>
+    <div class="bg-gradient"></div>
     <div class="bg-noise"></div>
   </div>
 </template>
@@ -18,107 +14,18 @@
   pointer-events: none;
 }
 
-.bg-orb {
+.bg-gradient {
   position: absolute;
-  border-radius: 50%;
-  filter: blur(100px);
-  will-change: transform;
+  inset: 0;
+  background: radial-gradient(ellipse 80% 50% at 50% -20%, rgba(94, 234, 212, 0.04), transparent);
 }
 
-.orb-cyan {
-  width: 600px;
-  height: 600px;
-  background: rgba(139, 233, 253, 0.07);
-  top: -10%;
-  left: 15%;
-  animation: drift-1 25s ease-in-out infinite;
-}
-
-.orb-magenta {
-  width: 500px;
-  height: 500px;
-  background: rgba(252, 76, 180, 0.06);
-  top: 10%;
-  right: -5%;
-  animation: drift-2 30s ease-in-out infinite;
-}
-
-.orb-blue {
-  width: 700px;
-  height: 700px;
-  background: rgba(73, 186, 255, 0.05);
-  bottom: -15%;
-  left: 40%;
-  animation: drift-3 35s ease-in-out infinite;
-}
-
-.orb-green {
-  width: 400px;
-  height: 400px;
-  background: rgba(80, 251, 123, 0.05);
-  top: 50%;
-  left: -5%;
-  animation: drift-4 28s ease-in-out infinite;
-}
-
-.orb-yellow {
-  width: 350px;
-  height: 350px;
-  background: rgba(240, 251, 140, 0.03);
-  top: 30%;
-  right: 20%;
-  animation: drift-5 32s ease-in-out infinite;
-}
-
-/* Each orb drifts on its own path */
-@keyframes drift-1 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  25% { transform: translate(80px, 60px) scale(1.1); }
-  50% { transform: translate(-40px, 120px) scale(0.95); }
-  75% { transform: translate(60px, -30px) scale(1.05); }
-}
-
-@keyframes drift-2 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  25% { transform: translate(-70px, 80px) scale(1.05); }
-  50% { transform: translate(50px, -40px) scale(1.1); }
-  75% { transform: translate(-90px, -60px) scale(0.9); }
-}
-
-@keyframes drift-3 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  33% { transform: translate(100px, -80px) scale(1.08); }
-  66% { transform: translate(-60px, 50px) scale(0.92); }
-}
-
-@keyframes drift-4 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  20% { transform: translate(50px, -70px) scale(1.12); }
-  40% { transform: translate(90px, 30px) scale(0.95); }
-  60% { transform: translate(-20px, 80px) scale(1.05); }
-  80% { transform: translate(-60px, -40px) scale(0.98); }
-}
-
-@keyframes drift-5 {
-  0%, 100% { transform: translate(0, 0) scale(1); }
-  30% { transform: translate(-50px, 60px) scale(1.1); }
-  60% { transform: translate(70px, -30px) scale(0.9); }
-}
-
-/* Film grain overlay via SVG noise */
 .bg-noise {
   position: absolute;
   inset: 0;
-  opacity: 0.035;
+  opacity: 0.025;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
   background-repeat: repeat;
   background-size: 256px 256px;
-}
-
-/* Reduce motion for accessibility */
-@media (prefers-reduced-motion: reduce) {
-  .bg-orb {
-    animation: none !important;
-  }
 }
 </style>

--- a/website/docs/.vitepress/theme/components/CommandShowcase.vue
+++ b/website/docs/.vitepress/theme/components/CommandShowcase.vue
@@ -47,9 +47,9 @@ const commands = [
     <div class="showcase-chrome">
       <div class="chrome-bar">
         <div class="chrome-dots">
-          <span class="chrome-dot red"></span>
-          <span class="chrome-dot yellow"></span>
-          <span class="chrome-dot green"></span>
+          <span class="chrome-dot"></span>
+          <span class="chrome-dot"></span>
+          <span class="chrome-dot"></span>
         </div>
         <div class="chrome-tabs">
           <button
@@ -76,19 +76,18 @@ const commands = [
 }
 
 .showcase-chrome {
-  background: #0d0d12;
+  background: var(--willow-bg-code);
   border-radius: 12px;
-  border: 1px solid rgba(129, 174, 198, 0.15);
+  border: 1px solid var(--willow-border);
   overflow: hidden;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
 .chrome-bar {
-  background: #1a1a22;
+  background: var(--willow-bg-mute);
   padding: 0 16px;
   display: flex;
   align-items: stretch;
-  border-bottom: 1px solid rgba(129, 174, 198, 0.1);
+  border-bottom: 1px solid var(--willow-border);
 }
 
 .chrome-dots {
@@ -102,11 +101,8 @@ const commands = [
   width: 12px;
   height: 12px;
   border-radius: 50%;
+  background: var(--willow-text-dim);
 }
-
-.chrome-dot.red { background: #fc4346; }
-.chrome-dot.yellow { background: #f0fb8c; }
-.chrome-dot.green { background: #50fb7b; }
 
 .chrome-tabs {
   display: flex;
@@ -122,19 +118,19 @@ const commands = [
   font-family: var(--vp-font-family-mono);
   font-size: 0.82rem;
   font-weight: 500;
-  color: var(--willow-ash-gray);
+  color: var(--willow-text-3);
   cursor: pointer;
-  transition: color 0.2s, border-color 0.2s;
+  transition: color 0.2s ease-in-out, border-color 0.2s ease-in-out;
   position: relative;
 }
 
 .chrome-tab:hover {
-  color: var(--willow-steel-blue);
+  color: var(--willow-text-1);
 }
 
 .chrome-tab.active {
-  color: var(--willow-neon-cyan);
-  border-bottom-color: var(--willow-neon-cyan);
+  color: var(--willow-text-1);
+  border-bottom-color: var(--willow-accent);
 }
 
 .showcase-body {
@@ -145,12 +141,12 @@ const commands = [
 }
 
 .command-line {
-  color: var(--willow-phantom-green);
+  color: var(--willow-accent);
   margin-bottom: 8px;
 }
 
 .showcase-output {
-  color: var(--willow-pale-bone);
+  color: var(--willow-text-2);
   margin: 0;
   white-space: pre;
   overflow-x: auto;

--- a/website/docs/.vitepress/theme/components/DirectoryTree.vue
+++ b/website/docs/.vitepress/theme/components/DirectoryTree.vue
@@ -2,9 +2,9 @@
   <div class="directory-tree">
     <div class="terminal-window">
       <div class="terminal-titlebar">
-        <span class="terminal-dot red"></span>
-        <span class="terminal-dot yellow"></span>
-        <span class="terminal-dot green"></span>
+        <span class="terminal-dot"></span>
+        <span class="terminal-dot"></span>
+        <span class="terminal-dot"></span>
         <span class="terminal-title">~/.willow/</span>
       </div>
       <div class="tree-content">
@@ -44,20 +44,20 @@
 }
 
 .tree-structure {
-  color: var(--willow-ash-gray);
+  color: var(--willow-text-dim);
 }
 
 .tree-dir {
-  color: var(--willow-electric-blue);
+  color: var(--willow-accent);
   font-weight: 600;
 }
 
 .tree-file {
-  color: var(--willow-pale-bone);
+  color: var(--willow-text-2);
 }
 
 .tree-annotation {
-  color: var(--willow-ash-gray);
+  color: var(--willow-text-3);
   font-style: italic;
   margin-left: 16px;
   font-size: 0.8rem;
@@ -73,15 +73,15 @@
 }
 
 .tree-badge.busy {
-  background: rgba(252, 67, 70, 0.15);
-  color: #fc4346;
-  border: 1px solid rgba(252, 67, 70, 0.3);
+  background: rgba(248, 113, 113, 0.06);
+  color: var(--willow-status-busy);
+  border: 1px solid rgba(248, 113, 113, 0.12);
 }
 
 .tree-badge.wait {
-  background: rgba(240, 251, 140, 0.15);
-  color: #f0fb8c;
-  border: 1px solid rgba(240, 251, 140, 0.3);
+  background: rgba(251, 191, 36, 0.06);
+  color: var(--willow-status-wait);
+  border: 1px solid rgba(251, 191, 36, 0.12);
 }
 
 @media (max-width: 640px) {

--- a/website/docs/.vitepress/theme/components/FeatureCard.vue
+++ b/website/docs/.vitepress/theme/components/FeatureCard.vue
@@ -3,13 +3,12 @@ defineProps<{
   icon: string
   title: string
   description: string
-  color?: string
 }>()
 </script>
 
 <template>
   <div class="feature-card">
-    <div class="feature-icon" :style="color ? { color } : {}">{{ icon }}</div>
+    <div class="feature-icon">{{ icon }}</div>
     <h3 class="feature-title">{{ title }}</h3>
     <p class="feature-desc">{{ description }}</p>
   </div>
@@ -21,13 +20,12 @@ defineProps<{
   border: 1px solid var(--vp-c-divider);
   border-radius: 12px;
   padding: 28px 24px;
-  transition: border-color 0.25s, box-shadow 0.25s, transform 0.25s;
+  transition: border-color 0.2s ease-in-out, transform 0.2s ease-in-out;
 }
 
 .feature-card:hover {
-  border-color: var(--willow-neon-cyan);
-  box-shadow: 0 0 24px rgba(139, 233, 253, 0.08);
-  transform: translateY(-2px);
+  border-color: var(--willow-border-hover);
+  transform: translateY(-1px);
 }
 
 .feature-icon {
@@ -36,15 +34,15 @@ defineProps<{
 }
 
 .feature-title {
-  font-family: var(--vp-font-family-mono);
+  font-family: var(--vp-font-family-heading);
   font-size: 1.05rem;
   font-weight: 600;
-  color: var(--willow-neon-cyan);
+  color: var(--willow-text-1);
   margin-bottom: 8px;
 }
 
 .feature-desc {
-  color: var(--willow-steel-blue);
+  color: var(--willow-text-2);
   font-size: 0.9rem;
   line-height: 1.6;
   margin: 0;

--- a/website/docs/.vitepress/theme/components/FeatureGrid.vue
+++ b/website/docs/.vitepress/theme/components/FeatureGrid.vue
@@ -6,25 +6,21 @@ const features = [
     icon: '🤖',
     title: 'AI-Agent Optimized',
     description: 'Built for running multiple Claude Code sessions in parallel. Each agent gets its own isolated worktree — no conflicts, no stashing.',
-    color: '#fc4cb4',
   },
   {
     icon: '📡',
     title: 'Live Status Tracking',
     description: 'See which agents are BUSY, WAIT, DONE, or IDLE in real time. Status hooks integrate directly with Claude Code.',
-    color: '#50fb7b',
   },
   {
     icon: '⚡',
     title: 'fzf-Powered Switching',
     description: 'Switch between worktrees instantly with an fzf picker that shows agent status. Two keystrokes and you\'re there.',
-    color: '#f0fb8c',
   },
   {
     icon: '🌿',
     title: 'Git-Native',
     description: 'Thin wrapper around git worktree, git branch, and git fetch. No custom database — state comes from git itself.',
-    color: '#8be9fd',
   },
 ]
 </script>
@@ -37,7 +33,6 @@ const features = [
       :icon="f.icon"
       :title="f.title"
       :description="f.description"
-      :color="f.color"
     />
   </div>
 </template>

--- a/website/docs/.vitepress/theme/components/HowItWorks.vue
+++ b/website/docs/.vitepress/theme/components/HowItWorks.vue
@@ -44,39 +44,39 @@ const steps = [
   border-radius: 12px;
   padding: 28px 24px;
   position: relative;
-  transition: border-color 0.25s;
+  transition: border-color 0.2s ease-in-out;
 }
 
 .step:hover {
-  border-color: var(--willow-phantom-green);
+  border-color: var(--willow-border-hover);
 }
 
 .step-number {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
-  background: var(--willow-phantom-green);
-  color: var(--willow-void-black);
+  background: var(--willow-accent);
+  color: var(--willow-bg);
   display: flex;
   align-items: center;
   justify-content: center;
   font-family: var(--vp-font-family-mono);
   font-weight: 700;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   margin: 0 auto 16px;
 }
 
 .step-title {
-  font-family: var(--vp-font-family-mono);
+  font-family: var(--vp-font-family-heading);
   font-weight: 600;
   font-size: 1.1rem;
-  color: var(--willow-pale-bone);
+  color: var(--willow-text-1);
   margin-bottom: 8px;
   text-align: center;
 }
 
 .step-desc {
-  color: var(--willow-steel-blue);
+  color: var(--willow-text-2);
   font-size: 0.9rem;
   line-height: 1.6;
   margin-bottom: 16px;
@@ -85,13 +85,13 @@ const steps = [
 
 .step-command {
   display: block;
-  background: #0d0d12;
-  border: 1px solid rgba(129, 174, 198, 0.1);
+  background: var(--willow-bg-code);
+  border: 1px solid var(--willow-border);
   border-radius: 6px;
   padding: 8px 12px;
   font-family: var(--vp-font-family-mono);
   font-size: 0.8rem;
-  color: var(--willow-phantom-green);
+  color: var(--willow-accent);
   overflow-x: auto;
   white-space: nowrap;
   text-align: center;

--- a/website/docs/.vitepress/theme/components/InstallCommand.vue
+++ b/website/docs/.vitepress/theme/components/InstallCommand.vue
@@ -27,30 +27,29 @@ function copyCommand() {
   display: inline-flex;
   align-items: center;
   gap: 12px;
-  background: #0d0d12;
-  border: 1px solid rgba(129, 174, 198, 0.2);
+  background: var(--willow-bg-code);
+  border: 1px solid var(--willow-border);
   border-radius: 8px;
   padding: 12px 20px;
   cursor: pointer;
   font-family: var(--vp-font-family-mono);
   font-size: 0.95rem;
-  transition: border-color 0.25s, box-shadow 0.25s;
+  transition: border-color 0.2s ease-in-out;
   max-width: 100%;
 }
 
 .install-command:hover {
-  border-color: var(--willow-neon-cyan);
-  box-shadow: 0 0 16px rgba(139, 233, 253, 0.1);
+  border-color: var(--willow-border-hover);
 }
 
 .install-prompt {
-  color: var(--willow-phantom-green);
+  color: var(--willow-accent);
   font-weight: 600;
   user-select: none;
 }
 
 .install-text {
-  color: var(--willow-pale-bone);
+  color: var(--willow-text-1);
 }
 
 .install-copy {
@@ -63,16 +62,16 @@ function copyCommand() {
 }
 
 .install-icon {
-  color: var(--willow-ash-gray);
-  transition: color 0.2s;
+  color: var(--willow-text-dim);
+  transition: color 0.2s ease-in-out;
 }
 
 .install-command:hover .install-icon {
-  color: var(--willow-steel-blue);
+  color: var(--willow-text-2);
 }
 
 .install-copied {
-  color: var(--willow-phantom-green);
+  color: var(--willow-accent);
 }
 
 @media (max-width: 480px) {

--- a/website/docs/.vitepress/theme/style/custom.css
+++ b/website/docs/.vitepress/theme/style/custom.css
@@ -1,8 +1,9 @@
-@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Poppins:wght@600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 :root {
   --vp-font-family-base: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --vp-font-family-mono: 'JetBrains Mono', 'DejaVu Sans Mono', monospace;
+  --vp-font-family-heading: 'Poppins', -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 /* Force dark appearance */
@@ -10,37 +11,40 @@ html {
   color-scheme: dark;
 }
 
+/* Teal text selection */
+::selection {
+  background: rgba(94, 234, 212, 0.25);
+}
+
 /* Hero section */
 .VPHero .name {
-  font-family: var(--vp-font-family-mono) !important;
+  font-family: var(--vp-font-family-heading) !important;
   font-weight: 700;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.03em;
 }
 
 .VPHero .text {
-  font-family: var(--vp-font-family-mono) !important;
-  color: var(--willow-steel-blue) !important;
+  font-family: var(--vp-font-family-heading) !important;
+  color: var(--willow-text-2) !important;
 }
 
 .VPHero .tagline {
-  color: var(--willow-pale-bone) !important;
-  opacity: 0.8;
+  color: var(--willow-text-3) !important;
 }
 
 /* Feature cards */
 .VPFeature {
   background: var(--vp-c-bg-soft) !important;
   border: 1px solid var(--vp-c-divider) !important;
-  transition: border-color 0.25s, box-shadow 0.25s;
+  transition: border-color 0.2s ease-in-out;
 }
 
 .VPFeature:hover {
-  border-color: var(--willow-neon-cyan) !important;
-  box-shadow: 0 0 20px rgba(139, 233, 253, 0.1);
+  border-color: var(--willow-border-hover) !important;
 }
 
 .VPFeature .title {
-  color: var(--willow-neon-cyan) !important;
+  color: var(--willow-text-1) !important;
 }
 
 /* Feature grid — 5 columns so all cards fit on one row */
@@ -67,16 +71,17 @@ html {
 }
 
 .section-title {
-  font-family: var(--vp-font-family-mono);
+  font-family: var(--vp-font-family-heading);
   font-size: 1.75rem;
   font-weight: 700;
-  color: var(--willow-neon-cyan);
+  color: var(--willow-text-1);
   margin-bottom: 1rem;
   text-align: center;
+  letter-spacing: -0.03em;
 }
 
 .section-subtitle {
-  color: var(--willow-steel-blue);
+  color: var(--willow-text-3);
   text-align: center;
   max-width: 800px;
   margin: 0 auto 2.5rem !important;
@@ -86,38 +91,34 @@ html {
 
 /* Terminal chrome */
 .terminal-window {
-  background: #0d0d12;
+  background: var(--willow-bg-code);
   border-radius: 12px;
-  border: 1px solid rgba(129, 174, 198, 0.15);
+  border: 1px solid var(--willow-border);
   overflow: hidden;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
 .terminal-titlebar {
-  background: #1a1a22;
+  background: var(--willow-bg-mute);
   padding: 12px 16px;
   display: flex;
   align-items: center;
   gap: 8px;
-  border-bottom: 1px solid rgba(129, 174, 198, 0.1);
+  border-bottom: 1px solid var(--willow-border);
 }
 
 .terminal-dot {
   width: 12px;
   height: 12px;
   border-radius: 50%;
+  background: var(--willow-text-dim);
 }
-
-.terminal-dot.red { background: #fc4346; }
-.terminal-dot.yellow { background: #f0fb8c; }
-.terminal-dot.green { background: #50fb7b; }
 
 .terminal-title {
   flex: 1;
   text-align: center;
   font-family: var(--vp-font-family-mono);
   font-size: 0.8rem;
-  color: var(--willow-ash-gray);
+  color: var(--willow-text-3);
   margin-right: 52px;
 }
 
@@ -145,27 +146,27 @@ html {
 }
 
 .status-badge.busy {
-  background: rgba(252, 67, 70, 0.15);
-  color: #fc4346;
-  border: 1px solid rgba(252, 67, 70, 0.3);
+  background: rgba(248, 113, 113, 0.06);
+  color: var(--willow-status-busy);
+  border: 1px solid rgba(248, 113, 113, 0.12);
 }
 
 .status-badge.done {
-  background: rgba(80, 251, 123, 0.15);
-  color: #50fb7b;
-  border: 1px solid rgba(80, 251, 123, 0.3);
+  background: rgba(94, 234, 212, 0.06);
+  color: var(--willow-status-done);
+  border: 1px solid rgba(94, 234, 212, 0.12);
 }
 
 .status-badge.wait {
-  background: rgba(240, 251, 140, 0.15);
-  color: #f0fb8c;
-  border: 1px solid rgba(240, 251, 140, 0.3);
+  background: rgba(251, 191, 36, 0.06);
+  color: var(--willow-status-wait);
+  border: 1px solid rgba(251, 191, 36, 0.12);
 }
 
 .status-badge.idle {
-  background: rgba(73, 186, 255, 0.15);
-  color: #49baff;
-  border: 1px solid rgba(73, 186, 255, 0.3);
+  background: rgba(148, 163, 184, 0.06);
+  color: var(--willow-status-idle);
+  border: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 /* Code group styling */
@@ -184,17 +185,69 @@ html {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--willow-ash-gray);
+  background: var(--willow-text-dim);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--willow-steel-blue);
+  background: var(--willow-text-3);
+}
+
+/* Sliding underline — shared pattern */
+/* Target inline/text-width elements so underline matches text, not container */
+.vp-doc a,
+a.VPNavBarMenuLink > span,
+.VPFooter a,
+.VPSidebarItem a.link .text {
+  position: relative;
+  text-decoration: none;
+}
+
+.vp-doc a::after,
+a.VPNavBarMenuLink > span::after,
+.VPFooter a::after,
+.VPSidebarItem a.link .text::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 0;
+  height: 1px;
+  background: var(--willow-accent);
+  transition: width 0.25s ease;
+}
+
+.vp-doc a:hover::after,
+a.VPNavBarMenuLink:hover > span::after,
+.VPFooter a:hover::after,
+.VPSidebarItem a.link:hover .text::after {
+  width: 100%;
+}
+
+/* Nav links — suppress VitePress active indicator on the <a>, show it on <span> */
+a.VPNavBarMenuLink {
+  transition: color 0.2s ease-in-out;
+}
+
+a.VPNavBarMenuLink:hover {
+  color: var(--willow-text-1) !important;
+}
+
+a.VPNavBarMenuLink.active::after {
+  display: none !important;
+}
+
+a.VPNavBarMenuLink.active > span::after {
+  width: 100%;
 }
 
 /* Footer */
 .VPFooter {
   border-top-color: var(--vp-c-divider) !important;
+}
+
+.VPFooter a {
+  text-decoration: none !important;
 }
 
 /* Responsive */

--- a/website/docs/.vitepress/theme/style/vars.css
+++ b/website/docs/.vitepress/theme/style/vars.css
@@ -1,102 +1,105 @@
 :root {
-  /* Neon Phantom palette */
-  --willow-void-black: #131318;
-  --willow-pale-bone: #ebece6;
-  --willow-neon-cyan: #8be9fd;
-  --willow-electric-blue: #49baff;
-  --willow-phantom-green: #50fb7b;
-  --willow-hot-magenta: #fc4cb4;
-  --willow-signal-red: #fc4346;
-  --willow-soft-yellow: #f0fb8c;
-  --willow-steel-blue: #81aec6;
-  --willow-ash-gray: #555555;
+  /* Zinc + Teal palette */
+  --willow-bg: #0a0a0f;
+  --willow-bg-soft: #111116;
+  --willow-bg-mute: #1a1a1f;
+  --willow-bg-code: #08080c;
+  --willow-text-1: #fafafa;
+  --willow-text-2: #a1a1aa;
+  --willow-text-3: #71717a;
+  --willow-text-dim: #3f3f46;
+  --willow-border: rgba(255, 255, 255, 0.08);
+  --willow-border-hover: rgba(255, 255, 255, 0.15);
+  --willow-accent: #5eead4;
+  --willow-accent-dim: rgba(94, 234, 212, 0.08);
+  --willow-accent-bg: rgba(94, 234, 212, 0.04);
 
-  /* Status badge colors */
-  --willow-status-busy: #fc4346;
-  --willow-status-done: #50fb7b;
-  --willow-status-wait: #f0fb8c;
-  --willow-status-idle: #49baff;
+  /* Status badge colors — semantic but muted */
+  --willow-status-busy: #f87171;
+  --willow-status-done: #5eead4;
+  --willow-status-wait: #fbbf24;
+  --willow-status-idle: #94a3b8;
 }
 
 .dark {
-  --vp-c-bg: #131318;
-  --vp-c-bg-alt: #131318;
-  --vp-c-bg-soft: #1a1a22;
-  --vp-c-bg-mute: #2a2a35;
-  --vp-c-bg-elv: #1a1a22;
+  --vp-c-bg: #0a0a0f;
+  --vp-c-bg-alt: #0a0a0f;
+  --vp-c-bg-soft: #111116;
+  --vp-c-bg-mute: #1a1a1f;
+  --vp-c-bg-elv: #111116;
 
-  --vp-c-text-1: #ebece6;
-  --vp-c-text-2: #81aec6;
-  --vp-c-text-3: #555555;
+  --vp-c-text-1: #fafafa;
+  --vp-c-text-2: #a1a1aa;
+  --vp-c-text-3: #71717a;
 
-  --vp-c-brand-1: #8be9fd;
-  --vp-c-brand-2: #49baff;
-  --vp-c-brand-3: #3a9fe6;
-  --vp-c-brand-soft: rgba(139, 233, 253, 0.14);
+  --vp-c-brand-1: #5eead4;
+  --vp-c-brand-2: #2dd4bf;
+  --vp-c-brand-3: #14b8a6;
+  --vp-c-brand-soft: rgba(94, 234, 212, 0.08);
 
-  --vp-c-tip-1: #50fb7b;
-  --vp-c-tip-2: rgba(80, 251, 123, 0.14);
-  --vp-c-tip-soft: rgba(80, 251, 123, 0.14);
+  --vp-c-tip-1: #5eead4;
+  --vp-c-tip-2: rgba(94, 234, 212, 0.08);
+  --vp-c-tip-soft: rgba(94, 234, 212, 0.08);
 
-  --vp-c-warning-1: #f0fb8c;
-  --vp-c-warning-2: rgba(240, 251, 140, 0.14);
-  --vp-c-warning-soft: rgba(240, 251, 140, 0.14);
+  --vp-c-warning-1: #fbbf24;
+  --vp-c-warning-2: rgba(251, 191, 36, 0.08);
+  --vp-c-warning-soft: rgba(251, 191, 36, 0.08);
 
-  --vp-c-danger-1: #fc4346;
-  --vp-c-danger-2: rgba(252, 67, 70, 0.14);
-  --vp-c-danger-soft: rgba(252, 67, 70, 0.14);
+  --vp-c-danger-1: #f87171;
+  --vp-c-danger-2: rgba(248, 113, 113, 0.08);
+  --vp-c-danger-soft: rgba(248, 113, 113, 0.08);
 
-  --vp-c-divider: rgba(129, 174, 198, 0.2);
-  --vp-c-gutter: rgba(129, 174, 198, 0.2);
+  --vp-c-divider: rgba(255, 255, 255, 0.08);
+  --vp-c-gutter: rgba(255, 255, 255, 0.08);
 
-  --vp-c-default-1: #81aec6;
-  --vp-c-default-2: rgba(129, 174, 198, 0.2);
-  --vp-c-default-3: rgba(129, 174, 198, 0.1);
-  --vp-c-default-soft: rgba(129, 174, 198, 0.1);
+  --vp-c-default-1: #a1a1aa;
+  --vp-c-default-2: rgba(255, 255, 255, 0.08);
+  --vp-c-default-3: rgba(255, 255, 255, 0.05);
+  --vp-c-default-soft: rgba(255, 255, 255, 0.05);
 
   --vp-button-brand-border: transparent;
-  --vp-button-brand-text: #131318;
-  --vp-button-brand-bg: #8be9fd;
+  --vp-button-brand-text: #0a0a0f;
+  --vp-button-brand-bg: #5eead4;
   --vp-button-brand-hover-border: transparent;
-  --vp-button-brand-hover-text: #131318;
-  --vp-button-brand-hover-bg: #49baff;
+  --vp-button-brand-hover-text: #0a0a0f;
+  --vp-button-brand-hover-bg: #2dd4bf;
   --vp-button-brand-active-border: transparent;
-  --vp-button-brand-active-text: #131318;
-  --vp-button-brand-active-bg: #3a9fe6;
+  --vp-button-brand-active-text: #0a0a0f;
+  --vp-button-brand-active-bg: #14b8a6;
 
-  --vp-button-alt-border: rgba(129, 174, 198, 0.3);
-  --vp-button-alt-text: #ebece6;
-  --vp-button-alt-bg: rgba(129, 174, 198, 0.1);
-  --vp-button-alt-hover-border: rgba(129, 174, 198, 0.5);
-  --vp-button-alt-hover-text: #ebece6;
-  --vp-button-alt-hover-bg: rgba(129, 174, 198, 0.15);
+  --vp-button-alt-border: rgba(255, 255, 255, 0.1);
+  --vp-button-alt-text: #fafafa;
+  --vp-button-alt-bg: rgba(255, 255, 255, 0.05);
+  --vp-button-alt-hover-border: rgba(255, 255, 255, 0.18);
+  --vp-button-alt-hover-text: #fafafa;
+  --vp-button-alt-hover-bg: rgba(255, 255, 255, 0.08);
 
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: linear-gradient(135deg, #8be9fd 0%, #49baff 50%, #fc4cb4 100%);
-  --vp-home-hero-image-background-image: radial-gradient(circle, rgba(139, 233, 253, 0.15) 0%, transparent 70%);
+  --vp-home-hero-name-background: linear-gradient(135deg, #5eead4 0%, #2dd4bf 100%);
+  --vp-home-hero-image-background-image: radial-gradient(circle, rgba(94, 234, 212, 0.08) 0%, transparent 70%);
   --vp-home-hero-image-filter: blur(40px);
 
-  --vp-code-block-bg: #0d0d12;
-  --vp-code-line-highlight-color: rgba(139, 233, 253, 0.08);
-  --vp-code-tab-text-color: #81aec6;
-  --vp-code-tab-active-text-color: #8be9fd;
-  --vp-code-tab-hover-text-color: #ebece6;
-  --vp-code-tab-active-bar-color: #8be9fd;
-  --vp-code-copy-code-border-color: rgba(129, 174, 198, 0.2);
-  --vp-code-copy-code-bg: #1a1a22;
-  --vp-code-copy-code-hover-bg: #2a2a35;
-  --vp-code-copy-code-hover-border-color: rgba(129, 174, 198, 0.4);
-  --vp-code-copy-code-active-text: #50fb7b;
+  --vp-code-block-bg: #08080c;
+  --vp-code-line-highlight-color: rgba(94, 234, 212, 0.06);
+  --vp-code-tab-text-color: #a1a1aa;
+  --vp-code-tab-active-text-color: #5eead4;
+  --vp-code-tab-hover-text-color: #fafafa;
+  --vp-code-tab-active-bar-color: #5eead4;
+  --vp-code-copy-code-border-color: rgba(255, 255, 255, 0.08);
+  --vp-code-copy-code-bg: #111116;
+  --vp-code-copy-code-hover-bg: #1a1a1f;
+  --vp-code-copy-code-hover-border-color: rgba(255, 255, 255, 0.15);
+  --vp-code-copy-code-active-text: #5eead4;
 
-  --vp-carbon-ads-text-color: #81aec6;
-  --vp-carbon-ads-poweredby-color: #555555;
-  --vp-carbon-ads-bg-color: #1a1a22;
-  --vp-carbon-ads-hover-text-color: #ebece6;
+  --vp-carbon-ads-text-color: #a1a1aa;
+  --vp-carbon-ads-poweredby-color: #71717a;
+  --vp-carbon-ads-bg-color: #111116;
+  --vp-carbon-ads-hover-text-color: #fafafa;
 
-  --vp-sidebar-bg-color: #131318;
+  --vp-sidebar-bg-color: #0a0a0f;
 
-  --vp-nav-bg-color: rgba(19, 19, 24, 0.85);
+  --vp-nav-bg-color: rgba(10, 10, 15, 0.85);
 
-  --vp-input-border-color: rgba(129, 174, 198, 0.3);
-  --vp-input-hover-border-color: #8be9fd;
+  --vp-input-border-color: rgba(255, 255, 255, 0.1);
+  --vp-input-hover-border-color: #5eead4;
 }

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 hero:
   name: willow
   text: Git worktree manager
-  tagline: Spin up isolated worktrees for Claude Code sessions. Switch between them instantly with fzf. See which agents are busy, waiting, or idle.
+  tagline: Spin up isolated worktrees for agent sessions.<br>Switch between them instantly with fzf.<br>See which agents are busy, waiting, or idle.
   actions:
     - theme: brand
       text: Get Started

--- a/website/docs/public/favicon.svg
+++ b/website/docs/public/favicon.svg
@@ -1,16 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
   <defs>
     <linearGradient id="leaf" x1="16" y1="2" x2="16" y2="28" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#8be9fd"/>
-      <stop offset="60%" stop-color="#50fb7b"/>
-      <stop offset="100%" stop-color="#49baff"/>
+      <stop offset="0%" stop-color="#5eead4"/>
+      <stop offset="60%" stop-color="#2dd4bf"/>
+      <stop offset="100%" stop-color="#14b8a6"/>
     </linearGradient>
   </defs>
   <!-- Main leaf shape -->
   <path d="M16 2C12 8 10 14 10 18C10 23 12.5 26 16 28C19.5 26 22 23 22 18C22 14 20 8 16 2Z" fill="url(#leaf)"/>
   <!-- Center vein -->
-  <path d="M16 6L16 24" stroke="#131318" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/>
+  <path d="M16 6L16 24" stroke="#0a0a0f" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/>
   <!-- Side veins -->
-  <path d="M16 10L12 14M16 14L11.5 18M16 18L13 21" stroke="#131318" stroke-width="0.8" stroke-linecap="round" opacity="0.25"/>
-  <path d="M16 10L20 14M16 14L20.5 18M16 18L19 21" stroke="#131318" stroke-width="0.8" stroke-linecap="round" opacity="0.25"/>
+  <path d="M16 10L12 14M16 14L11.5 18M16 18L13 21" stroke="#0a0a0f" stroke-width="0.8" stroke-linecap="round" opacity="0.25"/>
+  <path d="M16 10L20 14M16 14L20.5 18M16 18L19 21" stroke="#0a0a0f" stroke-width="0.8" stroke-linecap="round" opacity="0.25"/>
 </svg>

--- a/website/docs/public/logo.svg
+++ b/website/docs/public/logo.svg
@@ -1,16 +1,16 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
   <defs>
     <linearGradient id="leaf" x1="16" y1="2" x2="16" y2="28" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#8be9fd"/>
-      <stop offset="60%" stop-color="#50fb7b"/>
-      <stop offset="100%" stop-color="#49baff"/>
+      <stop offset="0%" stop-color="#5eead4"/>
+      <stop offset="60%" stop-color="#2dd4bf"/>
+      <stop offset="100%" stop-color="#14b8a6"/>
     </linearGradient>
   </defs>
   <!-- Main leaf shape -->
   <path d="M16 2C12 8 10 14 10 18C10 23 12.5 26 16 28C19.5 26 22 23 22 18C22 14 20 8 16 2Z" fill="url(#leaf)"/>
   <!-- Center vein -->
-  <path d="M16 6L16 24" stroke="#131318" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/>
+  <path d="M16 6L16 24" stroke="#0a0a0f" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/>
   <!-- Side veins -->
-  <path d="M16 10L12 14M16 14L11.5 18M16 18L13 21" stroke="#131318" stroke-width="0.8" stroke-linecap="round" opacity="0.25"/>
-  <path d="M16 10L20 14M16 14L20.5 18M16 18L19 21" stroke="#131318" stroke-width="0.8" stroke-linecap="round" opacity="0.25"/>
+  <path d="M16 10L12 14M16 14L11.5 18M16 18L13 21" stroke="#0a0a0f" stroke-width="0.8" stroke-linecap="round" opacity="0.25"/>
+  <path d="M16 10L20 14M16 14L20.5 18M16 18L19 21" stroke="#0a0a0f" stroke-width="0.8" stroke-linecap="round" opacity="0.25"/>
 </svg>


### PR DESCRIPTION
## Description of the change

Complete visual revamp of getwillow.dev from neon UI aesthetic to modern minimalism:

- **Color palette**: Replaced 8 neon colors with monochromatic zinc + single teal accent
- **Background**: Removed 5 animated floating orbs, replaced with static teal gradient + faint noise grain
- **Typography**: Added Poppins for headings (was monospace everywhere), kept Inter body + JetBrains Mono for code
- **Interactions**: Sliding teal underline on links, subtle hover effects, no glow/box-shadow
- **Terminal chrome**: Monochrome dots (was red/yellow/green neon)
- **Status badges**: Muted semantic colors (was saturated neon)
- **Assets**: Monochrome teal leaf favicon/logo (was cyan-green-blue rainbow gradient)
- **Footer**: Single line with middot separators, all links
- **Selection**: Teal text selection matching personal site

## Test plan

- `pnpm build` passes cleanly
- Visual verification via dev server

## Loom or screenshots

Before: Neon phantom aesthetic with animated orbs
After: Restrained zinc + teal matching blog/personal site design language