### PR TITLE
🐛 fix(status): correct status decay, display, self-heal, and double-read bugs

### DIFF
--- a/internal/claude/hook.go
+++ b/internal/claude/hook.go
@@ -117,12 +117,12 @@ case "$HOOK_EVENT" in
     STATUS="DONE"
     ;;
   Notification)
-    # Don't overwrite DONE — only set WAIT if not already DONE
+    # Don't overwrite DONE or BUSY — only set WAIT if currently idle/unknown
     DEST_DIR="$STATUS_DIR/$REPO_NAME/$WT_NAME"
     DEST_FILE="$DEST_DIR/$SESSION_ID.json"
     if [ -f "$DEST_FILE" ]; then
       CURRENT="$(sed -n 's/.*"status" *: *"\([^"]*\)".*/\1/p' "$DEST_FILE" | head -1)"
-      if [ "$CURRENT" = "DONE" ]; then
+      if [ "$CURRENT" = "DONE" ] || [ "$CURRENT" = "BUSY" ]; then
         exit 0
       fi
     fi

--- a/internal/claude/status.go
+++ b/internal/claude/status.go
@@ -43,9 +43,8 @@ func StatusDir() string {
 
 // ReadAllSessions reads all session status files from the directory-based layout:
 // ~/.willow/status/<repo>/<worktree>/*.json
+// Stale sessions (>30 min) and corrupt files are cleaned up in the same pass.
 func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
-	CleanStaleSessions(repoName, worktreeDir)
-
 	dir := filepath.Join(StatusDir(), repoName, worktreeDir)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -57,12 +56,18 @@ func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
-		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}
 		var ss SessionStatus
 		if err := json.Unmarshal(data, &ss); err != nil {
+			os.Remove(path)
+			continue
+		}
+		if time.Since(ss.Timestamp) > cleanupTimeout {
+			os.Remove(path)
 			continue
 		}
 		sessions = append(sessions, &ss)
@@ -76,14 +81,14 @@ func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 func ReadStatus(repoName, worktreeDir string) *WorktreeStatus {
 	sessions := ReadAllSessions(repoName, worktreeDir)
 	if len(sessions) > 0 {
-		return aggregateStatus(sessions)
+		return AggregateStatus(sessions)
 	}
 
 	// Legacy single-file fallback
 	return readLegacyStatus(repoName, worktreeDir)
 }
 
-func aggregateStatus(sessions []*SessionStatus) *WorktreeStatus {
+func AggregateStatus(sessions []*SessionStatus) *WorktreeStatus {
 	best := &WorktreeStatus{Status: StatusOffline}
 	for _, ss := range sessions {
 		effective := EffectiveStatus(ss.Status, ss.Timestamp)
@@ -99,7 +104,7 @@ func aggregateStatus(sessions []*SessionStatus) *WorktreeStatus {
 }
 
 func EffectiveStatus(s Status, ts time.Time) Status {
-	if (s == StatusBusy || s == StatusDone || s == StatusWait) && time.Since(ts) > staleTimeout {
+	if (s == StatusBusy || s == StatusWait) && time.Since(ts) > staleTimeout {
 		return StatusIdle
 	}
 	return s

--- a/internal/claude/status_test.go
+++ b/internal/claude/status_test.go
@@ -61,7 +61,7 @@ func TestReadStatus_StaleBusyBecomesIdle(t *testing.T) {
 	}
 }
 
-func TestReadStatus_StaleDoneBecomesIdle(t *testing.T) {
+func TestReadStatus_StaleDoneStaysDone(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -79,8 +79,8 @@ func TestReadStatus_StaleDoneBecomesIdle(t *testing.T) {
 	os.WriteFile(filepath.Join(statusDir, wtName+".json"), data, 0o644)
 
 	got := ReadStatus(repoName, wtName)
-	if got.Status != StatusIdle {
-		t.Errorf("Status = %q, want %q (stale DONE should become IDLE)", got.Status, StatusIdle)
+	if got.Status != StatusDone {
+		t.Errorf("Status = %q, want %q (stale DONE should stay DONE)", got.Status, StatusDone)
 	}
 }
 
@@ -265,8 +265,8 @@ func TestEffectiveStatus_Stale(t *testing.T) {
 	if got := EffectiveStatus(StatusBusy, stale); got != StatusIdle {
 		t.Errorf("stale BUSY = %q, want IDLE", got)
 	}
-	if got := EffectiveStatus(StatusDone, stale); got != StatusIdle {
-		t.Errorf("stale DONE = %q, want IDLE", got)
+	if got := EffectiveStatus(StatusDone, stale); got != StatusDone {
+		t.Errorf("stale DONE = %q, want DONE", got)
 	}
 	if got := EffectiveStatus(StatusWait, stale); got != StatusIdle {
 		t.Errorf("stale WAIT = %q, want IDLE", got)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -43,22 +43,23 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 
 		if len(sessions) > 0 {
 			for _, ss := range sessions {
+				effective := claude.EffectiveStatus(ss.Status, ss.Timestamp)
 				entry := sessionEntry{
 					Repo:      repoName,
 					Branch:    wt.Branch,
 					SessionID: ss.SessionID,
-					Status:    string(ss.Status),
+					Status:    string(effective),
 					Path:      wt.Path,
 				}
 				if !ss.Timestamp.IsZero() {
 					entry.Timestamp = claude.TimeSince(ss.Timestamp)
 				}
-				if ss.Status == claude.StatusDone && unread {
+				if effective == claude.StatusDone && unread {
 					entry.Unread = true
 				}
 				rs.Entries = append(rs.Entries, entry)
 
-				if ss.Status == claude.StatusBusy || ss.Status == claude.StatusDone || ss.Status == claude.StatusWait {
+				if effective == claude.StatusBusy || effective == claude.StatusDone || effective == claude.StatusWait {
 					rs.ActiveCount++
 				}
 			}

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -438,15 +438,18 @@ func tmuxStatusBarCmd() *cli.Command {
 					}
 					totalWt++
 					wtDir := filepath.Base(wt.Path)
-					ws := claude.ReadStatus(repoName, wtDir)
+					sessions := claude.ReadAllSessions(repoName, wtDir)
+					ws := claude.AggregateStatus(sessions)
 
 					// Self-heal: clean orphaned BUSY/WAIT sessions when tmux session is gone
 					sessName := tmux.SessionNameForWorktree(repoName, wtDir)
 					if (ws.Status == claude.StatusBusy || ws.Status == claude.StatusWait) && !tmux.SessionExists(sessName) {
-						for _, ss := range claude.ReadAllSessions(repoName, wtDir) {
-							claude.RemoveSessionFile(repoName, wtDir, ss.SessionID)
+						for _, ss := range sessions {
+							if ss.Status == claude.StatusBusy || ss.Status == claude.StatusWait {
+								claude.RemoveSessionFile(repoName, wtDir, ss.SessionID)
+							}
 						}
-						ws = &claude.WorktreeStatus{Status: claude.StatusOffline}
+						ws = claude.AggregateStatus(claude.ReadAllSessions(repoName, wtDir))
 					}
 
 					currentStatuses[repoName+"/"+wtDir] = ws.Status

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -227,19 +227,20 @@ func collectData() ([]session, summary) {
 
 			if len(allSessions) > 0 {
 				for _, ss := range allSessions {
+					effective := claude.EffectiveStatus(ss.Status, ss.Timestamp)
 					s := session{
 						Repo:      repoName,
 						Branch:    wt.Branch,
 						SessionID: ss.SessionID,
-						Status:    ss.Status,
+						Status:    effective,
 						Tool:      ss.Tool,
 						DiffStats: diff,
 						Age:       claude.TimeSince(ss.Timestamp),
-						Unread:    ss.Status == claude.StatusDone && unread,
+						Unread:    effective == claude.StatusDone && unread,
 						WtDirName: wtDir,
 					}
 					sessions = append(sessions, s)
-					if ss.Status == claude.StatusBusy || ss.Status == claude.StatusWait || ss.Status == claude.StatusDone {
+					if effective == claude.StatusBusy || effective == claude.StatusWait || effective == claude.StatusDone {
 						sum.Agents++
 					}
 				}

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -213,13 +213,13 @@ func TestFilterActiveSessions(t *testing.T) {
 			3,
 		},
 		{
-			"stale BUSY becomes idle and is filtered",
+			"stale BUSY/WAIT become idle, stale DONE stays",
 			[]*claude.SessionStatus{
 				{Status: claude.StatusBusy, Timestamp: stale},
 				{Status: claude.StatusDone, Timestamp: stale},
 				{Status: claude.StatusWait, Timestamp: stale},
 			},
-			0,
+			1,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

Fixes six status handling bugs identified in an audit:

1. **DONE no longer decays to IDLE** — `EffectiveStatus` only decays BUSY/WAIT (DONE persists until 30m cleanup)
2. **Per-session consumers apply EffectiveStatus** — `status` cmd and dashboard now show effective status instead of raw
3. **Self-heal preserves DONE sessions** — only orphaned BUSY/WAIT sessions are removed when tmux is gone
4. **Single-pass ReadAllSessions** — merged stale cleanup into the read loop (no more double dir scan)
5. **Exported AggregateStatus** — status-bar calls `ReadAllSessions` once instead of `ReadStatus` + `ReadAllSessions`
6. **Hook guards BUSY from Notification** — Notification events no longer overwrite BUSY with WAIT

## Test plan

- `go test ./... -count=1` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)