### PR TITLE
✨ feat(new): worktree from existing branch picker and PR URL

### DIFF
--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -552,6 +552,128 @@ func TestRm_ScopedToCurrentRepo(t *testing.T) {
 	}
 }
 
+func TestNew_ExistingBranch(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	// Create a branch in the origin (push from the initial worktree)
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+
+	wg := &git.Git{Dir: mainDir}
+	if _, err := wg.Run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("git config email: %v", err)
+	}
+	if _, err := wg.Run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("git config name: %v", err)
+	}
+	if _, err := wg.Run("checkout", "-b", "existing-feature"); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	os.WriteFile(filepath.Join(mainDir, "feature.txt"), []byte("feature\n"), 0o644)
+	if _, err := wg.Run("add", "."); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if _, err := wg.Run("commit", "-m", "add feature"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	if _, err := wg.Run("push", "origin", "existing-feature"); err != nil {
+		t.Fatalf("git push: %v", err)
+	}
+	// Switch back so the branch isn't checked out in this worktree
+	if _, err := wg.Run("checkout", "-"); err != nil {
+		t.Fatalf("git checkout: %v", err)
+	}
+
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "-e", "existing-feature", "--no-fetch"); err != nil {
+		t.Fatalf("new -e failed: %v", err)
+	}
+
+	newWtDir := filepath.Join(worktreeDir, "existing-feature")
+	if _, err := os.Stat(newWtDir); os.IsNotExist(err) {
+		t.Errorf("worktree not created at %s", newWtDir)
+	}
+
+	// Verify the feature file exists (branch content was checked out)
+	if _, err := os.Stat(filepath.Join(newWtDir, "feature.txt")); os.IsNotExist(err) {
+		t.Error("feature.txt not found — existing branch content not checked out")
+	}
+}
+
+func TestNew_ExistingBranchSkipsPrefix(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+
+	// Create and push a branch
+	wg := &git.Git{Dir: mainDir}
+	if _, err := wg.Run("checkout", "-b", "prefixed-branch"); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	if _, err := wg.Run("push", "origin", "prefixed-branch"); err != nil {
+		t.Fatalf("git push: %v", err)
+	}
+	if _, err := wg.Run("checkout", "-"); err != nil {
+		t.Fatalf("git checkout: %v", err)
+	}
+
+	os.Chdir(mainDir)
+
+	// Set branchPrefix in local config
+	bareDir := filepath.Join(home, ".willow", "repos", "testrepo.git")
+	configPath := filepath.Join(bareDir, "willow.json")
+	os.WriteFile(configPath, []byte(`{"branchPrefix": "alice"}`), 0o644)
+
+	if err := runApp("new", "-e", "prefixed-branch", "--no-fetch"); err != nil {
+		t.Fatalf("new -e failed: %v", err)
+	}
+
+	// Directory should be "prefixed-branch", NOT "alice-prefixed-branch"
+	expectedDir := filepath.Join(worktreeDir, "prefixed-branch")
+	if _, err := os.Stat(expectedDir); os.IsNotExist(err) {
+		t.Errorf("worktree not at %s — branch prefix was wrongly applied", expectedDir)
+	}
+
+	wrongDir := filepath.Join(worktreeDir, "alice-prefixed-branch")
+	if _, err := os.Stat(wrongDir); !os.IsNotExist(err) {
+		t.Error("branch prefix was applied to existing branch (should be skipped)")
+	}
+}
+
+func TestIsPRURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"https://github.com/org/repo/pull/123", true},
+		{"github.com/org/repo/pull/456", true},
+		{"https://github.com/org/repo/pull/123#issuecomment-1", true},
+		{"feat-my-branch", false},
+		{"https://github.com/org/repo/issues/123", false},
+		{"", false},
+		{"123", false},
+	}
+	for _, tt := range tests {
+		if got := isPRURL(tt.input); got != tt.want {
+			t.Errorf("isPRURL(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestGc_EmptyTrash(t *testing.T) {
 	setupTestEnv(t)
 

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -6,12 +6,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/ui"
+	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
 
@@ -106,12 +109,9 @@ func newCmd() *cli.Command {
 			g := flags.NewGit()
 			u := flags.NewUI()
 			cdOnly := cmd.Bool("cd")
+			existing := cmd.Bool("existing")
 
-			branch := cmd.StringArg("branch")
-			if branch == "" {
-				return fmt.Errorf("branch name is required\n\nUsage: ww new <branch> [flags]")
-			}
-
+			// Resolve repo
 			var bareDir string
 			var err error
 			done := tr.Start("resolve repo")
@@ -135,6 +135,83 @@ func newCmd() *cli.Command {
 			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
 			repoName := repoNameFromDir(bareDir)
 
+			branch := cmd.StringArg("branch")
+
+			// PR URL auto-detection: resolve to branch name and force existing mode
+			if branch != "" && isPRURL(branch) {
+				done = tr.Start("resolve PR branch")
+				prBranch, ok := resolvePRBranch(branch, bareDir)
+				if !ok {
+					return fmt.Errorf("failed to resolve branch from PR URL: %s\n\nEnsure 'gh' is installed and you're authenticated", branch)
+				}
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Resolved PR to branch %s\n", prBranch)
+				} else {
+					u.Info(fmt.Sprintf("Resolved PR to branch %s", u.Bold(prBranch)))
+				}
+				branch = prBranch
+				existing = true
+				done()
+			}
+
+			// Existing-branch picker: -e with no branch arg
+			if existing && branch == "" {
+				done = tr.Start("pick existing branch")
+				branch, err = pickExistingBranch(repoGit)
+				if err != nil {
+					return err
+				}
+				if branch == "" {
+					return nil // user cancelled
+				}
+				done()
+			}
+
+			if branch == "" {
+				return fmt.Errorf("branch name is required\n\nUsage: ww new <branch> [flags]")
+			}
+
+			if existing {
+				// --- Existing branch path ---
+				// No branch prefix for existing branches
+				shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch")
+				if shouldFetch {
+					done = tr.Start("git fetch branch")
+					if cdOnly {
+						fmt.Fprintf(os.Stderr, "Fetching %s from origin...\n", branch)
+						if _, err := repoGit.RunStream(os.Stderr, "fetch", "--progress", "origin", branch); err != nil {
+							return fmt.Errorf("failed to fetch origin/%s: %w", branch, err)
+						}
+					} else {
+						u.Info(fmt.Sprintf("Fetching %s from origin...", u.Bold(branch)))
+						if _, err := repoGit.Run("fetch", "origin", branch); err != nil {
+							return fmt.Errorf("failed to fetch origin/%s: %w", branch, err)
+						}
+					}
+					done()
+				}
+
+				dirName := strings.ReplaceAll(branch, "/", "-")
+				wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
+
+				done = tr.Start("git worktree add")
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Creating worktree for existing branch %s...\n", branch)
+					if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, branch); err != nil {
+						return fmt.Errorf("failed to create worktree: %w", err)
+					}
+				} else {
+					u.Info(fmt.Sprintf("Creating worktree for existing branch %s...", u.Bold(branch)))
+					if _, err := repoGit.Run("worktree", "add", wtPath, branch); err != nil {
+						return fmt.Errorf("failed to create worktree: %w", err)
+					}
+				}
+				done()
+
+				return finishWorktree(tr, cfg, g, u, wtPath, repoName, branch, "", cdOnly)
+			}
+
+			// --- New branch path ---
 			// Apply branch prefix from config
 			if cfg.BranchPrefix != "" && !strings.HasPrefix(branch, cfg.BranchPrefix+"/") {
 				branch = cfg.BranchPrefix + "/" + branch
@@ -176,67 +253,124 @@ func newCmd() *cli.Command {
 			wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
 
 			done = tr.Start("git worktree add")
-			if cmd.Bool("existing") {
-				if cdOnly {
-					fmt.Fprintf(os.Stderr, "Creating worktree for existing branch %s...\n", branch)
-					if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, branch); err != nil {
-						return fmt.Errorf("failed to create worktree: %w", err)
-					}
-				} else {
-					u.Info(fmt.Sprintf("Creating worktree for existing branch %s...", u.Bold(branch)))
-					if _, err := repoGit.Run("worktree", "add", wtPath, branch); err != nil {
-						return fmt.Errorf("failed to create worktree: %w", err)
-					}
+			if cdOnly {
+				fmt.Fprintf(os.Stderr, "Creating worktree %s from %s...\n", branch, "origin/"+baseBranch)
+				if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			} else {
-				if cdOnly {
-					fmt.Fprintf(os.Stderr, "Creating worktree %s from %s...\n", branch, "origin/"+baseBranch)
-					if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
-						return fmt.Errorf("failed to create worktree: %w", err)
-					}
-				} else {
-					u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold("origin/"+baseBranch)))
-					if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
-						return fmt.Errorf("failed to create worktree: %w", err)
-					}
+				u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold("origin/"+baseBranch)))
+				if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			}
 			done()
 
-			done = tr.Start("post-checkout hook")
-			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
-			done()
-
-			done = tr.Start("auto setup remote")
-			if *cfg.Defaults.AutoSetupRemote {
-				wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
-				if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
-					return fmt.Errorf("failed to configure push.autoSetupRemote: %w", err)
-				}
-			}
-			done()
-
-			// Run setup hooks
-			done = tr.Start("setup hooks")
-			if len(cfg.Setup) > 0 && !cdOnly {
-				u.Info("Running setup hooks...")
-				if err := runHooks(cfg.Setup, wtPath, u); err != nil {
-					return err
-				}
-			}
-			done()
-
-			tr.Total()
-
-			if cdOnly {
-				fmt.Println(wtPath)
-				return nil
-			}
-
-			u.Success(fmt.Sprintf("Created worktree %s", u.Bold(branch)))
-			u.Info(fmt.Sprintf("  path:   %s", u.Dim(wtPath)))
-			u.Info(fmt.Sprintf("  base:   %s", u.Dim("origin/"+baseBranch)))
-			return nil
+			return finishWorktree(tr, cfg, g, u, wtPath, repoName, branch, baseBranch, cdOnly)
 		},
 	}
+}
+
+func finishWorktree(tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, wtPath, repoName, branch, baseBranch string, cdOnly bool) error {
+	done := tr.Start("post-checkout hook")
+	runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
+	done()
+
+	done = tr.Start("auto setup remote")
+	if *cfg.Defaults.AutoSetupRemote {
+		wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
+		if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
+			return fmt.Errorf("failed to configure push.autoSetupRemote: %w", err)
+		}
+	}
+	done()
+
+	done = tr.Start("setup hooks")
+	if len(cfg.Setup) > 0 && !cdOnly {
+		u.Info("Running setup hooks...")
+		if err := runHooks(cfg.Setup, wtPath, u); err != nil {
+			return err
+		}
+	}
+	done()
+
+	tr.Total()
+
+	if cdOnly {
+		fmt.Println(wtPath)
+		return nil
+	}
+
+	u.Success(fmt.Sprintf("Created worktree %s", u.Bold(branch)))
+	u.Info(fmt.Sprintf("  path:   %s", u.Dim(wtPath)))
+	if baseBranch != "" {
+		u.Info(fmt.Sprintf("  base:   %s", u.Dim("origin/"+baseBranch)))
+	}
+	return nil
+}
+
+var prURLPattern = regexp.MustCompile(`github\.com/.+/pull/\d+`)
+
+func isPRURL(s string) bool {
+	return prURLPattern.MatchString(s)
+}
+
+func resolvePRBranch(input, bareDir string) (string, bool) {
+	ghPath, err := exec.LookPath("gh")
+	if err != nil {
+		return "", false
+	}
+
+	cmd := exec.Command(ghPath, "pr", "view", input, "--json", "headRefName", "-q", ".headRefName")
+	cmd.Dir = bareDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+
+	branch := strings.TrimSpace(string(out))
+	if branch == "" {
+		return "", false
+	}
+	return branch, true
+}
+
+func pickExistingBranch(repoGit *git.Git) (string, error) {
+	remoteBranches, err := repoGit.RemoteBranches()
+	if err != nil {
+		return "", fmt.Errorf("failed to list remote branches: %w", err)
+	}
+	if len(remoteBranches) == 0 {
+		return "", fmt.Errorf("no remote branches found")
+	}
+
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		return "", fmt.Errorf("failed to list worktrees: %w", err)
+	}
+	wtBranches := make(map[string]bool)
+	for _, wt := range wts {
+		if !wt.IsBare {
+			wtBranches[wt.Branch] = true
+		}
+	}
+
+	var available []string
+	for _, b := range remoteBranches {
+		if !wtBranches[b] {
+			available = append(available, b)
+		}
+	}
+	if len(available) == 0 {
+		return "", fmt.Errorf("all remote branches already have worktrees")
+	}
+
+	selected, err := fzf.Run(available,
+		fzf.WithReverse(),
+		fzf.WithHeader("Select a branch to check out"),
+	)
+	if err != nil {
+		return "", err
+	}
+	return selected, nil
 }

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -86,8 +86,8 @@ func tmuxPickCmd() *cli.Command {
 					fzf.WithAnsi(),
 					fzf.WithReverse(),
 					fzf.WithNoSort(),
-					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-D: Delete"),
-					fzf.WithExpectKeys("ctrl-n", "ctrl-d"),
+					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-E: Existing | Ctrl-D: Delete"),
+					fzf.WithExpectKeys("ctrl-n", "ctrl-e", "ctrl-d"),
 					fzf.WithPrintQuery(),
 					fzf.WithBind(fmt.Sprintf("start:reload-sync(%s)", reloadCmd)),
 				}
@@ -111,6 +111,13 @@ func tmuxPickCmd() *cli.Command {
 				switch result.Key {
 				case "ctrl-n":
 					if err := tmuxPickNew(self, result.Query, repoFilter, items); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						continue
+					}
+					return nil
+
+				case "ctrl-e":
+					if err := tmuxPickExisting(self, repoFilter, items); err != nil {
 						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 						continue
 					}
@@ -214,6 +221,42 @@ func tmuxPickNew(self, query, repoFilter string, items []tmux.PickerItem) error 
 	}
 
 	// Path format: ~/.willow/worktrees/<repo>/<dir>
+	wtDir := filepath.Base(wtPath)
+	repoName := filepath.Base(filepath.Dir(wtPath))
+
+	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
+	if !tmux.SessionExists(sessName) {
+		cfg := loadRepoConfig(repoName)
+		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
+			return fmt.Errorf("failed to create session: %w", err)
+		}
+	}
+
+	return tmux.SwitchClient(sessName)
+}
+
+func tmuxPickExisting(self, repoFilter string, items []tmux.PickerItem) error {
+	repo, err := resolveRepo(repoFilter, items)
+	if err != nil {
+		return err
+	}
+
+	// Calls `ww new -e --cd --repo <repo>` with no branch arg to trigger the picker
+	args := []string{"new", "-e", "--cd", "--repo", repo}
+
+	cmd := exec.Command(self, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to create worktree: %w", err)
+	}
+
+	wtPath := strings.TrimSpace(string(out))
+	if wtPath == "" {
+		return nil // user cancelled the picker
+	}
+
 	wtDir := filepath.Base(wtPath)
 	repoName := filepath.Base(filepath.Dir(wtPath))
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -118,6 +118,27 @@ func (g *Git) MergedBranches(base string) ([]string, error) {
 	return branches, nil
 }
 
+// RemoteBranches returns remote branch names from origin, stripping the
+// "origin/" prefix. The HEAD pointer is excluded.
+func (g *Git) RemoteBranches() ([]string, error) {
+	out, err := g.Run("branch", "-r", "--format=%(refname:short)")
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+	var branches []string
+	for _, b := range strings.Split(out, "\n") {
+		b = strings.TrimSpace(b)
+		if b == "" || b == "origin/HEAD" || strings.HasSuffix(b, "/HEAD") {
+			continue
+		}
+		branches = append(branches, strings.TrimPrefix(b, "origin/"))
+	}
+	return branches, nil
+}
+
 func (g *Git) HasUnpushedCommits() (bool, error) {
 	out, err := g.Run("rev-list", "--count", "@{upstream}..HEAD")
 	if err != nil {


### PR DESCRIPTION
## Description of the change

Adds support for creating worktrees from existing branches and GitHub PR URLs:

- **`ww new -e`** (no branch arg) — opens fzf picker showing remote branches that don't already have worktrees
- **`ww new -e <branch>`** — fixed to skip branch prefix and fetch the target branch (not base branch)
- **`ww new <PR-URL>`** — auto-detects GitHub PR URLs, resolves the branch via `gh`, and creates a worktree
- **Ctrl-E** in `ww tmux pick` — opens the existing-branch picker, creates worktree + tmux session
- **Ctrl-N** in tmux picker — now handles PR URLs transparently (paste URL, hit Ctrl-N)

Also fixes bugs in `--existing` mode: branch prefix was wrongly applied, and base branch was fetched instead of the target branch.

## Test plan

- Unit tests: `TestIsPRURL` for URL pattern detection
- Integration tests: `TestNew_ExistingBranch`, `TestNew_ExistingBranchSkipsPrefix`
- Live tested: bare-cloned willow, created worktree from PR #62 URL, verified correct branch + content