### PR TITLE
🎨 style(tmux): inline branch picker for Ctrl-E and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,14 @@ ww clone git@github.com:org/repo.git --force    # re-clone from scratch
 
 ### `ww new <branch> [flags]`
 
-Create a new worktree with a new branch.
+Create a new worktree with a new branch, an existing branch, or a GitHub PR.
 
 ```bash
 ww new feature/auth                    # create worktree
 ww new feature/auth -b develop         # fork from specific branch
 ww new -e existing-branch              # use existing branch
+ww new -e                              # pick from remote branches (fzf)
+ww new https://github.com/org/repo/pull/123  # checkout a PR
 ww new feature/auth -r myrepo          # target a specific repo
 wwn feature/auth                       # create + cd (shell integration)
 ```
@@ -157,7 +159,7 @@ wwn feature/auth                       # create + cd (shell integration)
 |------|-------------|
 | `-b, --base` | Base branch to fork from |
 | `-r, --repo` | Target repo by name |
-| `-e, --existing` | Use an existing branch |
+| `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) |
 | `--no-fetch` | Skip fetching from remote |
 | `--cd` | Print only the path (for scripting) |
 

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -241,11 +241,56 @@ func tmuxPickExisting(self, repoFilter string, items []tmux.PickerItem) error {
 		return err
 	}
 
-	// Calls `ww new -e --cd --repo <repo>` with no branch arg to trigger the picker
-	args := []string{"new", "-e", "--cd", "--repo", repo}
+	bareDir, err := config.ResolveRepo(repo)
+	if err != nil {
+		return err
+	}
 
+	repoGit := &git.Git{Dir: bareDir}
+	remoteBranches, err := repoGit.RemoteBranches()
+	if err != nil {
+		return fmt.Errorf("failed to list remote branches: %w", err)
+	}
+	if len(remoteBranches) == 0 {
+		return fmt.Errorf("no remote branches found")
+	}
+
+	// Filter out branches that already have worktrees
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		return fmt.Errorf("failed to list worktrees: %w", err)
+	}
+	wtBranches := make(map[string]bool)
+	for _, wt := range wts {
+		if !wt.IsBare {
+			wtBranches[wt.Branch] = true
+		}
+	}
+	var available []string
+	for _, b := range remoteBranches {
+		if !wtBranches[b] {
+			available = append(available, b)
+		}
+	}
+	if len(available) == 0 {
+		return fmt.Errorf("all remote branches already have worktrees")
+	}
+
+	// Pick branch in-process (no nested shell-out)
+	branch, err := fzf.Run(available,
+		fzf.WithReverse(),
+		fzf.WithHeader("Select a branch to check out"),
+	)
+	if err != nil {
+		return err
+	}
+	if branch == "" {
+		return nil // user cancelled
+	}
+
+	// Create worktree via `ww new -e --cd`
+	args := []string{"new", "-e", "--cd", "--repo", repo, "--", branch}
 	cmd := exec.Command(self, args...)
-	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
@@ -254,7 +299,7 @@ func tmuxPickExisting(self, repoFilter string, items []tmux.PickerItem) error {
 
 	wtPath := strings.TrimSpace(string(out))
 	if wtPath == "" {
-		return nil // user cancelled the picker
+		return fmt.Errorf("no path returned from willow new")
 	}
 
 	wtDir := filepath.Base(wtPath)

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -25,12 +25,14 @@ ww clone git@github.com:org/repo.git --force    # re-clone from scratch
 
 ## `ww new <branch> [flags]`
 
-Create a new worktree with a new branch.
+Create a new worktree with a new branch, an existing branch, or a GitHub PR.
 
 ```bash
 ww new feature/auth                    # create worktree
 ww new feature/auth -b develop         # fork from specific branch
 ww new -e existing-branch              # use existing branch
+ww new -e                              # pick from remote branches (fzf)
+ww new https://github.com/org/repo/pull/123  # checkout a PR
 ww new feature/auth -r myrepo          # target a specific repo
 wwn feature/auth                       # create + cd (shell integration)
 ```
@@ -39,9 +41,23 @@ wwn feature/auth                       # create + cd (shell integration)
 |------|-------------|---------|
 | `-b, --base` | Base branch to fork from | Config default / auto-detected |
 | `-r, --repo` | Target repo by name | Auto-detected from cwd |
-| `-e, --existing` | Use an existing branch | `false` |
+| `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) | `false` |
 | `--no-fetch` | Skip fetching from remote | `false` |
 | `--cd` | Print only the path (for scripting) | `false` |
+
+### Existing branch picker
+
+Running `ww new -e` without a branch name opens an fzf picker showing all remote branches that don't already have worktrees. Select one to create a worktree for it.
+
+### GitHub PR support
+
+Pass a GitHub PR URL as the branch argument and willow will resolve the branch name via `gh`, fetch it, and create the worktree. Requires the [GitHub CLI](https://cli.github.com/) (`gh`).
+
+```bash
+ww new https://github.com/org/repo/pull/123
+```
+
+This also works from the tmux picker — paste a PR URL and press `Ctrl-N`.
 
 ## `ww sw`
 

--- a/website/docs/tmux/index.md
+++ b/website/docs/tmux/index.md
@@ -31,9 +31,18 @@ The right panel shows a live preview of the tmux pane content (Claude Code outpu
 | Key | Action |
 |-----|--------|
 | `Enter` | Switch to worktree (creates tmux session if needed) |
-| `Ctrl-N` | Create new worktree from typed query |
+| `Ctrl-N` | Create new worktree from typed query (also accepts PR URLs) |
+| `Ctrl-E` | Browse existing remote branches and create a worktree |
 | `Ctrl-D` | Delete selected worktree and its tmux session |
 | `Esc` | Close picker |
+
+### GitHub PR support
+
+Paste a GitHub PR URL into the picker's query field and press `Ctrl-N`. Willow resolves the branch via `gh` and creates a worktree for it — no need to look up the branch name manually. Requires the [GitHub CLI](https://cli.github.com/).
+
+### Existing branch picker
+
+Press `Ctrl-E` to open a secondary picker showing all remote branches that don't already have worktrees. Select one to create a worktree and switch to it immediately.
 
 ### Features
 


### PR DESCRIPTION
## Description of the change

Follow-up to #63. Two changes:

1. **Smoother Ctrl-E in tmux picker** — the branch picker now runs in-process instead of shelling out to `ww new -e` (which spawned a nested fzf). No more blank flash between pickers.

2. **Docs** — updated README, website commands page, and tmux integration page to document `ww new -e` picker, PR URL support, and the new Ctrl-E / Ctrl-N keybindings.

## Test plan

- `go test ./...` all passing
- Manual: verified build compiles