### PR TITLE
✨ feat(checkout): smart switch-or-create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ This gives you:
 | `ww <cmd>` | Alias for `willow` |
 | `ww sw` | fzf worktree switcher (cd's into selection) |
 | `wwn <branch>` | Create worktree + cd into it |
+| `wwc <branch>` | Smart checkout + cd (switch or create) |
 | `www` | cd to `~/.willow/worktrees/` |
 
 **Optional:** Set terminal tab title to the current worktree name:
@@ -160,6 +161,25 @@ wwn feature/auth                       # create + cd (shell integration)
 | `-b, --base` | Base branch to fork from |
 | `-r, --repo` | Target repo by name |
 | `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) |
+| `--no-fetch` | Skip fetching from remote |
+| `--cd` | Print only the path (for scripting) |
+
+### `ww checkout <branch-or-pr-url>` (alias: `co`)
+
+Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree.
+
+```bash
+ww checkout auth-refactor                # switch if exists, create if not
+ww checkout https://github.com/org/repo/pull/123  # checkout a PR
+ww checkout brand-new-feature            # creates new branch + worktree
+ww checkout brand-new -b develop         # new branch from develop
+wwc auth-refactor                        # checkout + cd (shell integration)
+```
+
+| Flag | Description |
+|------|-------------|
+| `-r, --repo` | Target repo by name |
+| `-b, --base` | Base branch (only when creating a new branch) |
 | `--no-fetch` | Skip fetching from remote |
 | `--cd` | Print only the path (for scripting) |
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -80,6 +80,7 @@ func NewApp() *cli.Command {
 		Commands: []*cli.Command{
 			cloneCmd(),
 			newCmd(),
+			checkoutCmd(),
 			swCmd(),
 			rmCmd(),
 			lsCmd(),

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -1,0 +1,199 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/trace"
+	"github.com/urfave/cli/v3"
+)
+
+func checkoutCmd() *cli.Command {
+	return &cli.Command{
+		Name:          "checkout",
+		Aliases:       []string{"co"},
+		Usage:         "Switch to a worktree, or create one if it doesn't exist",
+		ShellComplete: completeWorktreesWithFlag,
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "branch",
+				UsageText: "<branch-or-pr-url>",
+			},
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target a willow-managed repo by name",
+			},
+			&cli.StringFlag{
+				Name:    "base",
+				Aliases: []string{"b"},
+				Usage:   "Base branch (only when creating a new branch)",
+			},
+			&cli.BoolFlag{
+				Name:  "no-fetch",
+				Usage: "Skip fetching latest from remote",
+			},
+			&cli.BoolFlag{
+				Name:  "cd",
+				Usage: "Print only the worktree path to stdout",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			tr := trace.New(flags.Trace)
+			g := flags.NewGit()
+			u := flags.NewUI()
+			cdOnly := cmd.Bool("cd")
+
+			branch := cmd.StringArg("branch")
+			if branch == "" {
+				return fmt.Errorf("branch name or PR URL is required\n\nUsage: ww checkout <branch-or-pr-url>")
+			}
+
+			// Resolve repos
+			done := tr.Start("resolve repos")
+			repos, err := resolveRepos(g, cmd.String("repo"))
+			if err != nil {
+				return err
+			}
+			done()
+
+			// PR URL auto-detection
+			if isPRURL(branch) {
+				done = tr.Start("resolve PR branch")
+				// Use first repo's bare dir for gh context
+				prBranch, ok := resolvePRBranch(branch, repos[0].BareDir)
+				if !ok {
+					return fmt.Errorf("failed to resolve branch from PR URL: %s\n\nEnsure 'gh' is installed and you're authenticated", branch)
+				}
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Resolved PR to branch %s\n", prBranch)
+				} else {
+					u.Info(fmt.Sprintf("Resolved PR to branch %s", u.Bold(prBranch)))
+				}
+				branch = prBranch
+				done()
+			}
+
+			// Step 1: Check if a worktree already exists for this branch
+			done = tr.Start("find existing worktree")
+			allWts := collectAllWorktrees(repos, g.Verbose)
+			rwt, _ := findCrossRepoWorktree(allWts, branch)
+			done()
+
+			if rwt != nil {
+				// Switch mode — worktree exists
+				wtDir := filepath.Base(rwt.Worktree.Path)
+				claude.MarkRead(rwt.Repo.Name, wtDir)
+
+				if cdOnly {
+					fmt.Println(rwt.Worktree.Path)
+					return nil
+				}
+
+				u.Success(fmt.Sprintf("Switched to %s", u.Bold(branch)))
+				u.Info(fmt.Sprintf("  path:   %s", u.Dim(rwt.Worktree.Path)))
+				fmt.Println(rwt.Worktree.Path)
+				return nil
+			}
+
+			// Step 2: No worktree found — need to create one.
+			// Resolve to a single repo.
+			done = tr.Start("resolve single repo")
+			if len(repos) > 1 {
+				return fmt.Errorf("multiple repos found — use --repo to specify which one")
+			}
+			repo := repos[0]
+			done()
+
+			done = tr.Start("load config")
+			cfg := config.Load(repo.BareDir)
+			done()
+
+			repoGit := &git.Git{Dir: repo.BareDir, Verbose: g.Verbose}
+
+			// Fetch to ensure we have the latest remote refs
+			shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch")
+
+			// Step 3: Check if branch exists on remote
+			if shouldFetch {
+				done = tr.Start("git fetch")
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Fetching from origin...\n")
+					repoGit.RunStream(os.Stderr, "fetch", "--progress", "origin")
+				} else {
+					u.Info("Fetching from origin...")
+					repoGit.Run("fetch", "origin")
+				}
+				done()
+			}
+
+			if repoGit.RemoteBranchExists(branch) {
+				// Existing branch — create worktree for it
+				dirName := strings.ReplaceAll(branch, "/", "-")
+				wtPath := filepath.Join(config.WorktreesDir(), repo.Name, dirName)
+
+				done = tr.Start("git worktree add (existing)")
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Creating worktree for existing branch %s...\n", branch)
+					if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, branch); err != nil {
+						return fmt.Errorf("failed to create worktree: %w", err)
+					}
+				} else {
+					u.Info(fmt.Sprintf("Creating worktree for existing branch %s...", u.Bold(branch)))
+					if _, err := repoGit.Run("worktree", "add", wtPath, branch); err != nil {
+						return fmt.Errorf("failed to create worktree: %w", err)
+					}
+				}
+				done()
+
+				return finishWorktree(tr, cfg, g, u, wtPath, repo.Name, branch, "", cdOnly)
+			}
+
+			// New branch — apply prefix, resolve base, create
+			if cfg.BranchPrefix != "" && !strings.HasPrefix(branch, cfg.BranchPrefix+"/") {
+				branch = cfg.BranchPrefix + "/" + branch
+			}
+
+			done = tr.Start("resolve base branch")
+			baseBranch := cmd.String("base")
+			if baseBranch == "" {
+				baseBranch = cfg.BaseBranch
+			}
+			if baseBranch == "" {
+				baseBranch, err = repoGit.DefaultBranch()
+				if err != nil {
+					return fmt.Errorf("failed to detect default branch (use --base to specify): %w", err)
+				}
+			}
+			done()
+
+			dirName := strings.ReplaceAll(branch, "/", "-")
+			wtPath := filepath.Join(config.WorktreesDir(), repo.Name, dirName)
+
+			done = tr.Start("git worktree add (new)")
+			if cdOnly {
+				fmt.Fprintf(os.Stderr, "Creating worktree %s from %s...\n", branch, "origin/"+baseBranch)
+				if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+					return fmt.Errorf("failed to create worktree: %w", err)
+				}
+			} else {
+				u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold("origin/"+baseBranch)))
+				if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+					return fmt.Errorf("failed to create worktree: %w", err)
+				}
+			}
+			done()
+
+			return finishWorktree(tr, cfg, g, u, wtPath, repo.Name, branch, baseBranch, cdOnly)
+		},
+	}
+}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -674,6 +674,118 @@ func TestIsPRURL(t *testing.T) {
 	}
 }
 
+func TestCheckout_SwitchesToExistingWorktree(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "branch-a", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	// checkout should switch to the existing worktree (print its path)
+	if err := runApp("checkout", "branch-a", "--cd"); err != nil {
+		t.Fatalf("checkout failed: %v", err)
+	}
+}
+
+func TestCheckout_CreatesWorktreeForExistingBranch(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+
+	// Create and push a branch to origin
+	wg := &git.Git{Dir: mainDir}
+	if _, err := wg.Run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("git config email: %v", err)
+	}
+	if _, err := wg.Run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("git config name: %v", err)
+	}
+	if _, err := wg.Run("checkout", "-b", "remote-only"); err != nil {
+		t.Fatalf("create branch: %v", err)
+	}
+	os.WriteFile(filepath.Join(mainDir, "remote.txt"), []byte("remote\n"), 0o644)
+	if _, err := wg.Run("add", "."); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if _, err := wg.Run("commit", "-m", "remote commit"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	if _, err := wg.Run("push", "origin", "remote-only"); err != nil {
+		t.Fatalf("git push: %v", err)
+	}
+	if _, err := wg.Run("checkout", "-"); err != nil {
+		t.Fatalf("git checkout: %v", err)
+	}
+
+	os.Chdir(mainDir)
+
+	// checkout should detect the remote branch and create a worktree
+	if err := runApp("checkout", "remote-only", "--no-fetch"); err != nil {
+		t.Fatalf("checkout failed: %v", err)
+	}
+
+	newWtDir := filepath.Join(worktreeDir, "remote-only")
+	if _, err := os.Stat(newWtDir); os.IsNotExist(err) {
+		t.Errorf("worktree not created at %s", newWtDir)
+	}
+
+	// Verify content
+	if _, err := os.Stat(filepath.Join(newWtDir, "remote.txt")); os.IsNotExist(err) {
+		t.Error("remote.txt not found — existing branch content not checked out")
+	}
+}
+
+func TestCheckout_CreatesNewBranch(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("checkout", "brand-new", "--no-fetch"); err != nil {
+		t.Fatalf("checkout failed: %v", err)
+	}
+
+	newWtDir := filepath.Join(worktreeDir, "brand-new")
+	if _, err := os.Stat(newWtDir); os.IsNotExist(err) {
+		t.Errorf("worktree not created at %s", newWtDir)
+	}
+
+	// Verify the branch was created
+	bareDir := filepath.Join(home, ".willow", "repos", "testrepo.git")
+	repoGit := &git.Git{Dir: bareDir}
+	out, err := repoGit.Run("branch", "--list", "brand-new")
+	if err != nil {
+		t.Fatalf("git branch --list: %v", err)
+	}
+	if out == "" {
+		t.Error("branch 'brand-new' not found")
+	}
+}
+
 func TestGc_EmptyTrash(t *testing.T) {
 	setupTestEnv(t)
 

--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -43,6 +43,16 @@ ww() {
     cd "$dir" || return
     return
   fi
+  if [ "$1" = "checkout" ] || [ "$1" = "co" ]; then
+    local dir
+    dir="$(command willow checkout "${@:2}" --cd)" || return
+    if [ -n "$TMUX" ] && [ -n "$dir" ]; then
+      command willow tmux sw "$dir"
+      return
+    fi
+    cd "$dir" || return
+    return
+  fi
   if [ "$1" = "rm" ]; then
     local cwd="$PWD"
     command willow "$@"
@@ -58,6 +68,12 @@ ww() {
 wwn() {
   local dir
   dir="$(willow new "$@" --cd)" || return
+  cd "$dir" || return
+}
+
+wwc() {
+  local dir
+  dir="$(willow checkout "$@" --cd)" || return
   cd "$dir" || return
 }
 
@@ -130,6 +146,16 @@ ww() {
     cd "$dir" || return
     return
   fi
+  if [ "$1" = "checkout" ] || [ "$1" = "co" ]; then
+    local dir
+    dir="$(command willow checkout "${@:2}" --cd)" || return
+    if [ -n "$TMUX" ] && [ -n "$dir" ]; then
+      command willow tmux sw "$dir"
+      return
+    fi
+    cd "$dir" || return
+    return
+  fi
   if [ "$1" = "rm" ]; then
     local cwd="$PWD"
     command willow "$@"
@@ -145,6 +171,12 @@ ww() {
 wwn() {
   local dir
   dir="$(willow new "$@" --cd)" || return
+  cd "$dir" || return
+}
+
+wwc() {
+  local dir
+  dir="$(willow checkout "$@" --cd)" || return
   cd "$dir" || return
 }
 
@@ -206,6 +238,16 @@ function ww
     cd $dir
     return
   end
+  if test (count $argv) -gt 0; and test "$argv[1]" = "checkout" -o "$argv[1]" = "co"
+    set -l dir (command willow checkout $argv[2..] --cd)
+    or return
+    if test -n "$TMUX"; and test -n "$dir"
+      command willow tmux sw "$dir"
+      return
+    end
+    cd $dir
+    return
+  end
   if test (count $argv) -gt 0; and test "$argv[1]" = "rm"
     set -l cwd $PWD
     command willow $argv
@@ -222,6 +264,12 @@ end
 
 function wwn
   set -l dir (willow new $argv --cd)
+  or return
+  cd $dir
+end
+
+function wwc
+  set -l dir (willow checkout $argv --cd)
   or return
   cd $dir
 end

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -139,6 +139,12 @@ func (g *Git) RemoteBranches() ([]string, error) {
 	return branches, nil
 }
 
+// RemoteBranchExists checks if a branch exists on origin.
+func (g *Git) RemoteBranchExists(branch string) bool {
+	out, _ := g.Run("branch", "-r", "--list", "origin/"+branch)
+	return strings.TrimSpace(out) != ""
+}
+
 func (g *Git) HasUnpushedCommits() (bool, error) {
 	out, err := g.Run("rev-list", "--count", "@{upstream}..HEAD")
 	if err != nil {

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -59,6 +59,30 @@ ww new https://github.com/org/repo/pull/123
 
 This also works from the tmux picker — paste a PR URL and press `Ctrl-N`.
 
+## `ww checkout <branch-or-pr-url>` (alias: `co`)
+
+Smart switch-or-create. Figures out the right action based on what exists:
+
+1. **Worktree exists** for that branch → switch to it (like `ww sw`)
+2. **Branch exists on remote** but no worktree → create a worktree for it (like `ww new -e`)
+3. **Branch doesn't exist** → create a new branch + worktree (like `ww new`)
+4. **PR URL** → resolve the branch via `gh`, then apply the logic above
+
+```bash
+ww checkout auth-refactor                # switch if exists, create if not
+ww checkout https://github.com/org/repo/pull/123  # checkout a PR
+ww checkout brand-new-feature            # creates new branch + worktree
+ww checkout brand-new -b develop         # new branch forked from develop
+wwc auth-refactor                        # checkout + cd (shell integration)
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-r, --repo` | Target repo by name | Auto-detected from cwd |
+| `-b, --base` | Base branch (only when creating a new branch) | Config default / auto-detected |
+| `--no-fetch` | Skip fetching from remote | `false` |
+| `--cd` | Print only the path (for scripting) | `false` |
+
 ## `ww sw`
 
 Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by activity.
@@ -206,6 +230,7 @@ Setup: `ww tmux install` prints the config to add to `~/.tmux.conf`, including a
 | Alias | Command |
 |-------|---------|
 | `ww n` | `ww new` |
+| `ww co` | `ww checkout` |
 | `ww l` | `ww ls` |
 | `ww s` | `ww status` |
 | `ww dash` / `ww d` | `ww dashboard` |


### PR DESCRIPTION
## Description of the change

Adds `ww checkout <branch-or-pr-url>` (alias: `co`) — a single command that figures out the right action:

1. **Worktree exists** → switch to it (like `ww sw`)
2. **Branch exists on remote** → create worktree for it (like `ww new -e`)
3. **Branch doesn't exist** → create new branch + worktree (like `ww new`)
4. **PR URL** → resolve branch via `gh`, then apply the logic above

Also adds shell integration: `wwc <branch>` for checkout + cd, and `ww checkout`/`ww co` with tmux session support.

## Test plan

- Integration tests: `TestCheckout_SwitchesToExistingWorktree`, `TestCheckout_CreatesWorktreeForExistingBranch`, `TestCheckout_CreatesNewBranch`
- Full test suite passing on local