### PR TITLE
✨ feat: --pr flag, Ctrl-P PR picker, merged worktree indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ ww new feature/auth                    # create worktree
 ww new feature/auth -b develop         # fork from specific branch
 ww new -e existing-branch              # use existing branch
 ww new -e                              # pick from remote branches (fzf)
-ww new https://github.com/org/repo/pull/123  # checkout a PR
+ww new --pr 123                        # checkout PR #123
+ww new https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww new feature/auth -r myrepo          # target a specific repo
 wwn feature/auth                       # create + cd (shell integration)
 ```
@@ -161,16 +162,18 @@ wwn feature/auth                       # create + cd (shell integration)
 | `-b, --base` | Base branch to fork from |
 | `-r, --repo` | Target repo by name |
 | `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) |
+| `--pr` | GitHub PR number or URL |
 | `--no-fetch` | Skip fetching from remote |
 | `--cd` | Print only the path (for scripting) |
 
 ### `ww checkout <branch-or-pr-url>` (alias: `co`)
 
-Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree.
+Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree. Merged worktrees show a `[merged]` indicator in `ww ls` and the tmux picker.
 
 ```bash
 ww checkout auth-refactor                # switch if exists, create if not
-ww checkout https://github.com/org/repo/pull/123  # checkout a PR
+ww checkout --pr 123                     # checkout PR #123
+ww checkout https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww checkout brand-new-feature            # creates new branch + worktree
 ww checkout brand-new -b develop         # new branch from develop
 wwc auth-refactor                        # checkout + cd (shell integration)
@@ -180,6 +183,7 @@ wwc auth-refactor                        # checkout + cd (shell integration)
 |------|-------------|
 | `-r, --repo` | Target repo by name |
 | `-b, --base` | Base branch (only when creating a new branch) |
+| `--pr` | GitHub PR number or URL |
 | `--no-fetch` | Skip fetching from remote |
 | `--cd` | Print only the path (for scripting) |
 

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -45,6 +45,10 @@ func checkoutCmd() *cli.Command {
 				Name:  "cd",
 				Usage: "Print only the worktree path to stdout",
 			},
+			&cli.StringFlag{
+				Name:  "pr",
+				Usage: "GitHub PR number or URL",
+			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
@@ -54,9 +58,6 @@ func checkoutCmd() *cli.Command {
 			cdOnly := cmd.Bool("cd")
 
 			branch := cmd.StringArg("branch")
-			if branch == "" {
-				return fmt.Errorf("branch name or PR URL is required\n\nUsage: ww checkout <branch-or-pr-url>")
-			}
 
 			// Resolve repos
 			done := tr.Start("resolve repos")
@@ -66,11 +67,26 @@ func checkoutCmd() *cli.Command {
 			}
 			done()
 
-			// PR URL auto-detection
-			if isPRURL(branch) {
+			// --pr flag: resolve PR number or URL to branch name
+			if prRef := cmd.String("pr"); prRef != "" {
+				done = tr.Start("resolve PR")
+				prBranch, ok := resolvePRRef(prRef, repos[0].BareDir)
+				if !ok {
+					return fmt.Errorf("failed to resolve PR: %s\n\nEnsure 'gh' is installed and you're authenticated", prRef)
+				}
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Resolved PR to branch %s\n", prBranch)
+				} else {
+					u.Info(fmt.Sprintf("Resolved PR to branch %s", u.Bold(prBranch)))
+				}
+				branch = prBranch
+				done()
+			}
+
+			// PR URL auto-detection in branch arg
+			if branch != "" && isPRURL(branch) {
 				done = tr.Start("resolve PR branch")
-				// Use first repo's bare dir for gh context
-				prBranch, ok := resolvePRBranch(branch, repos[0].BareDir)
+				prBranch, ok := resolvePRRef(branch, repos[0].BareDir)
 				if !ok {
 					return fmt.Errorf("failed to resolve branch from PR URL: %s\n\nEnsure 'gh' is installed and you're authenticated", branch)
 				}
@@ -81,6 +97,10 @@ func checkoutCmd() *cli.Command {
 				}
 				branch = prBranch
 				done()
+			}
+
+			if branch == "" {
+				return fmt.Errorf("branch name or PR URL is required\n\nUsage: ww checkout <branch-or-pr-url>")
 			}
 
 			// Step 1: Check if a worktree already exists for this branch

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -88,7 +88,7 @@ func listWorktrees(flags Flags, cmd *cli.Command, repoGit *git.Git) error {
 	}
 
 	repoName := repoNameFromDir(repoGit.Dir)
-	printTable(flags, filtered, repoName)
+	printTable(flags, filtered, repoName, repoGit)
 	return nil
 }
 
@@ -163,7 +163,7 @@ func completeRepos(ctx context.Context, cmd *cli.Command) {
 	}
 }
 
-func printTable(flags Flags, worktrees []worktree.Worktree, repoName string) {
+func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, repoGit *git.Git) {
 	u := flags.NewUI()
 
 	if len(worktrees) == 0 {
@@ -171,13 +171,29 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string) {
 		return
 	}
 
+	// Detect merged branches
+	cfg := config.Load(repoGit.Dir)
+	baseBranch := cfg.BaseBranch
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	mergedBranches, _ := repoGit.MergedBranches(baseBranch)
+	mergedSet := make(map[string]bool)
+	for _, b := range mergedBranches {
+		mergedSet[b] = true
+	}
+
 	branchW := len("BRANCH")
 	statusW := len("STATUS")
 	pathW := len("PATH")
 	ageW := len("AGE")
 	for _, wt := range worktrees {
-		if len(wt.Branch) > branchW {
-			branchW = len(wt.Branch)
+		display := wt.Branch
+		if mergedSet[wt.Branch] {
+			display += " [merged]"
+		}
+		if len(display) > branchW {
+			branchW = len(display)
 		}
 		if len(wt.Path) > pathW {
 			pathW = len(wt.Path)
@@ -199,9 +215,13 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string) {
 		if ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir) {
 			statusLabel += "\u25CF" // ●
 		}
+		branchDisplay := wt.Branch
+		if mergedSet[wt.Branch] {
+			branchDisplay += " " + u.Dim("[merged]")
+		}
 		pathPadded := fmt.Sprintf("%-*s", pathW, wt.Path)
 		agePadded := fmt.Sprintf("%*s", ageW, age)
-		line := fmt.Sprintf("  %-*s  %-*s  %s  %s", branchW, wt.Branch, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))
+		line := fmt.Sprintf("  %-*s  %-*s  %s  %s", branchW, branchDisplay, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))
 		u.Info(line)
 	}
 }

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -102,6 +102,10 @@ func newCmd() *cli.Command {
 				Name:  "cd",
 				Usage: "Print only the worktree path to stdout",
 			},
+			&cli.StringFlag{
+				Name:  "pr",
+				Usage: "GitHub PR number or URL",
+			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
@@ -137,10 +141,27 @@ func newCmd() *cli.Command {
 
 			branch := cmd.StringArg("branch")
 
-			// PR URL auto-detection: resolve to branch name and force existing mode
+			// --pr flag: resolve PR number or URL to branch name
+			if prRef := cmd.String("pr"); prRef != "" {
+				done = tr.Start("resolve PR")
+				prBranch, ok := resolvePRRef(prRef, bareDir)
+				if !ok {
+					return fmt.Errorf("failed to resolve PR: %s\n\nEnsure 'gh' is installed and you're authenticated", prRef)
+				}
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Resolved PR to branch %s\n", prBranch)
+				} else {
+					u.Info(fmt.Sprintf("Resolved PR to branch %s", u.Bold(prBranch)))
+				}
+				branch = prBranch
+				existing = true
+				done()
+			}
+
+			// PR URL auto-detection in branch arg
 			if branch != "" && isPRURL(branch) {
 				done = tr.Start("resolve PR branch")
-				prBranch, ok := resolvePRBranch(branch, bareDir)
+				prBranch, ok := resolvePRRef(branch, bareDir)
 				if !ok {
 					return fmt.Errorf("failed to resolve branch from PR URL: %s\n\nEnsure 'gh' is installed and you're authenticated", branch)
 				}
@@ -315,7 +336,9 @@ func isPRURL(s string) bool {
 	return prURLPattern.MatchString(s)
 }
 
-func resolvePRBranch(input, bareDir string) (string, bool) {
+// resolvePRRef resolves a PR reference (number like "123" or full URL) to a branch name.
+// Uses `gh pr view` which handles both forms natively.
+func resolvePRRef(input, bareDir string) (string, bool) {
 	ghPath, err := exec.LookPath("gh")
 	if err != nil {
 		return "", false

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -86,8 +86,8 @@ func tmuxPickCmd() *cli.Command {
 					fzf.WithAnsi(),
 					fzf.WithReverse(),
 					fzf.WithNoSort(),
-					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-E: Existing | Ctrl-D: Delete"),
-					fzf.WithExpectKeys("ctrl-n", "ctrl-e", "ctrl-d"),
+					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-D: Delete"),
+					fzf.WithExpectKeys("ctrl-n", "ctrl-e", "ctrl-p", "ctrl-d"),
 					fzf.WithPrintQuery(),
 					fzf.WithBind(fmt.Sprintf("start:reload-sync(%s)", reloadCmd)),
 				}
@@ -118,6 +118,13 @@ func tmuxPickCmd() *cli.Command {
 
 				case "ctrl-e":
 					if err := tmuxPickExisting(self, repoFilter, items); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						continue
+					}
+					return nil
+
+				case "ctrl-p":
+					if err := tmuxPickPR(self, repoFilter, items); err != nil {
 						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 						continue
 					}
@@ -314,6 +321,89 @@ func tmuxPickExisting(self, repoFilter string, items []tmux.PickerItem) error {
 	}
 
 	return tmux.SwitchClient(sessName)
+}
+
+func tmuxPickPR(self, repoFilter string, items []tmux.PickerItem) error {
+	repo, err := resolveRepo(repoFilter, items)
+	if err != nil {
+		return err
+	}
+
+	bareDir, err := config.ResolveRepo(repo)
+	if err != nil {
+		return err
+	}
+
+	ghPath, err := exec.LookPath("gh")
+	if err != nil {
+		return fmt.Errorf("gh CLI is required for PR picker")
+	}
+
+	cmd := exec.Command(ghPath, "pr", "list", "--json", "number,title,author,headRefName",
+		"-q", `.[] | "#\(.number)  \(.title)  (\(.author.login))  [\(.headRefName)]"`)
+	cmd.Dir = bareDir
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to list PRs: %w", err)
+	}
+
+	raw := strings.TrimSpace(string(out))
+	if raw == "" {
+		return fmt.Errorf("no open PRs found")
+	}
+	lines := strings.Split(raw, "\n")
+
+	selected, err := fzf.Run(lines,
+		fzf.WithReverse(),
+		fzf.WithHeader("Select a PR to check out"),
+	)
+	if err != nil {
+		return err
+	}
+	if selected == "" {
+		return nil
+	}
+
+	branch := extractBranchFromPRLine(selected)
+	if branch == "" {
+		return fmt.Errorf("could not extract branch from selection")
+	}
+
+	args := []string{"checkout", "--cd", "--repo", repo, "--", branch}
+	coCmd := exec.Command(self, args...)
+	coCmd.Stderr = os.Stderr
+	coOut, err := coCmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to checkout PR branch: %w", err)
+	}
+
+	wtPath := strings.TrimSpace(string(coOut))
+	if wtPath == "" {
+		return fmt.Errorf("no path returned from checkout")
+	}
+
+	wtDir := filepath.Base(wtPath)
+	repoName := filepath.Base(filepath.Dir(wtPath))
+
+	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
+	if !tmux.SessionExists(sessName) {
+		cfg := loadRepoConfig(repoName)
+		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
+			return fmt.Errorf("failed to create session: %w", err)
+		}
+	}
+
+	return tmux.SwitchClient(sessName)
+}
+
+// extractBranchFromPRLine parses "[branch-name]" from the end of a PR picker line.
+func extractBranchFromPRLine(line string) string {
+	start := strings.LastIndex(line, "[")
+	end := strings.LastIndex(line, "]")
+	if start == -1 || end == -1 || end <= start {
+		return ""
+	}
+	return line[start+1 : end]
 }
 
 func resolveRepo(repoFilter string, items []tmux.PickerItem) (string, error) {

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -31,6 +31,7 @@ type PickerItem struct {
 	Unread     bool
 	HasSession bool
 	Sessions   []*claude.SessionStatus
+	Merged     bool
 }
 
 func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
@@ -56,6 +57,19 @@ func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
 		if err != nil {
 			continue
 		}
+
+		// Detect merged branches for this repo
+		cfg := config.Load(bareDir)
+		baseBranch := cfg.BaseBranch
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+		mergedBranches, _ := repoGit.MergedBranches(baseBranch)
+		mergedSet := make(map[string]bool)
+		for _, b := range mergedBranches {
+			mergedSet[b] = true
+		}
+
 		for _, wt := range wts {
 			if wt.IsBare {
 				continue
@@ -73,12 +87,18 @@ func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
 				Unread:     ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir),
 				HasSession: SessionExists(sessName),
 				Sessions:   sessions,
+				Merged:     mergedSet[wt.Branch],
 			})
 		}
 	}
 
 	sort.SliceStable(items, func(i, j int) bool {
-		return statusOrder(items[i].Status) < statusOrder(items[j].Status)
+		oi, oj := statusOrder(items[i].Status), statusOrder(items[j].Status)
+		// Merged items sort last
+		if items[i].Merged != items[j].Merged {
+			return !items[i].Merged
+		}
+		return oi < oj
 	})
 
 	return items, nil
@@ -110,6 +130,9 @@ func FormatPickerLines(items []PickerItem) []string {
 		}
 
 		name := displayName(item, multiRepo)
+		if item.Merged {
+			name += fmt.Sprintf(" %s[merged]%s", colorDim, colorReset)
+		}
 
 		line := fmt.Sprintf("%s%s %s%s%s | %-*s | %s%s%s",
 			color, icon, label, dot, colorReset,

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -32,7 +32,8 @@ ww new feature/auth                    # create worktree
 ww new feature/auth -b develop         # fork from specific branch
 ww new -e existing-branch              # use existing branch
 ww new -e                              # pick from remote branches (fzf)
-ww new https://github.com/org/repo/pull/123  # checkout a PR
+ww new --pr 123                        # checkout PR #123
+ww new https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww new feature/auth -r myrepo          # target a specific repo
 wwn feature/auth                       # create + cd (shell integration)
 ```
@@ -42,6 +43,7 @@ wwn feature/auth                       # create + cd (shell integration)
 | `-b, --base` | Base branch to fork from | Config default / auto-detected |
 | `-r, --repo` | Target repo by name | Auto-detected from cwd |
 | `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) | `false` |
+| `--pr` | GitHub PR number or URL | |
 | `--no-fetch` | Skip fetching from remote | `false` |
 | `--cd` | Print only the path (for scripting) | `false` |
 
@@ -51,13 +53,14 @@ Running `ww new -e` without a branch name opens an fzf picker showing all remote
 
 ### GitHub PR support
 
-Pass a GitHub PR URL as the branch argument and willow will resolve the branch name via `gh`, fetch it, and create the worktree. Requires the [GitHub CLI](https://cli.github.com/) (`gh`).
+Use `--pr` with a PR number or pass a full PR URL as the branch argument. Willow resolves the branch name via `gh`, fetches it, and creates the worktree. Requires the [GitHub CLI](https://cli.github.com/) (`gh`).
 
 ```bash
-ww new https://github.com/org/repo/pull/123
+ww new --pr 123                              # by number
+ww new https://github.com/org/repo/pull/123  # by URL
 ```
 
-This also works from the tmux picker — paste a PR URL and press `Ctrl-N`.
+This also works from the tmux picker — press `Ctrl-P` for a dedicated PR picker, or paste a PR URL and press `Ctrl-N`.
 
 ## `ww checkout <branch-or-pr-url>` (alias: `co`)
 
@@ -70,7 +73,8 @@ Smart switch-or-create. Figures out the right action based on what exists:
 
 ```bash
 ww checkout auth-refactor                # switch if exists, create if not
-ww checkout https://github.com/org/repo/pull/123  # checkout a PR
+ww checkout --pr 123                     # checkout PR #123
+ww checkout https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww checkout brand-new-feature            # creates new branch + worktree
 ww checkout brand-new -b develop         # new branch forked from develop
 wwc auth-refactor                        # checkout + cd (shell integration)
@@ -80,6 +84,7 @@ wwc auth-refactor                        # checkout + cd (shell integration)
 |------|-------------|---------|
 | `-r, --repo` | Target repo by name | Auto-detected from cwd |
 | `-b, --base` | Base branch (only when creating a new branch) | Config default / auto-detected |
+| `--pr` | GitHub PR number or URL | |
 | `--no-fetch` | Skip fetching from remote | `false` |
 | `--cd` | Print only the path (for scripting) | `false` |
 

--- a/website/docs/tmux/index.md
+++ b/website/docs/tmux/index.md
@@ -33,16 +33,23 @@ The right panel shows a live preview of the tmux pane content (Claude Code outpu
 | `Enter` | Switch to worktree (creates tmux session if needed) |
 | `Ctrl-N` | Create new worktree from typed query (also accepts PR URLs) |
 | `Ctrl-E` | Browse existing remote branches and create a worktree |
+| `Ctrl-P` | Browse open PRs and create a worktree for the selected one |
 | `Ctrl-D` | Delete selected worktree and its tmux session |
 | `Esc` | Close picker |
 
-### GitHub PR support
+### PR picker
 
-Paste a GitHub PR URL into the picker's query field and press `Ctrl-N`. Willow resolves the branch via `gh` and creates a worktree for it — no need to look up the branch name manually. Requires the [GitHub CLI](https://cli.github.com/).
+Press `Ctrl-P` to list open PRs via `gh pr list`. Each line shows the PR number, title, author, and branch. Select one to create a worktree (or switch to it if one already exists). Requires the [GitHub CLI](https://cli.github.com/).
+
+You can also paste a PR URL into the query field and press `Ctrl-N` for quick one-off access.
 
 ### Existing branch picker
 
 Press `Ctrl-E` to open a secondary picker showing all remote branches that don't already have worktrees. Select one to create a worktree and switch to it immediately.
+
+### Merged worktree indicator
+
+Worktrees whose branches have been merged into the base branch show a dim `[merged]` tag. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up with `Ctrl-D` or `ww gc --prune`.
 
 ### Features
 
@@ -50,6 +57,7 @@ Press `Ctrl-E` to open a secondary picker showing all remote branches that don't
 - **Auto-navigate** — opens with the cursor on your current session
 - **Status colors** — BUSY (green), WAIT (red), DONE (blue), IDLE (yellow)
 - **Unread indicator** — `●` marks completed sessions you haven't viewed
+- **Merged indicator** — `[merged]` marks worktrees whose branches are merged
 - **Multi-Claude sub-rows** — when a worktree has multiple active Claude sessions, each is shown as an indented sub-row with its own status and tool info
 - **Embedded fzf** — fzf is compiled into the willow binary, no external `fzf` dependency needed
 


### PR DESCRIPTION
## Description of the change

Three features in one PR:

1. **`--pr` flag** — `ww new --pr 123` and `ww checkout --pr 123` resolve a PR number (or URL) against the current repo via `gh`. No need to paste the full URL.

2. **Ctrl-P in tmux picker** — dedicated PR picker. Press Ctrl-P to list open PRs via `gh pr list`, shows PR number, title, author, and branch in fzf. Select one to create a worktree (or switch if one exists).

3. **Merged worktree indicators** — worktrees whose branches have been merged into the base branch show a dim `[merged]` tag in `ww ls` and the tmux picker. Merged worktrees sort to the bottom.

## Test plan

- Full test suite passing (`go test ./...`)
- Manual: `ww new --pr <number>` resolves branch correctly
- Manual: Ctrl-P in tmux picker lists open PRs
- Manual: `ww ls` shows `[merged]` for merged branches