### PR TITLE
✨ feat: stacked worktrees, ww sync, and tree display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ CI runs this on both ubuntu and macos via `.github/workflows/test.yml`.
 - `internal/fzf/` - Embedded fzf wrapper (uses `github.com/junegunn/fzf` as a Go library, no external binary)
 - `internal/claude/` - Claude Code status tracking (hooks, session status, unread markers)
 - `internal/tmux/` - Tmux CLI primitives, picker logic, and notifications
+- `internal/stack/` - Stacked branch tracking (branches.json per repo, topo sort, tree display)
 - `internal/dashboard/` - Live TUI dashboard
 - `website/` - VitePress docs site (https://getwillow.dev)
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,34 @@ wwc auth-refactor                        # checkout + cd (shell integration)
 | `--no-fetch` | Skip fetching from remote |
 | `--cd` | Print only the path (for scripting) |
 
+### Stacked PRs
+
+Create stacked branches with `--base`:
+
+```bash
+ww new feature-a -b main              # start a stack
+ww new feature-b -b feature-a         # stack on top
+ww new feature-c -b feature-b         # third layer
+```
+
+Stacked branches are shown as a tree in `ww ls` and the tmux picker. Parent relationships are tracked in `branches.json` per repo.
+
+### `ww sync [branch]`
+
+Rebase stacked worktrees onto their parents in topological order.
+
+```bash
+ww sync                    # sync all stacks in current repo
+ww sync feature-b          # sync feature-b and its descendants only
+ww sync --abort            # abort any in-progress rebases
+```
+
+| Flag | Description |
+|------|-------------|
+| `-r, --repo` | Target repo by name |
+| `--no-fetch` | Skip fetching from remote |
+| `--abort` | Abort in-progress rebases |
+
 ### `ww sw`
 
 Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by activity.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -81,6 +81,7 @@ func NewApp() *cli.Command {
 			cloneCmd(),
 			newCmd(),
 			checkoutCmd(),
+			syncCmd(),
 			swCmd(),
 			rmCmd(),
 			lsCmd(),

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/urfave/cli/v3"
 )
@@ -196,21 +197,35 @@ func checkoutCmd() *cli.Command {
 			}
 			done()
 
+			// Local branch as base (for stacked PRs) or remote
+			localBase := repoGit.LocalBranchExists(baseBranch)
+			gitRef := "origin/" + baseBranch
+			if localBase {
+				gitRef = baseBranch
+			}
+
 			dirName := strings.ReplaceAll(branch, "/", "-")
 			wtPath := filepath.Join(config.WorktreesDir(), repo.Name, dirName)
 
 			done = tr.Start("git worktree add (new)")
 			if cdOnly {
-				fmt.Fprintf(os.Stderr, "Creating worktree %s from %s...\n", branch, "origin/"+baseBranch)
-				if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+				fmt.Fprintf(os.Stderr, "Creating worktree %s from %s...\n", branch, gitRef)
+				if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, "-b", branch, gitRef); err != nil {
 					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			} else {
-				u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold("origin/"+baseBranch)))
-				if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+				u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold(gitRef)))
+				if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, gitRef); err != nil {
 					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			}
+			done()
+
+			// Record parent in stack
+			done = tr.Start("record stack parent")
+			st := stack.Load(repo.BareDir)
+			st.SetParent(branch, baseBranch)
+			st.Save(repo.BareDir)
 			done()
 
 			return finishWorktree(tr, cfg, g, u, wtPath, repo.Name, branch, baseBranch, cdOnly)

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/iamrajjoshi/willow/internal/git"
@@ -671,6 +672,49 @@ func TestIsPRURL(t *testing.T) {
 		if got := isPRURL(tt.input); got != tt.want {
 			t.Errorf("isPRURL(%q) = %v, want %v", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestNew_StackedBranch(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	// Create feature-a from main
+	if err := runApp("new", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-a failed: %v", err)
+	}
+
+	// Create feature-b stacked on feature-a
+	if err := runApp("new", "feature-b", "-b", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-b -b feature-a failed: %v", err)
+	}
+
+	// Verify worktrees exist
+	if _, err := os.Stat(filepath.Join(worktreeDir, "feature-a")); os.IsNotExist(err) {
+		t.Error("feature-a worktree not created")
+	}
+	if _, err := os.Stat(filepath.Join(worktreeDir, "feature-b")); os.IsNotExist(err) {
+		t.Error("feature-b worktree not created")
+	}
+
+	// Verify stack was recorded
+	bareDir := filepath.Join(home, ".willow", "repos", "testrepo.git")
+	data, err := os.ReadFile(filepath.Join(bareDir, "branches.json"))
+	if err != nil {
+		t.Fatalf("branches.json not found: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "feature-a") || !strings.Contains(content, "feature-b") {
+		t.Errorf("branches.json missing expected entries: %s", content)
 	}
 }
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
@@ -163,6 +164,13 @@ func completeRepos(ctx context.Context, cmd *cli.Command) {
 	}
 }
 
+type lsRow struct {
+	branch      string
+	prefix      string // tree-drawing prefix
+	merged      bool
+	wt          worktree.Worktree
+}
+
 func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, repoGit *git.Git) {
 	u := flags.NewUI()
 
@@ -183,22 +191,62 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, rep
 		mergedSet[b] = true
 	}
 
+	// Load stack for tree display
+	st := stack.Load(repoGit.Dir)
+	branchSet := make(map[string]bool)
+	wtMap := make(map[string]worktree.Worktree)
+	for _, wt := range worktrees {
+		branchSet[wt.Branch] = true
+		wtMap[wt.Branch] = wt
+	}
+
+	// Build ordered rows: stacked branches in tree order, then non-stacked
+	var rows []lsRow
+	stackedBranches := make(map[string]bool)
+
+	if !st.IsEmpty() {
+		treeLines := st.TreeLines(branchSet)
+		for _, tl := range treeLines {
+			if wt, ok := wtMap[tl.Branch]; ok {
+				stackedBranches[tl.Branch] = true
+				rows = append(rows, lsRow{
+					branch: tl.Branch,
+					prefix: tl.Prefix,
+					merged: mergedSet[tl.Branch],
+					wt:     wt,
+				})
+			}
+		}
+	}
+
+	// Non-stacked branches
+	for _, wt := range worktrees {
+		if !stackedBranches[wt.Branch] {
+			rows = append(rows, lsRow{
+				branch: wt.Branch,
+				merged: mergedSet[wt.Branch],
+				wt:     wt,
+			})
+		}
+	}
+
+	// Calculate column widths
 	branchW := len("BRANCH")
 	statusW := len("STATUS")
 	pathW := len("PATH")
 	ageW := len("AGE")
-	for _, wt := range worktrees {
-		display := wt.Branch
-		if mergedSet[wt.Branch] {
+	for _, row := range rows {
+		display := row.prefix + row.branch
+		if row.merged {
 			display += " [merged]"
 		}
 		if len(display) > branchW {
 			branchW = len(display)
 		}
-		if len(wt.Path) > pathW {
-			pathW = len(wt.Path)
+		if len(row.wt.Path) > pathW {
+			pathW = len(row.wt.Path)
 		}
-		age := worktreeAge(wt.Path)
+		age := worktreeAge(row.wt.Path)
 		if len(age) > ageW {
 			ageW = len(age)
 		}
@@ -207,19 +255,19 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, rep
 	header := fmt.Sprintf("  %-*s  %-*s  %-*s  %*s", branchW, "BRANCH", statusW, "STATUS", pathW, "PATH", ageW, "AGE")
 	u.Info(u.Bold(header))
 
-	for _, wt := range worktrees {
-		age := worktreeAge(wt.Path)
-		wtDir := filepath.Base(wt.Path)
+	for _, row := range rows {
+		age := worktreeAge(row.wt.Path)
+		wtDir := filepath.Base(row.wt.Path)
 		ws := claude.ReadStatus(repoName, wtDir)
 		statusLabel := claude.StatusLabel(ws.Status)
 		if ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir) {
 			statusLabel += "\u25CF" // ●
 		}
-		branchDisplay := wt.Branch
-		if mergedSet[wt.Branch] {
+		branchDisplay := row.prefix + row.branch
+		if row.merged {
 			branchDisplay += " " + u.Dim("[merged]")
 		}
-		pathPadded := fmt.Sprintf("%-*s", pathW, wt.Path)
+		pathPadded := fmt.Sprintf("%-*s", pathW, row.wt.Path)
 		agePadded := fmt.Sprintf("%*s", ageW, age)
 		line := fmt.Sprintf("  %-*s  %-*s  %s  %s", branchW, branchDisplay, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))
 		u.Info(line)

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -252,8 +253,15 @@ func newCmd() *cli.Command {
 			}
 			done()
 
-			// Fetch latest from remote (config default, --no-fetch overrides)
-			shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch")
+			// Determine if base is a local branch (for stacked PRs) or remote
+			localBase := repoGit.LocalBranchExists(baseBranch)
+			gitRef := "origin/" + baseBranch
+			if localBase {
+				gitRef = baseBranch
+			}
+
+			// Fetch latest from remote (only for remote bases)
+			shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch") && !localBase
 			if shouldFetch {
 				done = tr.Start("git fetch")
 				if cdOnly {
@@ -275,16 +283,23 @@ func newCmd() *cli.Command {
 
 			done = tr.Start("git worktree add")
 			if cdOnly {
-				fmt.Fprintf(os.Stderr, "Creating worktree %s from %s...\n", branch, "origin/"+baseBranch)
-				if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+				fmt.Fprintf(os.Stderr, "Creating worktree %s from %s...\n", branch, gitRef)
+				if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", wtPath, "-b", branch, gitRef); err != nil {
 					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			} else {
-				u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold("origin/"+baseBranch)))
-				if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, "origin/"+baseBranch); err != nil {
+				u.Info(fmt.Sprintf("Creating worktree %s from %s...", u.Bold(branch), u.Bold(gitRef)))
+				if _, err := repoGit.Run("worktree", "add", wtPath, "-b", branch, gitRef); err != nil {
 					return fmt.Errorf("failed to create worktree: %w", err)
 				}
 			}
+			done()
+
+			// Record parent in stack for stacked PRs
+			done = tr.Start("record stack parent")
+			st := stack.Load(bareDir)
+			st.SetParent(branch, baseBranch)
+			st.Save(bareDir)
 			done()
 
 			return finishWorktree(tr, cfg, g, u, wtPath, repoName, branch, baseBranch, cdOnly)

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -6,11 +6,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/trace"
@@ -196,6 +198,14 @@ func rmCmd() *cli.Command {
 func removeWorktree(tr *trace.Tracer, u *ui.UI, repoGit *git.Git, wt *worktree.Worktree, bareDir string, cfg *config.Config, force, keepBranch, verbose bool) error {
 	wtGit := &git.Git{Dir: wt.Path, Verbose: verbose}
 
+	// Warn if branch has stacked children
+	st := stack.Load(bareDir)
+	if children := st.Children(wt.Branch); len(children) > 0 && !force {
+		u.Warn(fmt.Sprintf("Branch %s has stacked children: %s", u.Bold(wt.Branch), strings.Join(children, ", ")))
+		u.Warn("Children will be re-parented. Use --force to proceed.")
+		return fmt.Errorf("branch has stacked children (use --force)")
+	}
+
 	if !force {
 		done := tr.Start("check dirty " + wt.Branch)
 		dirty, err := wtGit.IsDirty()
@@ -263,6 +273,12 @@ func removeWorktree(tr *trace.Tracer, u *ui.UI, repoGit *git.Git, wt *worktree.W
 	wtDir := filepath.Base(wt.Path)
 	claude.RemoveStatusDir(repoName, wtDir)
 	done()
+
+	// Remove from stack (re-parents children to this branch's parent)
+	if st.IsTracked(wt.Branch) {
+		st.Remove(wt.Branch)
+		st.Save(bareDir)
+	}
 
 	u.Success(fmt.Sprintf("Removed worktree %s", u.Bold(wt.Branch)))
 	return nil

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1,0 +1,220 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/ui"
+	"github.com/iamrajjoshi/willow/internal/worktree"
+	"github.com/urfave/cli/v3"
+)
+
+func syncCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "sync",
+		Usage: "Rebase stacked worktrees onto their parents",
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "branch",
+				UsageText: "[branch]",
+			},
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target a willow-managed repo by name",
+			},
+			&cli.BoolFlag{
+				Name:  "no-fetch",
+				Usage: "Skip fetching from remote",
+			},
+			&cli.BoolFlag{
+				Name:  "abort",
+				Usage: "Abort any in-progress rebases across stacked worktrees",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			var bareDir string
+			var err error
+			if repoFlag := cmd.String("repo"); repoFlag != "" {
+				bareDir, err = config.ResolveRepo(repoFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				bareDir, err = requireWillowRepo(g)
+				if err != nil {
+					return err
+				}
+			}
+
+			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+
+			st := stack.Load(bareDir)
+			if st.IsEmpty() {
+				u.Info("No stacked branches found. Use 'ww new <branch> -b <parent>' to create a stack.")
+				return nil
+			}
+
+			// Build worktree path lookup
+			wts, err := worktree.List(repoGit)
+			if err != nil {
+				return fmt.Errorf("failed to list worktrees: %w", err)
+			}
+			wtPaths := make(map[string]string) // branch → worktree path
+			for _, wt := range wts {
+				if !wt.IsBare {
+					wtPaths[wt.Branch] = wt.Path
+				}
+			}
+
+			// Handle --abort
+			if cmd.Bool("abort") {
+				return syncAbort(st, wtPaths, g.Verbose, u)
+			}
+
+			// Determine which branches to sync
+			var branches []string
+			if targetBranch := cmd.StringArg("branch"); targetBranch != "" {
+				if !st.IsTracked(targetBranch) {
+					return fmt.Errorf("branch %q is not in the stack", targetBranch)
+				}
+				branches = st.SubtreeSort(targetBranch)
+			} else {
+				branches = st.TopoSort()
+			}
+
+			if len(branches) == 0 {
+				u.Info("Nothing to sync.")
+				return nil
+			}
+
+			// Fetch origin once
+			if !cmd.Bool("no-fetch") {
+				u.Info("Fetching origin...")
+				if _, err := repoGit.Run("fetch", "origin"); err != nil {
+					u.Warn(fmt.Sprintf("fetch failed: %v (continuing anyway)", err))
+				}
+			}
+
+			u.Info(fmt.Sprintf("\nSyncing %d stacked worktree(s):\n", len(branches)))
+
+			// Track which branches had conflicts so we skip their descendants
+			conflicted := make(map[string]bool)
+			synced := 0
+			skipped := 0
+
+			for _, branch := range branches {
+				parent := st.Parent(branch)
+
+				// Skip if an ancestor had a conflict
+				if isAncestorConflicted(st, branch, conflicted) {
+					u.Info(fmt.Sprintf("  %s → %s", parent, branch))
+					u.Info(fmt.Sprintf("    %s Skipped (ancestor has conflict)", u.Dim("⊘")))
+					skipped++
+					continue
+				}
+
+				wtPath, hasWorktree := wtPaths[branch]
+				if !hasWorktree {
+					u.Info(fmt.Sprintf("  %s → %s", parent, branch))
+					u.Info(fmt.Sprintf("    %s Skipped (no worktree)", u.Dim("⊘")))
+					skipped++
+					continue
+				}
+
+				wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
+
+				// Check for dirty worktree
+				dirty, _ := wtGit.IsDirty()
+				if dirty {
+					u.Info(fmt.Sprintf("  %s → %s", parent, branch))
+					u.Warn(fmt.Sprintf("    ⚠ Skipped (uncommitted changes)"))
+					skipped++
+					continue
+				}
+
+				// Check for in-progress rebase
+				if wtGit.IsRebaseInProgress() {
+					u.Info(fmt.Sprintf("  %s → %s", parent, branch))
+					u.Warn(fmt.Sprintf("    ⚠ Rebase in progress — resolve manually"))
+					conflicted[branch] = true
+					continue
+				}
+
+				// Resolve rebase target: tracked parent → local branch, untracked → origin/<parent>
+				rebaseOnto := parent
+				if !st.IsTracked(parent) {
+					rebaseOnto = "origin/" + parent
+				}
+
+				u.Info(fmt.Sprintf("  %s → %s", parent, u.Bold(branch)))
+
+				if err := wtGit.Rebase(rebaseOnto); err != nil {
+					conflicted[branch] = true
+					u.Warn(fmt.Sprintf("    ✗ Conflict — resolve in %s", wtPath))
+					u.Info(fmt.Sprintf("      cd %s && git rebase --continue", wtPath))
+					continue
+				}
+
+				ahead, _ := wtGit.CommitsAhead(rebaseOnto)
+				u.Info(fmt.Sprintf("    %s Rebased onto %s (%d commits ahead)", u.Green("✔"), rebaseOnto, ahead))
+				synced++
+			}
+
+			fmt.Println()
+			if len(conflicted) > 0 {
+				u.Warn(fmt.Sprintf("%d synced, %d conflicted, %d skipped", synced, len(conflicted), skipped))
+				u.Info("After resolving conflicts, run 'ww sync' again.")
+			} else {
+				u.Success(fmt.Sprintf("All %d worktree(s) synced.", synced))
+			}
+			return nil
+		},
+	}
+}
+
+func syncAbort(st *stack.Stack, wtPaths map[string]string, verbose bool, u *ui.UI) error {
+	aborted := 0
+	for _, branch := range st.TopoSort() {
+		wtPath, ok := wtPaths[branch]
+		if !ok {
+			continue
+		}
+		wtGit := &git.Git{Dir: wtPath, Verbose: verbose}
+		if wtGit.IsRebaseInProgress() {
+			u.Info(fmt.Sprintf("Aborting rebase in %s...", branch))
+			if err := wtGit.RebaseAbort(); err != nil {
+				u.Warn(fmt.Sprintf("  Failed to abort rebase in %s: %v", branch, err))
+			} else {
+				aborted++
+			}
+		}
+	}
+	if aborted == 0 {
+		u.Info("No rebases in progress.")
+	} else {
+		u.Success(fmt.Sprintf("Aborted %d rebase(s).", aborted))
+	}
+	return nil
+}
+
+// isAncestorConflicted checks if any ancestor of branch in the stack has a conflict.
+func isAncestorConflicted(st *stack.Stack, branch string, conflicted map[string]bool) bool {
+	parent := st.Parent(branch)
+	for parent != "" && st.IsTracked(parent) {
+		if conflicted[parent] {
+			return true
+		}
+		parent = st.Parent(parent)
+	}
+	return false
+}

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/dashboard"
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -86,8 +87,8 @@ func tmuxPickCmd() *cli.Command {
 					fzf.WithAnsi(),
 					fzf.WithReverse(),
 					fzf.WithNoSort(),
-					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-D: Delete"),
-					fzf.WithExpectKeys("ctrl-n", "ctrl-e", "ctrl-p", "ctrl-d"),
+					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-S: Sync | Ctrl-D: Delete"),
+					fzf.WithExpectKeys("ctrl-n", "ctrl-e", "ctrl-p", "ctrl-s", "ctrl-d"),
 					fzf.WithPrintQuery(),
 					fzf.WithBind(fmt.Sprintf("start:reload-sync(%s)", reloadCmd)),
 				}
@@ -129,6 +130,23 @@ func tmuxPickCmd() *cli.Command {
 						continue
 					}
 					return nil
+
+				case "ctrl-s":
+					// Sync selected branch's subtree, or all stacks if no selection
+					branch := ""
+					if result.Selection != "" {
+						wtPath := tmux.ExtractPathFromLine(result.Selection)
+						if item := findItemByPath(items, wtPath); item != nil {
+							branch = item.Branch
+						}
+					}
+					if err := tmuxPickSync(self, repoFilter, items, branch); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+					}
+					// Re-enter picker loop to show refreshed state
+					fmt.Fprintf(os.Stderr, "\nPress Enter to return to picker...\n")
+					fmt.Fscanln(os.Stdin)
+					continue
 
 				case "ctrl-d":
 					if result.Selection == "" {
@@ -406,6 +424,23 @@ func extractBranchFromPRLine(line string) string {
 	return line[start+1 : end]
 }
 
+func tmuxPickSync(self, repoFilter string, items []tmux.PickerItem, branch string) error {
+	repo, err := resolveRepo(repoFilter, items)
+	if err != nil {
+		return err
+	}
+
+	args := []string{"sync", "--repo", repo}
+	if branch != "" {
+		args = append(args, branch)
+	}
+
+	cmd := exec.Command(self, args...)
+	cmd.Stdout = os.Stderr // Show output in the popup
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 func resolveRepo(repoFilter string, items []tmux.PickerItem) (string, error) {
 	if repoFilter != "" {
 		return repoFilter, nil
@@ -536,8 +571,20 @@ func printPreviewMetadata(wtPath, repoName string) {
 		baseBranch = "main"
 	}
 
-	if branch, err := g.Run("rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+	branch := ""
+	if b, err := g.Run("rev-parse", "--abbrev-ref", "HEAD"); err == nil {
+		branch = b
 		fmt.Printf("  \033[1mBranch:\033[0m  %s\n", branch)
+	}
+
+	// Show stack chain if branch is stacked
+	bareDir, _ := config.ResolveRepo(repoName)
+	if bareDir != "" {
+		st := stack.Load(bareDir)
+		if st.IsTracked(branch) {
+			chain := buildStackChain(st, branch)
+			fmt.Printf("  \033[1mStack:\033[0m   %s\n", chain)
+		}
 	}
 
 	if diffOut, err := g.Run("diff", "--shortstat", fmt.Sprintf("origin/%s...HEAD", baseBranch)); err == nil {
@@ -560,6 +607,45 @@ func printPreviewMetadata(wtPath, repoName string) {
 		}
 	}
 	fmt.Println()
+}
+
+// buildStackChain returns a display string like "main → feature-a → [feature-b] → feature-c"
+func buildStackChain(st *stack.Stack, current string) string {
+	// Walk up to find the root
+	var ancestors []string
+	b := current
+	for {
+		parent := st.Parent(b)
+		if parent == "" {
+			break
+		}
+		ancestors = append([]string{parent}, ancestors...)
+		if !st.IsTracked(parent) {
+			break
+		}
+		b = parent
+	}
+
+	// Walk down to find descendants
+	var descendants []string
+	queue := st.Children(current)
+	for len(queue) > 0 {
+		child := queue[0]
+		queue = queue[1:]
+		descendants = append(descendants, child)
+		queue = append(queue, st.Children(child)...)
+	}
+
+	var parts []string
+	for _, a := range ancestors {
+		parts = append(parts, a)
+	}
+	parts = append(parts, fmt.Sprintf("\033[1m[%s]\033[0m", current))
+	for _, d := range descendants {
+		parts = append(parts, d)
+	}
+
+	return strings.Join(parts, " → ")
 }
 
 func tmuxListCmd() *cli.Command {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -145,6 +145,49 @@ func (g *Git) RemoteBranchExists(branch string) bool {
 	return strings.TrimSpace(out) != ""
 }
 
+// LocalBranchExists checks if a local branch exists in the repo.
+func (g *Git) LocalBranchExists(branch string) bool {
+	out, _ := g.Run("branch", "--list", branch)
+	return strings.TrimSpace(out) != ""
+}
+
+// Rebase runs git rebase <onto> in the current directory.
+func (g *Git) Rebase(onto string) error {
+	_, err := g.Run("rebase", onto)
+	return err
+}
+
+// RebaseAbort aborts an in-progress rebase.
+func (g *Git) RebaseAbort() error {
+	_, err := g.Run("rebase", "--abort")
+	return err
+}
+
+// IsRebaseInProgress checks if a rebase is currently in progress.
+func (g *Git) IsRebaseInProgress() bool {
+	gitDir, err := g.Run("rev-parse", "--git-dir")
+	if err != nil {
+		return false
+	}
+	for _, dir := range []string{"rebase-merge", "rebase-apply"} {
+		if _, err := os.Stat(filepath.Join(gitDir, dir)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// CommitsAhead returns the number of commits HEAD is ahead of base.
+func (g *Git) CommitsAhead(base string) (int, error) {
+	out, err := g.Run("rev-list", "--count", base+"..HEAD")
+	if err != nil {
+		return 0, err
+	}
+	var count int
+	fmt.Sscanf(strings.TrimSpace(out), "%d", &count)
+	return count, nil
+}
+
 func (g *Git) HasUnpushedCommits() (bool, error) {
 	out, err := g.Run("rev-list", "--count", "@{upstream}..HEAD")
 	if err != nil {

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,0 +1,270 @@
+package stack
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Stack tracks parent-child relationships between branches for stacked PRs.
+// Stored as branches.json in the bare repo directory.
+type Stack struct {
+	Parents map[string]string `json:"parents"` // branch → parent
+}
+
+// TreeLine represents a branch with its tree-drawing prefix for display.
+type TreeLine struct {
+	Branch string
+	Prefix string // e.g., "├─ ", "│  └─ ", ""
+	Depth  int
+}
+
+func filePath(bareDir string) string {
+	return filepath.Join(bareDir, "branches.json")
+}
+
+// Load reads the stack from branches.json. Returns an empty stack if the file doesn't exist.
+func Load(bareDir string) *Stack {
+	s := &Stack{Parents: make(map[string]string)}
+	data, err := os.ReadFile(filePath(bareDir))
+	if err != nil {
+		return s
+	}
+	// Support both {"parents": {...}} and flat {...} formats
+	var wrapped struct {
+		Parents map[string]string `json:"parents"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Parents != nil {
+		s.Parents = wrapped.Parents
+		return s
+	}
+	// Try flat format
+	var flat map[string]string
+	if err := json.Unmarshal(data, &flat); err == nil {
+		s.Parents = flat
+	}
+	return s
+}
+
+// Save writes the stack to branches.json. Removes the file if the stack is empty.
+func (s *Stack) Save(bareDir string) error {
+	if len(s.Parents) == 0 {
+		err := os.Remove(filePath(bareDir))
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	data, err := json.MarshalIndent(s.Parents, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath(bareDir), append(data, '\n'), 0o644)
+}
+
+func (s *Stack) SetParent(branch, parent string) {
+	s.Parents[branch] = parent
+}
+
+// Remove deletes a branch from the stack and re-parents its children to
+// the removed branch's parent.
+func (s *Stack) Remove(branch string) {
+	parent := s.Parents[branch]
+	for child, p := range s.Parents {
+		if p == branch {
+			if parent != "" {
+				s.Parents[child] = parent
+			} else {
+				delete(s.Parents, child)
+			}
+		}
+	}
+	delete(s.Parents, branch)
+}
+
+func (s *Stack) Parent(branch string) string {
+	return s.Parents[branch]
+}
+
+func (s *Stack) IsTracked(branch string) bool {
+	_, ok := s.Parents[branch]
+	return ok
+}
+
+// Children returns direct children of a branch (branches whose parent is this branch).
+func (s *Stack) Children(branch string) []string {
+	var children []string
+	for child, parent := range s.Parents {
+		if parent == branch {
+			children = append(children, child)
+		}
+	}
+	sort.Strings(children)
+	return children
+}
+
+// Descendants returns all transitive children of a branch.
+func (s *Stack) Descendants(branch string) []string {
+	var result []string
+	queue := s.Children(branch)
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		result = append(result, cur)
+		queue = append(queue, s.Children(cur)...)
+	}
+	return result
+}
+
+// Roots returns branches whose parent is NOT itself a tracked branch.
+// These are the entry points of stacks (e.g., branches based on "main").
+func (s *Stack) Roots() []string {
+	var roots []string
+	for branch, parent := range s.Parents {
+		if _, parentTracked := s.Parents[parent]; !parentTracked {
+			roots = append(roots, branch)
+		}
+	}
+	sort.Strings(roots)
+	return roots
+}
+
+// TopoSort returns all tracked branches in topological order (parents before children).
+func (s *Stack) TopoSort() []string {
+	var result []string
+	visited := make(map[string]bool)
+
+	var visit func(branch string)
+	visit = func(branch string) {
+		if visited[branch] {
+			return
+		}
+		visited[branch] = true
+		// Visit parent first (if it's tracked)
+		if parent, ok := s.Parents[branch]; ok {
+			if _, parentTracked := s.Parents[parent]; parentTracked {
+				visit(parent)
+			}
+		}
+		result = append(result, branch)
+	}
+
+	// Process roots first for stable ordering
+	for _, root := range s.Roots() {
+		visit(root)
+	}
+	// Then any remaining
+	for branch := range s.Parents {
+		visit(branch)
+	}
+
+	return result
+}
+
+// SubtreeSort returns a branch and its descendants in topological order.
+func (s *Stack) SubtreeSort(root string) []string {
+	result := []string{root}
+	result = append(result, s.topoChildren(root)...)
+	return result
+}
+
+func (s *Stack) topoChildren(branch string) []string {
+	var result []string
+	for _, child := range s.Children(branch) {
+		result = append(result, child)
+		result = append(result, s.topoChildren(child)...)
+	}
+	return result
+}
+
+// IsEmpty returns true if no branches are tracked.
+func (s *Stack) IsEmpty() bool {
+	return len(s.Parents) == 0
+}
+
+// TreeLines generates display lines with tree-drawing characters for the given
+// set of branches. Only branches present in the provided set are included.
+func (s *Stack) TreeLines(branchSet map[string]bool) []TreeLine {
+	if s.IsEmpty() {
+		return nil
+	}
+
+	var lines []TreeLine
+	// Process each root and its subtree
+	for _, root := range s.Roots() {
+		if !branchSet[root] {
+			// Still process children that might have worktrees
+			s.collectTreeLines(&lines, root, "", 0, branchSet, true)
+			continue
+		}
+		s.collectTreeLines(&lines, root, "", 0, branchSet, false)
+	}
+	return lines
+}
+
+func (s *Stack) collectTreeLines(lines *[]TreeLine, branch, prefix string, depth int, branchSet map[string]bool, skipSelf bool) {
+	if !skipSelf && branchSet[branch] {
+		*lines = append(*lines, TreeLine{
+			Branch: branch,
+			Prefix: prefix,
+			Depth:  depth,
+		})
+	}
+
+	children := s.Children(branch)
+	// Filter to children that have worktrees (or have descendants with worktrees)
+	var visibleChildren []string
+	for _, child := range children {
+		if branchSet[child] || s.hasDescendantIn(child, branchSet) {
+			visibleChildren = append(visibleChildren, child)
+		}
+	}
+
+	for i, child := range visibleChildren {
+		isLast := i == len(visibleChildren)-1
+		var childPrefix, nextPrefix string
+		if depth == 0 && skipSelf {
+			// Root is not shown, children are at top level
+			if isLast {
+				childPrefix = "└─ "
+				nextPrefix = "   "
+			} else {
+				childPrefix = "├─ "
+				nextPrefix = "│  "
+			}
+		} else if skipSelf {
+			childPrefix = prefix
+			nextPrefix = prefix
+		} else {
+			if isLast {
+				childPrefix = prefix + "└─ "
+				nextPrefix = prefix + "   "
+			} else {
+				childPrefix = prefix + "├─ "
+				nextPrefix = prefix + "│  "
+			}
+		}
+		if branchSet[child] {
+			*lines = append(*lines, TreeLine{
+				Branch: child,
+				Prefix: childPrefix,
+				Depth:  depth + 1,
+			})
+		}
+		// Recurse into grandchildren
+		for _, grandchild := range s.Children(child) {
+			s.collectTreeLines(lines, grandchild, nextPrefix, depth+2, branchSet, false)
+		}
+	}
+}
+
+func (s *Stack) hasDescendantIn(branch string, branchSet map[string]bool) bool {
+	for _, child := range s.Children(branch) {
+		if branchSet[child] || s.hasDescendantIn(child, branchSet) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -1,0 +1,145 @@
+package stack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSave(t *testing.T) {
+	dir := t.TempDir()
+
+	s := &Stack{Parents: map[string]string{
+		"feature-a": "main",
+		"feature-b": "feature-a",
+	}}
+
+	if err := s.Save(dir); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded := Load(dir)
+	if loaded.Parent("feature-a") != "main" {
+		t.Errorf("expected feature-a parent=main, got %q", loaded.Parent("feature-a"))
+	}
+	if loaded.Parent("feature-b") != "feature-a" {
+		t.Errorf("expected feature-b parent=feature-a, got %q", loaded.Parent("feature-b"))
+	}
+}
+
+func TestSaveEmptyRemovesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	s := &Stack{Parents: map[string]string{"a": "main"}}
+	s.Save(dir)
+
+	s.Remove("a")
+	s.Save(dir)
+
+	if _, err := os.Stat(filepath.Join(dir, "branches.json")); !os.IsNotExist(err) {
+		t.Error("branches.json should be removed when stack is empty")
+	}
+}
+
+func TestChildren(t *testing.T) {
+	s := &Stack{Parents: map[string]string{
+		"a": "main",
+		"b": "a",
+		"c": "a",
+		"d": "b",
+	}}
+
+	children := s.Children("a")
+	if len(children) != 2 || children[0] != "b" || children[1] != "c" {
+		t.Errorf("Children(a) = %v, want [b c]", children)
+	}
+
+	children = s.Children("b")
+	if len(children) != 1 || children[0] != "d" {
+		t.Errorf("Children(b) = %v, want [d]", children)
+	}
+}
+
+func TestDescendants(t *testing.T) {
+	s := &Stack{Parents: map[string]string{
+		"a": "main",
+		"b": "a",
+		"c": "b",
+	}}
+
+	desc := s.Descendants("a")
+	if len(desc) != 2 {
+		t.Errorf("Descendants(a) = %v, want [b c]", desc)
+	}
+}
+
+func TestRoots(t *testing.T) {
+	s := &Stack{Parents: map[string]string{
+		"a": "main",
+		"b": "a",
+		"x": "develop",
+	}}
+
+	roots := s.Roots()
+	if len(roots) != 2 || roots[0] != "a" || roots[1] != "x" {
+		t.Errorf("Roots() = %v, want [a x]", roots)
+	}
+}
+
+func TestTopoSort(t *testing.T) {
+	s := &Stack{Parents: map[string]string{
+		"a": "main",
+		"b": "a",
+		"c": "b",
+	}}
+
+	sorted := s.TopoSort()
+	if len(sorted) != 3 {
+		t.Fatalf("TopoSort() = %v, want 3 elements", sorted)
+	}
+	// a must come before b, b before c
+	idx := make(map[string]int)
+	for i, b := range sorted {
+		idx[b] = i
+	}
+	if idx["a"] >= idx["b"] || idx["b"] >= idx["c"] {
+		t.Errorf("TopoSort() = %v, wrong order", sorted)
+	}
+}
+
+func TestSubtreeSort(t *testing.T) {
+	s := &Stack{Parents: map[string]string{
+		"a": "main",
+		"b": "a",
+		"c": "b",
+		"x": "main",
+	}}
+
+	subtree := s.SubtreeSort("a")
+	if len(subtree) != 3 {
+		t.Fatalf("SubtreeSort(a) = %v, want [a b c]", subtree)
+	}
+	if subtree[0] != "a" {
+		t.Errorf("first element should be a, got %s", subtree[0])
+	}
+}
+
+func TestRemoveReparentsChildren(t *testing.T) {
+	s := &Stack{Parents: map[string]string{
+		"a": "main",
+		"b": "a",
+		"c": "a",
+	}}
+
+	s.Remove("a")
+
+	if s.Parent("b") != "main" {
+		t.Errorf("b should be re-parented to main, got %q", s.Parent("b"))
+	}
+	if s.Parent("c") != "main" {
+		t.Errorf("c should be re-parented to main, got %q", s.Parent("c"))
+	}
+	if s.IsTracked("a") {
+		t.Error("a should be removed")
+	}
+}

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
@@ -23,15 +24,16 @@ const (
 )
 
 type PickerItem struct {
-	RepoName   string
-	Branch     string
-	WtDirName  string
-	WtPath     string
-	Status     claude.Status
-	Unread     bool
-	HasSession bool
-	Sessions   []*claude.SessionStatus
-	Merged     bool
+	RepoName    string
+	Branch      string
+	WtDirName   string
+	WtPath      string
+	Status      claude.Status
+	Unread      bool
+	HasSession  bool
+	Sessions    []*claude.SessionStatus
+	Merged      bool
+	StackPrefix string // tree-drawing prefix for stacked branches (e.g., "├─ ")
 }
 
 func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
@@ -92,16 +94,68 @@ func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
 		}
 	}
 
-	sort.SliceStable(items, func(i, j int) bool {
-		oi, oj := statusOrder(items[i].Status), statusOrder(items[j].Status)
-		// Merged items sort last
-		if items[i].Merged != items[j].Merged {
-			return !items[i].Merged
-		}
-		return oi < oj
-	})
+	// Compute stack prefixes and reorder: stacked branches grouped by tree, then non-stacked by status
+	items = applyStackOrder(items, repoNames)
 
 	return items, nil
+}
+
+func applyStackOrder(items []PickerItem, repoNames []string) []PickerItem {
+	// Build branch set for tree line computation
+	branchSet := make(map[string]bool)
+	for _, item := range items {
+		branchSet[item.Branch] = true
+	}
+
+	// Build item lookup by branch
+	itemMap := make(map[string]*PickerItem)
+	for i := range items {
+		itemMap[items[i].Branch] = &items[i]
+	}
+
+	// Load stacks for each repo and compute tree lines
+	stackedBranches := make(map[string]bool)
+	var stackedItems []PickerItem
+
+	for _, repoName := range repoNames {
+		bareDir, err := config.ResolveRepo(repoName)
+		if err != nil {
+			continue
+		}
+		st := stack.Load(bareDir)
+		if st.IsEmpty() {
+			continue
+		}
+
+		treeLines := st.TreeLines(branchSet)
+		for _, tl := range treeLines {
+			if item, ok := itemMap[tl.Branch]; ok {
+				item.StackPrefix = tl.Prefix
+				stackedBranches[tl.Branch] = true
+				stackedItems = append(stackedItems, *item)
+			}
+		}
+	}
+
+	// Collect non-stacked items
+	var nonStacked []PickerItem
+	for _, item := range items {
+		if !stackedBranches[item.Branch] {
+			nonStacked = append(nonStacked, item)
+		}
+	}
+
+	// Sort non-stacked by status (merged last)
+	sort.SliceStable(nonStacked, func(i, j int) bool {
+		if nonStacked[i].Merged != nonStacked[j].Merged {
+			return !nonStacked[i].Merged
+		}
+		return statusOrder(nonStacked[i].Status) < statusOrder(nonStacked[j].Status)
+	})
+
+	// Stacked first (in tree order), then non-stacked (by status)
+	result := append(stackedItems, nonStacked...)
+	return result
 }
 
 // FormatPickerLines produces ANSI-colored lines for the fzf picker.
@@ -178,10 +232,14 @@ func filterActiveSessions(sessions []*claude.SessionStatus) []*claude.SessionSta
 }
 
 func displayName(item PickerItem, multiRepo bool) string {
+	name := item.Branch
 	if multiRepo {
-		return item.RepoName + "/" + item.Branch
+		name = item.RepoName + "/" + item.Branch
 	}
-	return item.Branch
+	if item.StackPrefix != "" {
+		name = item.StackPrefix + name
+	}
+	return name
 }
 
 // ExtractPathFromLine pulls the worktree path from the last pipe-delimited field,

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -88,6 +88,54 @@ wwc auth-refactor                        # checkout + cd (shell integration)
 | `--no-fetch` | Skip fetching from remote | `false` |
 | `--cd` | Print only the path (for scripting) | `false` |
 
+## Stacked PRs
+
+Create a chain of branches where each builds on the previous:
+
+```bash
+ww new feature-a -b main              # start a stack
+ww new feature-b -b feature-a         # stack on top
+ww new feature-c -b feature-b         # third layer
+```
+
+When `--base` points to a local branch (another worktree), willow forks from it directly and records the parent relationship in `branches.json` per repo. Stacked branches are shown as a tree in `ww ls` and the tmux picker:
+
+```
+  BRANCH                    STATUS  PATH                                           AGE
+  ├─ feature-a              BUSY    ~/.willow/worktrees/repo/feature-a             2h
+  │  └─ feature-b           DONE    ~/.willow/worktrees/repo/feature-b             1h
+  │     └─ feature-c        --      ~/.willow/worktrees/repo/feature-c             30m
+  standalone                --      ~/.willow/worktrees/repo/standalone             1d
+```
+
+Removing a stacked branch re-parents its children to the removed branch's parent. Use `--force` if the branch has children.
+
+## `ww sync [branch]`
+
+Rebase stacked worktrees onto their parents in topological order. Like `git machete traverse` but for worktrees.
+
+```bash
+ww sync                    # sync all stacks in current repo
+ww sync feature-b          # sync only feature-b and its descendants
+ww sync -r myrepo          # target specific repo
+ww sync --abort            # abort any in-progress rebases
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-r, --repo` | Target repo by name | Auto-detected from cwd |
+| `--no-fetch` | Skip `git fetch origin` | `false` |
+| `--abort` | Abort in-progress rebases across all stacked worktrees | `false` |
+
+**How it works:**
+1. Fetches `origin` once
+2. Processes branches in topological order (parents before children)
+3. For root branches (parent is `main`): rebases onto `origin/main`
+4. For stacked branches: rebases onto the local parent (which was just synced)
+5. On conflict: stops descendants of the conflicting branch, continues other stacks
+
+Dirty worktrees and in-progress rebases are skipped with a warning.
+
 ## `ww sw`
 
 Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by activity.

--- a/website/docs/tmux/index.md
+++ b/website/docs/tmux/index.md
@@ -34,6 +34,7 @@ The right panel shows a live preview of the tmux pane content (Claude Code outpu
 | `Ctrl-N` | Create new worktree from typed query (also accepts PR URLs) |
 | `Ctrl-E` | Browse existing remote branches and create a worktree |
 | `Ctrl-P` | Browse open PRs and create a worktree for the selected one |
+| `Ctrl-S` | Sync stacked worktrees (selected branch's subtree, or all) |
 | `Ctrl-D` | Delete selected worktree and its tmux session |
 | `Esc` | Close picker |
 


### PR DESCRIPTION
## Description of the change

Adds stacked PR support to willow, inspired by git machete:

### Stacked worktrees
- `ww new feature-b -b feature-a` creates a branch stacked on feature-a (local branch, not just remote)
- Parent relationships tracked in `branches.json` per repo
- Works with both `ww new` and `ww checkout`

### `ww sync` command
- Rebases stacked worktrees in topological order (parents before children)
- `ww sync feature-b` syncs only that branch's subtree
- `ww sync --abort` aborts in-progress rebases
- Handles conflicts gracefully: stops descendants, continues other stacks
- Skips dirty worktrees and in-progress rebases with warnings

### Tree display
- `ww ls` shows stacked branches as a tree with `├─` / `└─` prefixes
- Tmux picker shows same tree structure, stacked branches grouped together
- Preview pane shows stack chain: `main → feature-a → [feature-b] → feature-c`

### Tmux integration
- **Ctrl-S** in tmux picker: sync selected branch's subtree (or all stacks)
- Stack chain shown in preview pane when hovering a stacked branch

### Stack-aware `ww rm`
- Warns if removing a branch with stacked children
- Re-parents children to the removed branch's parent on `--force`

### New package: `internal/stack/`
- `Stack` struct with Load/Save, SetParent, Remove, Children, TopoSort, SubtreeSort, TreeLines
- 8 unit tests covering all operations

## Test plan
- Unit tests: 8 tests for stack package (topo sort, children, descendants, roots, remove/re-parent, save/load)
- Integration test: `TestNew_StackedBranch` — creates stacked branches, verifies branches.json
- Full test suite passing