### PR TITLE
🐛 fix: unchecked errors, picker collision, ANSI alignment, tracing

### DIFF
--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -225,7 +225,9 @@ func checkoutCmd() *cli.Command {
 			done = tr.Start("record stack parent")
 			st := stack.Load(repo.BareDir)
 			st.SetParent(branch, baseBranch)
-			st.Save(repo.BareDir)
+			if err := st.Save(repo.BareDir); err != nil {
+				u.Warn(fmt.Sprintf("Failed to save stack: %v", err))
+			}
 			done()
 
 			return finishWorktree(tr, cfg, g, u, wtPath, repo.Name, branch, baseBranch, cdOnly)

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -263,13 +263,21 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, rep
 		if ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir) {
 			statusLabel += "\u25CF" // ●
 		}
-		branchDisplay := row.prefix + row.branch
+		branchPlain := row.prefix + row.branch
+		branchDisplay := branchPlain
 		if row.merged {
+			branchPlain += " [merged]"
 			branchDisplay += " " + u.Dim("[merged]")
 		}
+		// Pad based on plain text width to avoid ANSI code miscount
+		padding := branchW - len(branchPlain)
+		if padding < 0 {
+			padding = 0
+		}
+		branchCol := branchDisplay + strings.Repeat(" ", padding)
 		pathPadded := fmt.Sprintf("%-*s", pathW, row.wt.Path)
 		agePadded := fmt.Sprintf("%*s", ageW, age)
-		line := fmt.Sprintf("  %-*s  %-*s  %s  %s", branchW, branchDisplay, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))
+		line := fmt.Sprintf("  %s  %-*s  %s  %s", branchCol, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))
 		u.Info(line)
 	}
 }

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -299,7 +299,9 @@ func newCmd() *cli.Command {
 			done = tr.Start("record stack parent")
 			st := stack.Load(bareDir)
 			st.SetParent(branch, baseBranch)
-			st.Save(bareDir)
+			if err := st.Save(bareDir); err != nil {
+				u.Warn(fmt.Sprintf("Failed to save stack: %v", err))
+			}
 			done()
 
 			return finishWorktree(tr, cfg, g, u, wtPath, repoName, branch, baseBranch, cdOnly)

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -277,7 +277,9 @@ func removeWorktree(tr *trace.Tracer, u *ui.UI, repoGit *git.Git, wt *worktree.W
 	// Remove from stack (re-parents children to this branch's parent)
 	if st.IsTracked(wt.Branch) {
 		st.Remove(wt.Branch)
-		st.Save(bareDir)
+		if err := st.Save(bareDir); err != nil {
+			u.Warn(fmt.Sprintf("Failed to save stack: %v", err))
+		}
 	}
 
 	u.Success(fmt.Sprintf("Removed worktree %s", u.Bold(wt.Branch)))

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -39,9 +40,11 @@ func syncCmd() *cli.Command {
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
+			tr := trace.New(flags.Trace)
 			g := flags.NewGit()
 			u := flags.NewUI()
 
+			done := tr.Start("resolve repo")
 			var bareDir string
 			var err error
 			if repoFlag := cmd.String("repo"); repoFlag != "" {
@@ -55,16 +58,20 @@ func syncCmd() *cli.Command {
 					return err
 				}
 			}
+			done()
 
 			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
 
+			done = tr.Start("load stack")
 			st := stack.Load(bareDir)
+			done()
 			if st.IsEmpty() {
 				u.Info("No stacked branches found. Use 'ww new <branch> -b <parent>' to create a stack.")
 				return nil
 			}
 
 			// Build worktree path lookup
+			done = tr.Start("list worktrees")
 			wts, err := worktree.List(repoGit)
 			if err != nil {
 				return fmt.Errorf("failed to list worktrees: %w", err)
@@ -75,6 +82,7 @@ func syncCmd() *cli.Command {
 					wtPaths[wt.Branch] = wt.Path
 				}
 			}
+			done()
 
 			// Handle --abort
 			if cmd.Bool("abort") {
@@ -99,10 +107,12 @@ func syncCmd() *cli.Command {
 
 			// Fetch origin once
 			if !cmd.Bool("no-fetch") {
+				done = tr.Start("git fetch")
 				u.Info("Fetching origin...")
 				if _, err := repoGit.Run("fetch", "origin"); err != nil {
 					u.Warn(fmt.Sprintf("fetch failed: %v (continuing anyway)", err))
 				}
+				done()
 			}
 
 			u.Info(fmt.Sprintf("\nSyncing %d stacked worktree(s):\n", len(branches)))
@@ -169,6 +179,8 @@ func syncCmd() *cli.Command {
 				u.Info(fmt.Sprintf("    %s Rebased onto %s (%d commits ahead)", u.Green("✔"), rebaseOnto, ahead))
 				synced++
 			}
+
+			tr.Total()
 
 			fmt.Println()
 			if len(conflicted) > 0 {

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -107,14 +107,15 @@ func applyStackOrder(items []PickerItem, repoNames []string) []PickerItem {
 		branchSet[item.Branch] = true
 	}
 
-	// Build item lookup by branch
+	// Build item lookup by repo/branch to avoid collisions across repos
 	itemMap := make(map[string]*PickerItem)
 	for i := range items {
-		itemMap[items[i].Branch] = &items[i]
+		key := items[i].RepoName + "/" + items[i].Branch
+		itemMap[key] = &items[i]
 	}
 
 	// Load stacks for each repo and compute tree lines
-	stackedBranches := make(map[string]bool)
+	stackedKeys := make(map[string]bool)
 	var stackedItems []PickerItem
 
 	for _, repoName := range repoNames {
@@ -129,9 +130,10 @@ func applyStackOrder(items []PickerItem, repoNames []string) []PickerItem {
 
 		treeLines := st.TreeLines(branchSet)
 		for _, tl := range treeLines {
-			if item, ok := itemMap[tl.Branch]; ok {
+			key := repoName + "/" + tl.Branch
+			if item, ok := itemMap[key]; ok {
 				item.StackPrefix = tl.Prefix
-				stackedBranches[tl.Branch] = true
+				stackedKeys[key] = true
 				stackedItems = append(stackedItems, *item)
 			}
 		}
@@ -140,7 +142,8 @@ func applyStackOrder(items []PickerItem, repoNames []string) []PickerItem {
 	// Collect non-stacked items
 	var nonStacked []PickerItem
 	for _, item := range items {
-		if !stackedBranches[item.Branch] {
+		key := item.RepoName + "/" + item.Branch
+		if !stackedKeys[key] {
 			nonStacked = append(nonStacked, item)
 		}
 	}
@@ -166,9 +169,12 @@ func FormatPickerLines(items []PickerItem) []string {
 
 	nameW := 0
 	for _, item := range items {
-		label := displayName(item, multiRepo)
-		if len(label) > nameW {
-			nameW = len(label)
+		plain := displayName(item, multiRepo)
+		if item.Merged {
+			plain += " [merged]"
+		}
+		if len(plain) > nameW {
+			nameW = len(plain)
 		}
 	}
 
@@ -183,14 +189,22 @@ func FormatPickerLines(items []PickerItem) []string {
 			dot = "\u25CF"
 		}
 
-		name := displayName(item, multiRepo)
+		namePlain := displayName(item, multiRepo)
+		name := namePlain
 		if item.Merged {
+			namePlain += " [merged]"
 			name += fmt.Sprintf(" %s[merged]%s", colorDim, colorReset)
 		}
+		// Pad based on plain text width to avoid ANSI miscount
+		padding := nameW - len(namePlain)
+		if padding < 0 {
+			padding = 0
+		}
+		nameCol := name + strings.Repeat(" ", padding)
 
-		line := fmt.Sprintf("%s%s %s%s%s | %-*s | %s%s%s",
+		line := fmt.Sprintf("%s%s %s%s%s | %s | %s%s%s",
 			color, icon, label, dot, colorReset,
-			nameW, name,
+			nameCol,
 			colorDim, shortenPath(item.WtPath), colorReset,
 		)
 		lines = append(lines, line)


### PR DESCRIPTION
## Description of the change

Bug fixes found via deep audit of recent changes:

1. **stack.Save() error unchecked** — `st.Save(bareDir)` in new.go, checkout.go, and rm.go now checks the error return and warns on failure instead of silently dropping stack data.

2. **itemMap collision in picker** — `applyStackOrder` in picker.go now keys by `repo/branch` instead of just `branch`, fixing incorrect tree prefixes when two repos have branches with the same name.

3. **ANSI width misalignment** — `[merged]` tag uses `u.Dim()` which adds invisible ANSI codes. Width calculation now uses plain text length with manual padding, fixing column misalignment in both `ww ls` and the tmux picker.

4. **Tracing in sync command** — Added trace spans to `ww sync` for resolve repo, load stack, list worktrees, and git fetch operations.

## Test plan

- Full test suite passing (`go test ./...`)
- Manual: `ww ls` with merged branches shows properly aligned columns