### PR TITLE
✨ feat: enrich structured logs + fix test Sentry emissions

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -84,18 +84,22 @@ func StartCommand(ctx context.Context, command string) (context.Context, func(er
 			tx.Status = sentry.SpanStatusOK
 		}
 
+		elapsed := float64(time.Since(start).Milliseconds())
+
 		logger := sentry.NewLogger(tx.Context())
 		if err != nil {
 			logger.Warn().
 				String("command", command).
+				Float64("duration_ms", elapsed).
+				String("status", "error").
 				Emitf("command failed: %s", err)
 		} else {
 			logger.Info().
 				String("command", command).
+				Float64("duration_ms", elapsed).
+				String("status", "ok").
 				Emit("command completed")
 		}
-
-		elapsed := float64(time.Since(start).Milliseconds())
 		meter := sentry.NewMeter(tx.Context())
 		meter.Count("cli.command.count", 1,
 			sentry.WithAttributes(attribute.String("command", command)),

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/getsentry/sentry-go"
 )
 
 func TestIsOptedOut_EnvVar(t *testing.T) {
@@ -78,11 +80,9 @@ func TestStartCommand_NoopWhenDisabled(t *testing.T) {
 }
 
 func TestStartCommand_WithTransaction(t *testing.T) {
-	enabled = false
-	os.Unsetenv("WILLOW_TELEMETRY")
-
-	cleanup := Init("dev")
-	defer cleanup()
+	// Use empty DSN so events are silently discarded, not sent to real Sentry
+	sentry.Init(sentry.ClientOptions{EnableTracing: true, EnableLogs: true})
+	enabled = true
 	defer func() { enabled = false }()
 
 	ctx, finish := StartCommand(context.Background(), "new")
@@ -95,11 +95,9 @@ func TestStartCommand_WithTransaction(t *testing.T) {
 }
 
 func TestStartCommand_WithError(t *testing.T) {
-	enabled = false
-	os.Unsetenv("WILLOW_TELEMETRY")
-
-	cleanup := Init("dev")
-	defer cleanup()
+	// Use empty DSN so events are silently discarded, not sent to real Sentry
+	sentry.Init(sentry.ClientOptions{EnableTracing: true, EnableLogs: true})
+	enabled = true
 	defer func() { enabled = false }()
 
 	_, finish := StartCommand(context.Background(), "clone")


### PR DESCRIPTION
## Description of the change

- Add `duration_ms` and `status` attributes to Sentry log entries for queryability
- Fix tests to use empty DSN so `CaptureException` doesn't send phantom errors to real Sentry

## Test plan

- Unit tests (`go test ./internal/telemetry/...`)