### PR TITLE
🐛 fix(new): always fetch for auto-detected base branches

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -242,6 +242,7 @@ func newCmd() *cli.Command {
 			// Resolve base branch: flag → config → auto-detect
 			done = tr.Start("resolve base branch")
 			baseBranch := cmd.String("base")
+			explicitBase := baseBranch != ""
 			if baseBranch == "" {
 				baseBranch = cfg.BaseBranch
 			}
@@ -253,8 +254,11 @@ func newCmd() *cli.Command {
 			}
 			done()
 
-			// Determine if base is a local branch (for stacked PRs) or remote
-			localBase := repoGit.LocalBranchExists(baseBranch)
+			// Only treat as local base when --base was explicitly provided and the
+			// branch exists locally (stacked PRs). Auto-detected defaults always
+			// use origin/ so they stay current — in bare repos every branch appears
+			// local, which previously caused the fetch to be skipped.
+			localBase := explicitBase && repoGit.LocalBranchExists(baseBranch)
 			gitRef := "origin/" + baseBranch
 			if localBase {
 				gitRef = baseBranch


### PR DESCRIPTION
## Description of the change

In bare repos every branch exists as a local ref (`refs/heads/*`), so the `localBase` check was always true — skipping the fetch and forking new worktrees from a stale local master instead of `origin/master`.

Now only treats a branch as local when `--base` was explicitly provided (stacked PR intent). Auto-detected defaults always use `origin/` and fetch latest.

## Test plan

- `go test ./internal/cli/... -run TestNew` — all 6 tests pass
- Manual test: `willow new --trace --repo evergreen` now shows `git fetch` step and uses `origin/master`
- Stacked PR test: `TestNew_StackedBranch` confirms `--base` still uses local branch correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)