### PR TITLE
🐛 fix(telemetry): reduce Sentry noise from user errors and lock contention

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -1,16 +1,16 @@
 package cli
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/urfave/cli/v3"
 )
 
-var errNotWillowRepo = fmt.Errorf("not inside a willow-managed repo\n\nRun this command from a worktree under ~/.willow, or use 'ww ls' to see your repos.")
+var errNotWillowRepo = errs.Userf("not inside a willow-managed repo\n\nRun this command from a worktree under ~/.willow, or use 'ww ls' to see your repos.")
 
 func requireWillowRepo(g *git.Git) (string, error) {
 	bareDir, err := g.BareRepoDir()

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
@@ -73,7 +74,7 @@ func checkoutCmd() *cli.Command {
 				done = tr.Start("resolve PR")
 				prBranch, ok := resolvePRRef(prRef, repos[0].BareDir)
 				if !ok {
-					return fmt.Errorf("failed to resolve PR: %s\n\nEnsure 'gh' is installed and you're authenticated", prRef)
+					return errs.Userf("failed to resolve PR: %s\n\nEnsure 'gh' is installed and you're authenticated", prRef)
 				}
 				if cdOnly {
 					fmt.Fprintf(os.Stderr, "Resolved PR to branch %s\n", prBranch)
@@ -89,7 +90,7 @@ func checkoutCmd() *cli.Command {
 				done = tr.Start("resolve PR branch")
 				prBranch, ok := resolvePRRef(branch, repos[0].BareDir)
 				if !ok {
-					return fmt.Errorf("failed to resolve branch from PR URL: %s\n\nEnsure 'gh' is installed and you're authenticated", branch)
+					return errs.Userf("failed to resolve branch from PR URL: %s\n\nEnsure 'gh' is installed and you're authenticated", branch)
 				}
 				if cdOnly {
 					fmt.Fprintf(os.Stderr, "Resolved PR to branch %s\n", prBranch)
@@ -101,7 +102,7 @@ func checkoutCmd() *cli.Command {
 			}
 
 			if branch == "" {
-				return fmt.Errorf("branch name or PR URL is required\n\nUsage: ww checkout <branch-or-pr-url>")
+				return errs.Userf("branch name or PR URL is required\n\nUsage: ww checkout <branch-or-pr-url>")
 			}
 
 			// Step 1: Check if a worktree already exists for this branch
@@ -130,7 +131,7 @@ func checkoutCmd() *cli.Command {
 			// Resolve to a single repo.
 			done = tr.Start("resolve single repo")
 			if len(repos) > 1 {
-				return fmt.Errorf("multiple repos found — use --repo to specify which one")
+				return errs.Userf("multiple repos found — use --repo to specify which one")
 			}
 			repo := repos[0]
 			done()

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/urfave/cli/v3"
@@ -42,7 +43,7 @@ func cloneCmd() *cli.Command {
 
 			url := cmd.StringArg("url")
 			if url == "" {
-				return fmt.Errorf("repository URL is required\n\nUsage: ww clone <repo-url> [name]")
+				return errs.Userf("repository URL is required\n\nUsage: ww clone <repo-url> [name]")
 			}
 
 			name := cmd.StringArg("name")
@@ -56,7 +57,7 @@ func cloneCmd() *cli.Command {
 
 			if _, err := os.Stat(bareDir); err == nil {
 				if !force {
-					return fmt.Errorf("repository %q already exists at %s\n\nRun with --force to remove it and re-clone", name, bareDir)
+					return errs.Userf("repository %q already exists at %s\n\nRun with --force to remove it and re-clone", name, bareDir)
 				}
 				u.Info(fmt.Sprintf("Removing existing repo %s...", u.Bold(name)))
 				if err := os.RemoveAll(bareDir); err != nil {

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
@@ -147,7 +148,7 @@ func newCmd() *cli.Command {
 				done = tr.Start("resolve PR")
 				prBranch, ok := resolvePRRef(prRef, bareDir)
 				if !ok {
-					return fmt.Errorf("failed to resolve PR: %s\n\nEnsure 'gh' is installed and you're authenticated", prRef)
+					return errs.Userf("failed to resolve PR: %s\n\nEnsure 'gh' is installed and you're authenticated", prRef)
 				}
 				if cdOnly {
 					fmt.Fprintf(os.Stderr, "Resolved PR to branch %s\n", prBranch)
@@ -164,7 +165,7 @@ func newCmd() *cli.Command {
 				done = tr.Start("resolve PR branch")
 				prBranch, ok := resolvePRRef(branch, bareDir)
 				if !ok {
-					return fmt.Errorf("failed to resolve branch from PR URL: %s\n\nEnsure 'gh' is installed and you're authenticated", branch)
+					return errs.Userf("failed to resolve branch from PR URL: %s\n\nEnsure 'gh' is installed and you're authenticated", branch)
 				}
 				if cdOnly {
 					fmt.Fprintf(os.Stderr, "Resolved PR to branch %s\n", prBranch)
@@ -190,7 +191,7 @@ func newCmd() *cli.Command {
 			}
 
 			if branch == "" {
-				return fmt.Errorf("branch name is required\n\nUsage: ww new <branch> [flags]")
+				return errs.Userf("branch name is required\n\nUsage: ww new <branch> [flags]")
 			}
 
 			if existing {
@@ -321,8 +322,8 @@ func finishWorktree(tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, 
 	done = tr.Start("auto setup remote")
 	if *cfg.Defaults.AutoSetupRemote {
 		wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
-		if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
-			return fmt.Errorf("failed to configure push.autoSetupRemote: %w", err)
+		if _, err := wtGit.Run("config", "--lock-timeout", "500", "--local", "push.autoSetupRemote", "true"); err != nil {
+			u.Warn("Failed to set push.autoSetupRemote: " + err.Error())
 		}
 	}
 	done()
@@ -385,7 +386,7 @@ func pickExistingBranch(repoGit *git.Git) (string, error) {
 		return "", fmt.Errorf("failed to list remote branches: %w", err)
 	}
 	if len(remoteBranches) == 0 {
-		return "", fmt.Errorf("no remote branches found")
+		return "", errs.Userf("no remote branches found")
 	}
 
 	wts, err := worktree.List(repoGit)
@@ -406,7 +407,7 @@ func pickExistingBranch(repoGit *git.Git) (string, error) {
 		}
 	}
 	if len(available) == 0 {
-		return "", fmt.Errorf("all remote branches already have worktrees")
+		return "", errs.Userf("all remote branches already have worktrees")
 	}
 
 	selected, err := fzf.Run(available,

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -12,9 +12,10 @@ import (
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
-	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -74,7 +75,7 @@ func rmCmd() *cli.Command {
 				done = tr.Start("collect worktrees")
 				allWts := collectAllWorktrees(repos, g.Verbose)
 				if len(allWts) == 0 {
-					return fmt.Errorf("no worktrees found")
+					return errs.Userf("no worktrees found")
 				}
 				done()
 
@@ -203,7 +204,7 @@ func removeWorktree(tr *trace.Tracer, u *ui.UI, repoGit *git.Git, wt *worktree.W
 	if children := st.Children(wt.Branch); len(children) > 0 && !force {
 		u.Warn(fmt.Sprintf("Branch %s has stacked children: %s", u.Bold(wt.Branch), strings.Join(children, ", ")))
 		u.Warn("Children will be re-parented. Use --force to proceed.")
-		return fmt.Errorf("branch has stacked children (use --force)")
+		return errs.Userf("branch has stacked children (use --force)")
 	}
 
 	if !force {

--- a/internal/cli/sw.go
+++ b/internal/cli/sw.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -59,7 +60,7 @@ func swCmd() *cli.Command {
 			if multiRepo {
 				allWts := collectAllWorktrees(repos, g.Verbose)
 				if len(allWts) == 0 {
-					return fmt.Errorf("no worktrees found")
+					return errs.Userf("no worktrees found")
 				}
 
 				lines := buildCrossRepoWorktreeLines(allWts)
@@ -93,7 +94,7 @@ func swCmd() *cli.Command {
 
 			filtered := filterBareWorktrees(worktrees)
 			if len(filtered) == 0 {
-				return fmt.Errorf("no worktrees found")
+				return errs.Userf("no worktrees found")
 			}
 
 			repoName := repos[0].Name

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
@@ -93,7 +94,7 @@ func syncCmd() *cli.Command {
 			var branches []string
 			if targetBranch := cmd.StringArg("branch"); targetBranch != "" {
 				if !st.IsTracked(targetBranch) {
-					return fmt.Errorf("branch %q is not in the stack", targetBranch)
+					return errs.Userf("branch %q is not in the stack", targetBranch)
 				}
 				branches = st.SubtreeSort(targetBranch)
 			} else {

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/dashboard"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
@@ -182,7 +183,7 @@ func tmuxSwCmd() *cli.Command {
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			wtPath := cmd.StringArg("path")
 			if wtPath == "" {
-				return fmt.Errorf("worktree path is required")
+				return errs.Userf("worktree path is required")
 			}
 
 			wtDir := filepath.Base(wtPath)
@@ -223,7 +224,7 @@ func tmuxPickSwitch(selection string, items []tmux.PickerItem) error {
 
 func tmuxPickNew(self, query, repoFilter string, items []tmux.PickerItem) error {
 	if query == "" {
-		return fmt.Errorf("enter a branch name first")
+		return errs.Userf("enter a branch name first")
 	}
 
 	repo, err := resolveRepo(repoFilter, items)
@@ -277,7 +278,7 @@ func tmuxPickExisting(self, repoFilter string, items []tmux.PickerItem) error {
 		return fmt.Errorf("failed to list remote branches: %w", err)
 	}
 	if len(remoteBranches) == 0 {
-		return fmt.Errorf("no remote branches found")
+		return errs.Userf("no remote branches found")
 	}
 
 	// Filter out branches that already have worktrees
@@ -298,7 +299,7 @@ func tmuxPickExisting(self, repoFilter string, items []tmux.PickerItem) error {
 		}
 	}
 	if len(available) == 0 {
-		return fmt.Errorf("all remote branches already have worktrees")
+		return errs.Userf("all remote branches already have worktrees")
 	}
 
 	// Pick branch in-process (no nested shell-out)
@@ -354,7 +355,7 @@ func tmuxPickPR(self, repoFilter string, items []tmux.PickerItem) error {
 
 	ghPath, err := exec.LookPath("gh")
 	if err != nil {
-		return fmt.Errorf("gh CLI is required for PR picker")
+		return errs.Userf("gh CLI is required for PR picker")
 	}
 
 	cmd := exec.Command(ghPath, "pr", "list", "--json", "number,title,author,headRefName",
@@ -367,7 +368,7 @@ func tmuxPickPR(self, repoFilter string, items []tmux.PickerItem) error {
 
 	raw := strings.TrimSpace(string(out))
 	if raw == "" {
-		return fmt.Errorf("no open PRs found")
+		return errs.Userf("no open PRs found")
 	}
 	lines := strings.Split(raw, "\n")
 
@@ -448,7 +449,7 @@ func resolveRepo(repoFilter string, items []tmux.PickerItem) (string, error) {
 
 	repos, err := config.ListRepos()
 	if err != nil || len(repos) == 0 {
-		return "", fmt.Errorf("no repos found — run 'ww clone' first")
+		return "", errs.Userf("no repos found — run 'ww clone' first")
 	}
 
 	if len(repos) == 1 {
@@ -483,7 +484,7 @@ func resolveRepo(repoFilter string, items []tmux.PickerItem) (string, error) {
 
 	selected, err := fzf.Run(repos, fzf.WithHeader("Pick a repo"), fzf.WithReverse())
 	if err != nil || selected == "" {
-		return "", fmt.Errorf("no repo selected")
+		return "", errs.Userf("no repo selected")
 	}
 	return selected, nil
 }

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -58,7 +59,7 @@ func findWorktree(worktrees []worktree.Worktree, target string) (*worktree.Workt
 
 	switch len(matches) {
 	case 0:
-		return nil, fmt.Errorf("no worktree found matching %q", target)
+		return nil, errs.Userf("no worktree found matching %q", target)
 	case 1:
 		return &matches[0], nil
 	default:
@@ -66,7 +67,7 @@ func findWorktree(worktrees []worktree.Worktree, target string) (*worktree.Workt
 		for _, wt := range matches {
 			lines += fmt.Sprintf("  %s  %s\n", wt.Branch, wt.Path)
 		}
-		return nil, fmt.Errorf("%s", strings.TrimRight(lines, "\n"))
+		return nil, errs.User(fmt.Errorf("%s", strings.TrimRight(lines, "\n")))
 	}
 }
 
@@ -112,7 +113,7 @@ func resolveRepos(g *git.Git, repoFlag string) ([]repoInfo, error) {
 		return nil, fmt.Errorf("failed to list repos: %w", err)
 	}
 	if len(repos) == 0 {
-		return nil, fmt.Errorf("no willow-managed repos found\n\nUse 'ww clone <url>' to get started.")
+		return nil, errs.Userf("no willow-managed repos found\n\nUse 'ww clone <url>' to get started.")
 	}
 
 	var result []repoInfo
@@ -157,7 +158,7 @@ func findCrossRepoWorktree(rwts []repoWorktree, target string) (*repoWorktree, e
 
 	switch len(matches) {
 	case 0:
-		return nil, fmt.Errorf("no worktree found matching %q", target)
+		return nil, errs.Userf("no worktree found matching %q", target)
 	case 1:
 		return &matches[0], nil
 	default:
@@ -165,7 +166,7 @@ func findCrossRepoWorktree(rwts []repoWorktree, target string) (*repoWorktree, e
 		for _, rwt := range matches {
 			lines += fmt.Sprintf("  %s/%s  %s\n", rwt.Repo.Name, rwt.Worktree.Branch, rwt.Worktree.Path)
 		}
-		return nil, fmt.Errorf("%s", strings.TrimRight(lines, "\n"))
+		return nil, errs.User(fmt.Errorf("%s", strings.TrimRight(lines, "\n")))
 	}
 }
 
@@ -268,4 +269,3 @@ func completeWorktreesWithFlag(ctx context.Context, cmd *cli.Command) {
 
 	completeWorktreesCrossRepo(ctx, cmd)
 }
-

--- a/internal/errs/errs.go
+++ b/internal/errs/errs.go
@@ -1,0 +1,36 @@
+package errs
+
+import (
+	"errors"
+	"fmt"
+)
+
+// userError wraps an error to mark it as an expected user-facing error
+// (wrong directory, bad args, missing tools) that should not be
+// reported to error tracking as a bug.
+type userError struct {
+	err error
+}
+
+func (e *userError) Error() string     { return e.err.Error() }
+func (e *userError) Unwrap() error     { return e.err }
+func (e *userError) IsUserError() bool { return true }
+
+// User wraps err to mark it as a user error.
+func User(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &userError{err: err}
+}
+
+// Userf creates a new user error with a formatted message.
+func Userf(format string, args ...any) error {
+	return &userError{err: fmt.Errorf(format, args...)}
+}
+
+// IsUser reports whether err (or any error in its chain) is a user error.
+func IsUser(err error) bool {
+	var ue interface{ IsUserError() bool }
+	return errors.As(err, &ue)
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/getsentry/sentry-go/attribute"
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
 )
 
 var enabled bool
@@ -78,8 +79,12 @@ func StartCommand(ctx context.Context, command string) (context.Context, func(er
 
 	return tx.Context(), func(err error) {
 		if err != nil {
-			tx.Status = sentry.SpanStatusInternalError
-			sentry.CaptureException(err)
+			if errs.IsUser(err) {
+				tx.Status = sentry.SpanStatusInvalidArgument
+			} else {
+				tx.Status = sentry.SpanStatusInternalError
+				sentry.CaptureException(err)
+			}
 		} else {
 			tx.Status = sentry.SpanStatusOK
 		}
@@ -88,10 +93,15 @@ func StartCommand(ctx context.Context, command string) (context.Context, func(er
 
 		logger := sentry.NewLogger(tx.Context())
 		if err != nil {
+			errorType := "system"
+			if errs.IsUser(err) {
+				errorType = "user"
+			}
 			logger.Warn().
 				String("command", command).
 				Float64("duration_ms", elapsed).
 				String("status", "error").
+				String("error_type", errorType).
 				Emitf("command failed: %s", err)
 		} else {
 			logger.Info().


### PR DESCRIPTION
## Description of the change

Two Sentry issues that shouldn't be bugs:

1. **Lock contention on `push.autoSetupRemote`** — `git config` fails with exit 255 when another process holds the config lock. Now uses `--lock-timeout 500` so git retries natively, and downgrades to a warning if it still fails (shouldn't kill `willow new`).

2. **"not inside a willow-managed repo"** — expected user error when running commands from the wrong directory. Introduces a `UserError` type that telemetry recognizes via `errors.As` and skips `CaptureException` for.

## Test plan

- `go test ./...` passes
- Verified build compiles cleanly