### PR TITLE
✨ feat(tmux): per-pane commands for tmux sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,10 @@ Config merges two tiers (local wins):
   },
   "tmux": {
     "layout": ["split-window -h", "select-layout even-horizontal"],
-    "postWorktreeCreate": ["cd website"]
+    "panes": [
+      { "command": "cd website" },
+      { "command": "cd website" }
+    ]
   }
 }
 ```

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -337,6 +337,18 @@ func finishWorktree(tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, 
 	}
 	done()
 
+	done = tr.Start("pane commands")
+	if len(cfg.Tmux.Panes) > 0 && !cdOnly {
+		for _, p := range cfg.Tmux.Panes {
+			if p.Command != "" {
+				if err := runHooks([]string{p.Command}, wtPath, u); err != nil {
+					return errs.User(err)
+				}
+			}
+		}
+	}
+	done()
+
 	tr.Total()
 
 	if cdOnly {

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -192,7 +192,7 @@ func tmuxSwCmd() *cli.Command {
 			sessName := tmux.SessionNameForWorktree(repoName, wtDir)
 			if !tmux.SessionExists(sessName) {
 				cfg := loadRepoConfig(repoName)
-				if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
+				if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.Panes); err != nil {
 					return fmt.Errorf("failed to create session: %w", err)
 				}
 			}
@@ -213,7 +213,7 @@ func tmuxPickSwitch(selection string, items []tmux.PickerItem) error {
 	sessName := tmux.SessionNameForWorktree(item.RepoName, item.WtDirName)
 	if !tmux.SessionExists(sessName) {
 		cfg := loadRepoConfig(item.RepoName)
-		if err := tmux.NewSession(sessName, item.WtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
+		if err := tmux.NewSession(sessName, item.WtPath, cfg.Tmux.Layout, cfg.Tmux.Panes); err != nil {
 			return fmt.Errorf("failed to create session: %w", err)
 		}
 	}
@@ -253,7 +253,7 @@ func tmuxPickNew(self, query, repoFilter string, items []tmux.PickerItem) error 
 	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
 	if !tmux.SessionExists(sessName) {
 		cfg := loadRepoConfig(repoName)
-		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
+		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.Panes); err != nil {
 			return fmt.Errorf("failed to create session: %w", err)
 		}
 	}
@@ -334,7 +334,7 @@ func tmuxPickExisting(self, repoFilter string, items []tmux.PickerItem) error {
 	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
 	if !tmux.SessionExists(sessName) {
 		cfg := loadRepoConfig(repoName)
-		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
+		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.Panes); err != nil {
 			return fmt.Errorf("failed to create session: %w", err)
 		}
 	}
@@ -407,7 +407,7 @@ func tmuxPickPR(self, repoFilter string, items []tmux.PickerItem) error {
 	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
 	if !tmux.SessionExists(sessName) {
 		cfg := loadRepoConfig(repoName)
-		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.PostWorktreeCreate); err != nil {
+		if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.Panes); err != nil {
 			return fmt.Errorf("failed to create session: %w", err)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,8 +26,12 @@ type TmuxConfig struct {
 	NotifyCommand     string       `json:"notifyCommand,omitempty"`
 	NotifyWaitCommand string       `json:"notifyWaitCommand,omitempty"`
 	SwitcherPreview   *bool        `json:"switcherPreview,omitempty"`
-	Layout             []string `json:"layout,omitempty"`
-	PostWorktreeCreate []string `json:"postWorktreeCreate,omitempty"`
+	Layout            []string     `json:"layout,omitempty"`
+	Panes             []PaneConfig `json:"panes,omitempty"`
+}
+
+type PaneConfig struct {
+	Command string `json:"command,omitempty"`
 }
 
 type Defaults struct {
@@ -219,8 +223,8 @@ func merge(base, overlay *Config) {
 	if overlay.Tmux.Layout != nil {
 		base.Tmux.Layout = overlay.Tmux.Layout
 	}
-	if overlay.Tmux.PostWorktreeCreate != nil {
-		base.Tmux.PostWorktreeCreate = overlay.Tmux.PostWorktreeCreate
+	if overlay.Tmux.Panes != nil {
+		base.Tmux.Panes = overlay.Tmux.Panes
 	}
 	if overlay.Telemetry != nil {
 		base.Telemetry = overlay.Telemetry

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -526,25 +526,56 @@ func TestMerge_NotifyWaitCommand(t *testing.T) {
 	}
 }
 
-func TestMerge_PostWorktreeCreate(t *testing.T) {
-	base := &Config{Tmux: TmuxConfig{PostWorktreeCreate: []string{"cd old"}}}
-	overlay := &Config{Tmux: TmuxConfig{PostWorktreeCreate: []string{"cd website", "nvm use"}}}
+func TestMerge_Panes(t *testing.T) {
+	base := &Config{Tmux: TmuxConfig{Panes: []PaneConfig{{Command: "old"}}}}
+	overlay := &Config{Tmux: TmuxConfig{Panes: []PaneConfig{{}, {Command: "dev sync --only install"}}}}
 
 	merge(base, overlay)
 
-	if len(base.Tmux.PostWorktreeCreate) != 2 || base.Tmux.PostWorktreeCreate[0] != "cd website" {
-		t.Errorf("PostWorktreeCreate = %v, want [cd website, nvm use]", base.Tmux.PostWorktreeCreate)
+	if len(base.Tmux.Panes) != 2 || base.Tmux.Panes[1].Command != "dev sync --only install" {
+		t.Errorf("Panes = %v, want [{} {dev sync --only install}]", base.Tmux.Panes)
 	}
 }
 
-func TestMerge_PostWorktreeCreate_NilDoesNotOverride(t *testing.T) {
-	base := &Config{Tmux: TmuxConfig{PostWorktreeCreate: []string{"cd website"}}}
+func TestMerge_Panes_NilDoesNotOverride(t *testing.T) {
+	base := &Config{Tmux: TmuxConfig{Panes: []PaneConfig{{Command: "cd website"}}}}
 	overlay := &Config{}
 
 	merge(base, overlay)
 
-	if len(base.Tmux.PostWorktreeCreate) != 1 || base.Tmux.PostWorktreeCreate[0] != "cd website" {
-		t.Errorf("PostWorktreeCreate = %v, want [cd website]", base.Tmux.PostWorktreeCreate)
+	if len(base.Tmux.Panes) != 1 || base.Tmux.Panes[0].Command != "cd website" {
+		t.Errorf("Panes = %v, want [{cd website}]", base.Tmux.Panes)
+	}
+}
+
+func TestPanes_JSONRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	cfg := &Config{
+		Tmux: TmuxConfig{
+			Layout: []string{"split-window -h"},
+			Panes:  []PaneConfig{{}, {Command: "dev sync"}},
+		},
+	}
+
+	if err := Save(cfg, path); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error: %v", err)
+	}
+
+	if len(loaded.Tmux.Panes) != 2 {
+		t.Fatalf("Panes length = %d, want 2", len(loaded.Tmux.Panes))
+	}
+	if loaded.Tmux.Panes[0].Command != "" {
+		t.Errorf("Panes[0].Command = %q, want empty", loaded.Tmux.Panes[0].Command)
+	}
+	if loaded.Tmux.Panes[1].Command != "dev sync" {
+		t.Errorf("Panes[1].Command = %q, want %q", loaded.Tmux.Panes[1].Command, "dev sync")
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/config"
 )
 
 func InTmux() bool {
@@ -33,8 +35,8 @@ func SendKeys(target string, keys ...string) error {
 // NewSession creates a tmux session and applies layout commands.
 // Layout entries are raw tmux subcommands (e.g. "split-window -h").
 // The session target (-t) and working directory (-c) are auto-injected.
-// After layout setup, postWorktreeCreate commands are sent to every pane.
-func NewSession(name, dir string, layout []string, postWorktreeCreate []string) error {
+// After layout setup, each pane receives its configured command (by index).
+func NewSession(name, dir string, layout []string, panes []config.PaneConfig) error {
 	if _, err := run("new-session", "-d", "-s", name, "-c", dir); err != nil {
 		return err
 	}
@@ -44,9 +46,10 @@ func NewSession(name, dir string, layout []string, postWorktreeCreate []string) 
 		run(args...)
 	}
 
-	for _, paneID := range listSessionPanes(name) {
-		for _, cmd := range postWorktreeCreate {
-			SendKeys(paneID, cmd, "Enter")
+	paneIDs := listSessionPanes(name)
+	for i, paneID := range paneIDs {
+		if i < len(panes) && panes[i].Command != "" {
+			SendKeys(paneID, panes[i].Command, "Enter")
 		}
 	}
 

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -27,9 +27,10 @@ The local config lives inside the bare repo directory, so it's private to your m
   "tmux": {
     "notification": true,
     "notifyCommand": "afplay /System/Library/Sounds/Glass.aiff",
-    "layout": [
-      { "name": "claude", "panes": 1 },
-      { "name": "dev", "panes": 4, "layout": "tiled" }
+    "layout": ["split-window -h"],
+    "panes": [
+      {},
+      { "command": "dev sync --only install_system_deps" }
     ]
   },
   "telemetry": true
@@ -50,7 +51,7 @@ The local config lives inside the bare repo directory, so it's private to your m
 | `tmux.notification` | `boolean` | Play sound on BUSY→DONE transitions (default: `true`) |
 | `tmux.notifyCommand` | `string` | Command to run for notifications (default: `afplay Glass.aiff`) |
 | `tmux.layout` | `string[]` | Raw tmux subcommands to run after session creation (e.g. `["split-window -h", "select-layout even-horizontal"]`) |
-| `tmux.postWorktreeCreate` | `string[]` | Commands sent to every pane after session setup (e.g. `["cd website"]`) |
+| `tmux.panes` | `PaneConfig[]` | Per-pane commands, indexed by pane order. Pane 0 is the initial pane, pane 1 is the first split, etc. Each entry: `{ "command": "..." }` |
 | `telemetry` | `boolean` | Enable/disable anonymous usage telemetry (default: `true`). Also controllable via `WILLOW_TELEMETRY=off` env var |
 
 ## Directory structure

--- a/website/docs/tmux/index.md
+++ b/website/docs/tmux/index.md
@@ -102,9 +102,9 @@ By default, `willow tmux` creates a single window with one pane for each worktre
 
 Any tmux subcommand works: `split-window`, `new-window`, `select-layout`, `resize-pane`, etc.
 
-### Pane init commands
+### Per-pane commands
 
-Use `tmux.postWorktreeCreate` to send shell commands to every pane after the layout is set up. These run once when a session is first created.
+Use `tmux.panes` to send different commands to specific panes after the layout is set up. The array index maps to the pane index — pane 0 is the initial pane created by `new-session`, pane 1 is created by the first `split-window`, and so on. Panes without a config entry (or with an empty `command`) receive no command.
 
 ```jsonc
 {
@@ -113,12 +113,33 @@ Use `tmux.postWorktreeCreate` to send shell commands to every pane after the lay
       "split-window -h",
       "select-layout even-horizontal"
     ],
-    "postWorktreeCreate": ["cd website"]
+    "panes": [
+      { "command": "cd website" },
+      { "command": "cd website" }
+    ]
   }
 }
 ```
 
 This creates two side-by-side panes, each starting in the `website/` subdirectory.
+
+To run a command in only one pane, leave the others empty:
+
+```jsonc
+{
+  "tmux": {
+    "layout": ["split-window -h"],
+    "panes": [
+      {},
+      { "command": "dev sync --only install_system_deps,install_python_deps" }
+    ]
+  }
+}
+```
+
+The left pane (index 0) gets no startup command. The right pane (index 1) runs `dev sync`.
+
+Outside tmux (during `willow new`), pane commands run sequentially in the foreground after setup hooks.
 
 ## Shell integration
 


### PR DESCRIPTION
## Description of the change

Replace `postWorktreeCreate` (which sent the same commands to every pane) with `panes` — an indexed array where each entry targets a specific pane by index.

```json
{
  "tmux": {
    "layout": ["split-window -h"],
    "panes": [
      {},
      { "command": "dev sync --only install_system_deps,install_python_deps" }
    ]
  }
}
```

Pane 0 = initial pane (from `new-session`), pane 1 = first `split-window`, etc. Outside tmux, pane commands run sequentially after setup hooks during `willow new`.

**Breaking change**: `postWorktreeCreate` is removed. Replace with `panes` array.

## Test plan

- Unit tests for config merge, JSON round-trip, nil-does-not-override
- `go test ./... -count=1` passes