### PR TITLE
🐛 fix(tmux): error handling, config validation, and tests

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -338,11 +338,16 @@ func finishWorktree(tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, 
 	done()
 
 	done = tr.Start("pane commands")
+	if !cdOnly {
+		for _, w := range cfg.Validate() {
+			u.Warn(w)
+		}
+	}
 	if len(cfg.Tmux.Panes) > 0 && !cdOnly {
-		for _, p := range cfg.Tmux.Panes {
+		for i, p := range cfg.Tmux.Panes {
 			if p.Command != "" {
 				if err := runHooks([]string{p.Command}, wtPath, u); err != nil {
-					return errs.User(err)
+					return errs.User(fmt.Errorf("pane %d command failed: %w", i, err))
 				}
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -231,6 +231,32 @@ func merge(base, overlay *Config) {
 	}
 }
 
+// Validate checks for common config issues and returns warnings.
+// Returns nil if config is valid.
+func (cfg *Config) Validate() []string {
+	var warnings []string
+
+	if len(cfg.Tmux.Panes) > 0 && len(cfg.Tmux.Layout) == 0 {
+		warnings = append(warnings, "tmux.panes configured but tmux.layout is empty — only pane 0 will receive commands")
+	}
+
+	if len(cfg.Tmux.Panes) > 0 && len(cfg.Tmux.Layout) > 0 {
+		// Estimate pane count: 1 (initial) + number of split-window/new-window commands
+		estimated := 1
+		for _, cmd := range cfg.Tmux.Layout {
+			parts := strings.Fields(cmd)
+			if len(parts) > 0 && (parts[0] == "split-window" || parts[0] == "new-window") {
+				estimated++
+			}
+		}
+		if len(cfg.Tmux.Panes) > estimated {
+			warnings = append(warnings, fmt.Sprintf("tmux.panes has %d entries but layout creates ~%d panes — extra entries will be ignored", len(cfg.Tmux.Panes), estimated))
+		}
+	}
+
+	return warnings
+}
+
 // Save writes a config to the given path, creating directories as needed.
 func Save(cfg *Config, path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -576,6 +577,75 @@ func TestPanes_JSONRoundTrip(t *testing.T) {
 	}
 	if loaded.Tmux.Panes[1].Command != "dev sync" {
 		t.Errorf("Panes[1].Command = %q, want %q", loaded.Tmux.Panes[1].Command, "dev sync")
+	}
+}
+
+func TestValidate_PanesWithoutLayout(t *testing.T) {
+	cfg := &Config{
+		Tmux: TmuxConfig{
+			Panes: []PaneConfig{{Command: "echo hi"}},
+		},
+	}
+
+	warnings := cfg.Validate()
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "layout is empty") {
+		t.Errorf("expected layout warning, got %q", warnings[0])
+	}
+}
+
+func TestValidate_MorePanesThanLayout(t *testing.T) {
+	cfg := &Config{
+		Tmux: TmuxConfig{
+			Layout: []string{"split-window -h"},
+			Panes:  []PaneConfig{{}, {}, {Command: "echo extra"}},
+		},
+	}
+
+	warnings := cfg.Validate()
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "extra entries") {
+		t.Errorf("expected pane count warning, got %q", warnings[0])
+	}
+}
+
+func TestValidate_ValidConfig(t *testing.T) {
+	cfg := &Config{
+		Tmux: TmuxConfig{
+			Layout: []string{"split-window -h"},
+			Panes:  []PaneConfig{{}, {Command: "echo ok"}},
+		},
+	}
+
+	warnings := cfg.Validate()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestValidate_NoPanes(t *testing.T) {
+	cfg := &Config{}
+	warnings := cfg.Validate()
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for empty config, got %v", warnings)
+	}
+}
+
+func TestValidate_SelectLayoutNotCounted(t *testing.T) {
+	cfg := &Config{
+		Tmux: TmuxConfig{
+			Layout: []string{"split-window -h", "select-layout even-horizontal"},
+			Panes:  []PaneConfig{{}, {Command: "echo ok"}},
+		},
+	}
+
+	warnings := cfg.Validate()
+	if len(warnings) != 0 {
+		t.Errorf("select-layout should not count as a pane, got warnings: %v", warnings)
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -43,13 +43,17 @@ func NewSession(name, dir string, layout []string, panes []config.PaneConfig) er
 
 	for _, cmd := range layout {
 		args := prepareLayoutCmd(strings.Fields(cmd), name, dir)
-		run(args...)
+		if _, err := run(args...); err != nil {
+			return fmt.Errorf("layout command %q: %w", cmd, err)
+		}
 	}
 
 	paneIDs := listSessionPanes(name)
 	for i, paneID := range paneIDs {
 		if i < len(panes) && panes[i].Command != "" {
-			SendKeys(paneID, panes[i].Command, "Enter")
+			if err := SendKeys(paneID, panes[i].Command, "Enter"); err != nil {
+				return fmt.Errorf("pane %d command: %w", i, err)
+			}
 		}
 	}
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,0 +1,91 @@
+package tmux
+
+import (
+	"testing"
+)
+
+func TestPrepareLayoutCmd_InjectsSessionTarget(t *testing.T) {
+	args := prepareLayoutCmd([]string{"split-window", "-h"}, "mysession", "/tmp/dir")
+
+	if args[0] != "split-window" {
+		t.Errorf("args[0] = %q, want %q", args[0], "split-window")
+	}
+	if args[1] != "-t" || args[2] != "mysession" {
+		t.Errorf("expected -t mysession, got %v", args[1:3])
+	}
+}
+
+func TestPrepareLayoutCmd_InjectsWorkingDir(t *testing.T) {
+	args := prepareLayoutCmd([]string{"split-window", "-h"}, "sess", "/work")
+
+	found := false
+	for i, a := range args {
+		if a == "-c" && i+1 < len(args) && args[i+1] == "/work" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected -c /work in args, got %v", args)
+	}
+}
+
+func TestPrepareLayoutCmd_SkipsTargetIfPresent(t *testing.T) {
+	args := prepareLayoutCmd([]string{"split-window", "-t", "custom"}, "sess", "/work")
+
+	count := 0
+	for _, a := range args {
+		if a == "-t" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 -t flag, got %d in %v", count, args)
+	}
+}
+
+func TestPrepareLayoutCmd_SkipsDirIfPresent(t *testing.T) {
+	args := prepareLayoutCmd([]string{"split-window", "-c", "/custom"}, "sess", "/work")
+
+	count := 0
+	for _, a := range args {
+		if a == "-c" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 -c flag, got %d in %v", count, args)
+	}
+}
+
+func TestPrepareLayoutCmd_NoDirForSelectLayout(t *testing.T) {
+	args := prepareLayoutCmd([]string{"select-layout", "even-horizontal"}, "sess", "/work")
+
+	for _, a := range args {
+		if a == "-c" {
+			t.Errorf("select-layout should not get -c flag, got %v", args)
+		}
+	}
+}
+
+func TestPrepareLayoutCmd_NewWindowGetsDir(t *testing.T) {
+	args := prepareLayoutCmd([]string{"new-window"}, "sess", "/work")
+
+	found := false
+	for i, a := range args {
+		if a == "-c" && i+1 < len(args) && args[i+1] == "/work" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("new-window should get -c /work, got %v", args)
+	}
+}
+
+func TestPrepareLayoutCmd_EmptyArgs(t *testing.T) {
+	args := prepareLayoutCmd([]string{}, "sess", "/work")
+	if len(args) != 0 {
+		t.Errorf("expected empty args, got %v", args)
+	}
+}


### PR DESCRIPTION
## Description of the change

Four improvements to the tmux per-pane commands feature:

1. **Bug fix**: `NewSession()` was silently swallowing errors from layout commands and `SendKeys`. Now returns proper errors so users see what went wrong instead of getting broken sessions.

2. **Config validation**: `Config.Validate()` warns when panes are configured without layout (only pane 0 would work) or when pane entries exceed the number of panes layout creates.

3. **Telemetry**: Pane command failures now include the pane index in the error message (`pane 2 command failed: ...`), making them distinguishable from other errors in Sentry.

4. **Tests**: Added 12 new tests — 7 for `prepareLayoutCmd` (flag injection, dedup, subcommand-specific behavior) and 5 for config validation.

## Test plan

- `go test ./... -count=1` — all 12 new tests pass, full suite green