### PR TITLE
🐛 fix(config): deprecation warning for postWorktreeCreate

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,9 @@ type TmuxConfig struct {
 	SwitcherPreview   *bool        `json:"switcherPreview,omitempty"`
 	Layout            []string     `json:"layout,omitempty"`
 	Panes             []PaneConfig `json:"panes,omitempty"`
+
+	// Deprecated: captured for migration warnings only.
+	DeprecatedPostWorktreeCreate []string `json:"postWorktreeCreate,omitempty"`
 }
 
 type PaneConfig struct {
@@ -235,6 +238,10 @@ func merge(base, overlay *Config) {
 // Returns nil if config is valid.
 func (cfg *Config) Validate() []string {
 	var warnings []string
+
+	if len(cfg.Tmux.DeprecatedPostWorktreeCreate) > 0 {
+		warnings = append(warnings, "tmux.postWorktreeCreate is deprecated — migrate to tmux.panes (see https://getwillow.dev/configuration/)")
+	}
 
 	if len(cfg.Tmux.Panes) > 0 && len(cfg.Tmux.Layout) == 0 {
 		warnings = append(warnings, "tmux.panes configured but tmux.layout is empty — only pane 0 will receive commands")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -580,6 +580,49 @@ func TestPanes_JSONRoundTrip(t *testing.T) {
 	}
 }
 
+func TestValidate_DeprecatedPostWorktreeCreate(t *testing.T) {
+	cfg := &Config{
+		Tmux: TmuxConfig{
+			DeprecatedPostWorktreeCreate: []string{"cd website"},
+		},
+	}
+
+	warnings := cfg.Validate()
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "postWorktreeCreate is deprecated") {
+		t.Errorf("expected deprecation warning, got %q", warnings[0])
+	}
+}
+
+func TestValidate_DeprecatedFieldFromJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{
+		"tmux": {
+			"postWorktreeCreate": ["cd website"],
+			"layout": ["split-window -h"]
+		}
+	}`), 0o644)
+
+	cfg, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error: %v", err)
+	}
+
+	warnings := cfg.Validate()
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "postWorktreeCreate is deprecated") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected deprecation warning from old config, got: %v", warnings)
+	}
+}
+
 func TestValidate_PanesWithoutLayout(t *testing.T) {
 	cfg := &Config{
 		Tmux: TmuxConfig{


### PR DESCRIPTION
## Description of the change

Users upgrading to v1.1.0 with old `postWorktreeCreate` configs get silently broken — Go's `json.Unmarshal` discards unknown fields without error, so their pane commands just stop working with zero warning.

Fix: add a deprecated capture field to `TmuxConfig` that catches old configs during JSON parsing, then emit a warning via `Config.Validate()` telling users to migrate to `tmux.panes`.

## Test plan

- `TestValidate_DeprecatedPostWorktreeCreate` — struct-level detection
- `TestValidate_DeprecatedFieldFromJSON` — full JSON round-trip: loads old config, verifies warning fires
- `go test ./... -count=1` all green