### PR TITLE
🐛 fix(new): post-checkout hook stdout breaks tmux pane directory

### DIFF
--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -123,7 +123,7 @@ func cloneCmd() *cli.Command {
 
 			done = tr.Start("post-checkout hook")
 			cfg := config.Load(bareDir)
-			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
+			runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u, false)
 			done()
 
 			tr.Total()

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -42,7 +42,7 @@ func runHooks(commands []string, dir string, u *ui.UI) error {
 // the new worktree. This is needed for bare repos because git resolves relative
 // core.hooksPath against the bare repo dir (where hook files don't exist),
 // so the hook never fires automatically.
-func runPostCheckoutHook(hookPath, wtPath string, u *ui.UI) {
+func runPostCheckoutHook(hookPath, wtPath string, u *ui.UI, cdOnly bool) {
 	if hookPath == "" {
 		return
 	}
@@ -62,7 +62,13 @@ func runPostCheckoutHook(hookPath, wtPath string, u *ui.UI) {
 	nullRef := "0000000000000000000000000000000000000000"
 	cmd := exec.Command(hookFile, nullRef, head, "1")
 	cmd.Dir = wtPath
-	cmd.Stdout = os.Stdout
+	// In --cd mode stdout is captured for the worktree path, so redirect
+	// hook output to stderr to avoid contaminating it.
+	if cdOnly {
+		cmd.Stdout = os.Stderr
+	} else {
+		cmd.Stdout = os.Stdout
+	}
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		u.Warn(fmt.Sprintf("post-checkout hook failed: %v", err))
@@ -316,7 +322,7 @@ func newCmd() *cli.Command {
 
 func finishWorktree(tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, wtPath, repoName, branch, baseBranch string, cdOnly bool) error {
 	done := tr.Start("post-checkout hook")
-	runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u)
+	runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u, cdOnly)
 	done()
 
 	done = tr.Start("auto setup remote")


### PR DESCRIPTION
## Description of the change

When the tmux picker creates a worktree via `willow new --cd`, it captures stdout to get the worktree path. But `runPostCheckoutHook` pipes hook output (e.g. `.husky/post-checkout`) to `os.Stdout`, contaminating the captured path. tmux then receives a garbage `-c` directory path and defaults to `~`.

**Symptom**: Panes open in home directory instead of the worktree. `dev` and other project-local tools are not found.

**Fix**: Redirect hook stdout to stderr in `--cd` mode so it doesn't contaminate the path output.

## Test plan

- `go test ./... -count=1` all green
- Manual: create worktree from tmux picker for a repo with postCheckoutHook configured, verify panes open in correct directory