### PR TITLE
🐛 fix(new): route all UI output to stderr in --cd mode

### DIFF
--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -58,6 +58,9 @@ func checkoutCmd() *cli.Command {
 			g := flags.NewGit()
 			u := flags.NewUI()
 			cdOnly := cmd.Bool("cd")
+			if cdOnly {
+				u.Out = os.Stderr
+			}
 
 			branch := cmd.StringArg("branch")
 

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -121,6 +121,9 @@ func newCmd() *cli.Command {
 			g := flags.NewGit()
 			u := flags.NewUI()
 			cdOnly := cmd.Bool("cd")
+			if cdOnly {
+				u.Out = os.Stderr
+			}
 			existing := cmd.Bool("existing")
 
 			// Resolve repo

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -15,18 +16,27 @@ const (
 	cyan   = "\033[36m"
 )
 
-type UI struct{}
+type UI struct {
+	Out io.Writer // defaults to os.Stdout
+}
+
+func (u *UI) out() io.Writer {
+	if u.Out != nil {
+		return u.Out
+	}
+	return os.Stdout
+}
 
 func (u *UI) Success(msg string) {
-	fmt.Printf("%s %s\n", u.Green("✔"), msg)
+	fmt.Fprintf(u.out(), "%s %s\n", u.Green("✔"), msg)
 }
 
 func (u *UI) Info(msg string) {
-	fmt.Println(msg)
+	fmt.Fprintln(u.out(), msg)
 }
 
 func (u *UI) Warn(msg string) {
-	fmt.Printf("%s %s\n", u.Yellow("⚠"), msg)
+	fmt.Fprintf(u.out(), "%s %s\n", u.Yellow("⚠"), msg)
 }
 
 func (u *UI) Errorf(format string, args ...any) {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -1,6 +1,10 @@
 package ui
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
 
 func TestBold(t *testing.T) {
 	u := &UI{}
@@ -53,6 +57,46 @@ func TestDim(t *testing.T) {
 	want := dim + "faded" + reset
 	if got != want {
 		t.Errorf("Dim() = %q, want %q", got, want)
+	}
+}
+
+func TestUI_DefaultWritesToStdout(t *testing.T) {
+	u := &UI{}
+	if u.out() != nil {
+		// out() returns os.Stdout by default, just verify it doesn't panic
+	}
+}
+
+func TestUI_CustomOut(t *testing.T) {
+	var buf bytes.Buffer
+	u := &UI{Out: &buf}
+
+	u.Info("hello")
+	u.Warn("oops")
+	u.Success("done")
+
+	out := buf.String()
+	if !strings.Contains(out, "hello") {
+		t.Errorf("Info() not written to custom Out, got %q", out)
+	}
+	if !strings.Contains(out, "oops") {
+		t.Errorf("Warn() not written to custom Out, got %q", out)
+	}
+	if !strings.Contains(out, "done") {
+		t.Errorf("Success() not written to custom Out, got %q", out)
+	}
+}
+
+func TestUI_CustomOutDoesNotWriteToStdout(t *testing.T) {
+	var buf bytes.Buffer
+	u := &UI{Out: &buf}
+
+	u.Info("redirected")
+	u.Warn("redirected warning")
+
+	// Verify output went to buf, not stdout
+	if !strings.Contains(buf.String(), "redirected") {
+		t.Error("output should go to custom Out")
 	}
 }
 


### PR DESCRIPTION
## Description of the change

Completes the fix from #79. The post-checkout hook was one source of stdout contamination, but `u.Warn()`, `u.Info()`, and `u.Success()` also write to stdout via `fmt.Printf`. In `--cd` mode (used by the tmux picker), this contaminates the worktree path that tmux uses for `-c`.

For example, the `--lock-timeout` git config warning was being written to stdout, causing tmux to get a garbage directory path and default to `~`.

**Fix**: Add `Out io.Writer` field to `UI` struct. Default is `os.Stdout`. In `--cd` mode, set `Out = os.Stderr` so all UI output goes to stderr while stdout stays clean for the path. Applied to both `new` and `checkout` commands.

**Verified live**: Created evergreen worktree via `willow new --cd`, confirmed stdout is clean path only. Tmux session panes open in correct worktree directory and `dev sync` runs successfully.

## Test plan

- `TestUI_CustomOut` — verifies Info/Warn/Success write to custom Out
- `TestUI_CustomOutDoesNotWriteToStdout` — verifies redirection works
- Live test: worktree creation → tmux session → panes in correct dir → `dev sync` runs
- `go test ./... -count=1` all green