### PR TITLE
🐛 fix: hardening — error handling, atomic writes, git compat

### DIFF
--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path"
 	"path/filepath"
 	"strings"
@@ -83,11 +84,20 @@ func cloneCmd() *cli.Command {
 			}
 			done()
 
-			// If anything below fails, clean up the partial clone
+			// If anything below fails (or Ctrl-C), clean up the partial clone
 			cleanup := func() {
 				os.RemoveAll(bareDir)
 				os.RemoveAll(worktreesDir)
 			}
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, os.Interrupt)
+			go func() {
+				<-sigCh
+				cleanup()
+				os.Exit(1)
+			}()
+			defer signal.Stop(sigCh)
 
 			// Bare clones don't set up remote tracking by default.
 			// Configure the fetch refspec so `git fetch` populates refs/remotes/origin/*.

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -331,7 +331,7 @@ func finishWorktree(tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, 
 	done = tr.Start("auto setup remote")
 	if *cfg.Defaults.AutoSetupRemote {
 		wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
-		if _, err := wtGit.Run("config", "--lock-timeout", "500", "--local", "push.autoSetupRemote", "true"); err != nil {
+		if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
 			u.Warn("Failed to set push.autoSetupRemote: " + err.Error())
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -258,6 +258,7 @@ func (cfg *Config) Validate() []string {
 }
 
 // Save writes a config to the given path, creating directories as needed.
+// Uses atomic write (temp file + rename) to prevent corruption from interrupted writes.
 func Save(cfg *Config, path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
@@ -266,5 +267,9 @@ func Save(cfg *Config, path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(data, '\n'), 0o644)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, append(data, '\n'), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -184,7 +184,9 @@ func (g *Git) CommitsAhead(base string) (int, error) {
 		return 0, err
 	}
 	var count int
-	fmt.Sscanf(strings.TrimSpace(out), "%d", &count)
+	if _, err := fmt.Sscanf(strings.TrimSpace(out), "%d", &count); err != nil {
+		return 0, fmt.Errorf("failed to parse commit count %q: %w", out, err)
+	}
 	return count, nil
 }
 

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -50,8 +50,9 @@ func Load(bareDir string) *Stack {
 
 // Save writes the stack to branches.json. Removes the file if the stack is empty.
 func (s *Stack) Save(bareDir string) error {
+	fp := filePath(bareDir)
 	if len(s.Parents) == 0 {
-		err := os.Remove(filePath(bareDir))
+		err := os.Remove(fp)
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
@@ -61,7 +62,17 @@ func (s *Stack) Save(bareDir string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filePath(bareDir), append(data, '\n'), 0o644)
+	return atomicWrite(fp, append(data, '\n'))
+}
+
+// atomicWrite writes data to a temp file then renames it to path,
+// preventing corruption from interrupted writes.
+func atomicWrite(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
 }
 
 func (s *Stack) SetParent(branch, parent string) {


### PR DESCRIPTION
## Description of the change

Four hardening fixes found during deep audit:

1. **`git.CommitsAhead` silent parse failure** — `fmt.Sscanf` error was ignored, returning `(0, nil)` on unparseable git output. Now returns an error with context.

2. **`--lock-timeout` git compat** — Flag requires git 2.33+. Fails on older versions (we saw this during live testing). Dropped the flag — it's not worth the compat issue for a lock timeout.

3. **Atomic writes for state files** — `stack.Save()` and `config.Save()` now write to a temp file then `os.Rename`, preventing corruption from interrupted writes (Ctrl-C, disk full, process crash mid-write).

4. **Clone Ctrl-C cleanup** — `cleanup()` only ran on explicit errors. If user interrupts during `git fetch` or worktree creation, partial bare repos were left behind. Now registers a signal handler.

Note: Issue #5 (config merge can't clear arrays) was verified to already work correctly — Go's `json.Unmarshal` produces empty (non-nil) slices for `[]`, which correctly triggers the merge override.

## Test plan

- `go test ./... -count=1` all green
- Verified `--lock-timeout` removal fixes the git config warning we saw in live testing