### PR TITLE
🐛 fix: hardening round 2 — clone race, sync safety, gc paths

### DIFF
--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -92,11 +92,17 @@ func cloneCmd() *cli.Command {
 
 			sigCh := make(chan os.Signal, 1)
 			signal.Notify(sigCh, os.Interrupt)
+			cleanupDone := make(chan struct{})
 			go func() {
-				<-sigCh
-				cleanup()
-				os.Exit(1)
+				select {
+				case <-sigCh:
+					cleanup()
+					os.Exit(1)
+				case <-cleanupDone:
+					return
+				}
 			}()
+			defer close(cleanupDone)
 			defer signal.Stop(sigCh)
 
 			// Bare clones don't set up remote tracking by default.

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
@@ -47,7 +48,7 @@ func gcCmd() *cli.Command {
 				u.Info(fmt.Sprintf("Would clean up %d trash entries", len(entries)))
 			} else {
 				for _, e := range entries {
-					path := trashDir + "/" + e.Name()
+					path := filepath.Join(trashDir, e.Name())
 					if err := os.RemoveAll(path); err != nil {
 						u.Warn(fmt.Sprintf("Failed to remove %s: %v", e.Name(), err))
 					}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -145,7 +145,13 @@ func syncCmd() *cli.Command {
 				wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
 
 				// Check for dirty worktree
-				dirty, _ := wtGit.IsDirty()
+				dirty, err := wtGit.IsDirty()
+				if err != nil {
+					u.Info(fmt.Sprintf("  %s → %s", parent, branch))
+					u.Warn(fmt.Sprintf("    ⚠ Skipped (failed to check status: %v)", err))
+					skipped++
+					continue
+				}
 				if dirty {
 					u.Info(fmt.Sprintf("  %s → %s", parent, branch))
 					u.Warn(fmt.Sprintf("    ⚠ Skipped (uncommitted changes)"))


### PR DESCRIPTION
## Description of the change

Three more fixes found during deep audit:

1. **Clone signal handler race** — The goroutine could receive a queued signal after `signal.Stop()` and delete a successfully cloned repo. Fixed with a `done` channel that coordinates goroutine shutdown on normal return.

2. **Sync IsDirty error ignored** — `dirty, _ := wtGit.IsDirty()` swallowed the error. If `git status` fails (corrupted repo, permissions), `dirty` is `false` and sync proceeds on a potentially broken worktree. Now checks the error and skips with a warning.

3. **gc trash path construction** — Used string concatenation (`trashDir + "/" + e.Name()`) instead of `filepath.Join`. Not a bug on Unix but wrong by convention.

## Test plan

- `go test ./... -count=1` all green