### PR TITLE
📚 docs(website): clarify ww requires shell integration

### DIFF
--- a/website/docs/guide/index.md
+++ b/website/docs/guide/index.md
@@ -21,7 +21,7 @@ go install github.com/iamrajjoshi/willow/cmd/willow@latest
 - [git](https://git-scm.com/)
 - [tmux](https://github.com/tmux/tmux) — optional, for `ww tmux` integration
 
-## Shell integration
+## Shell integration (recommended)
 
 Add to your `.bashrc` / `.zshrc`:
 
@@ -35,7 +35,7 @@ For fish:
 willow shell-init | source
 ```
 
-This gives you:
+This gives you the `ww` alias and helper commands:
 
 | Command | Description |
 |---------|-------------|
@@ -53,6 +53,10 @@ eval "$(willow shell-init --tab-title)"
 ```
 
 Each tab shows `repo/branch` (e.g. `myrepo/auth-refactor`) when inside a willow worktree.
+
+::: tip
+All examples below use `ww`, which is the shell alias for `willow`. If you skipped shell integration, replace `ww` with `willow` in all commands.
+:::
 
 ## Claude Code status tracking
 


### PR DESCRIPTION
Fixes #86

## Description of the change

The website getting started guide uses `ww` in all examples, but `ww` is only available after running `eval "$(willow shell-init)"`. Users who skip shell integration get `command not found: ww`.

- Added a tip box before the quick start section: "All examples use `ww`, which is the shell alias for `willow`. If you skipped shell integration, replace `ww` with `willow`."
- Renamed "Shell integration" heading to "Shell integration (recommended)" to make it clearer it's not optional if you want `ww`