### PR TITLE
✨ feat(shell): export WILLOW=1 in shell-init scripts

### DIFF
--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -32,6 +32,8 @@ const bashInitScript = `# Willow shell integration
 # Add to your .bashrc:
 #   eval "$(willow shell-init)"
 
+export WILLOW=1
+
 ww() {
   if [ "$1" = "sw" ]; then
     local dir
@@ -135,6 +137,8 @@ const zshInitScript = `# Willow shell integration
 # Add to your .zshrc:
 #   eval "$(willow shell-init)"
 
+export WILLOW=1
+
 ww() {
   if [ "$1" = "sw" ]; then
     local dir
@@ -226,6 +230,8 @@ end
 const fishInitScript = `# Willow shell integration
 # Add to your config.fish:
 #   willow shell-init | source
+
+set -gx WILLOW 1
 
 function ww
   if test (count $argv) -gt 0; and test "$argv[1]" = "sw"


### PR DESCRIPTION
## Summary

Exports `WILLOW=1` in the shell-init scripts (bash, zsh, fish) so downstream tools can detect when a shell has willow integration loaded.

This enables the `dev` CLI context detection in Greenbax/evergreen#96459 to identify willow-managed environments.

## Test plan

- `go test ./...` passes
- `willow shell-init | grep WILLOW` shows `export WILLOW=1`
- After re-sourcing shell-init, `echo $WILLOW` prints `1`