### PR TITLE
✨ feat(shell): auto-cd into worktree on `ww new`

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ This gives you:
 |---------|-------------|
 | `ww <cmd>` | Alias for `willow` |
 | `ww sw` | fzf worktree switcher (cd's into selection) |
-| `wwn <branch>` | Create worktree + cd into it |
-| `wwc <branch>` | Smart checkout + cd (switch or create) |
+| `ww new <branch>` | Create worktree + cd into it (tmux-aware) |
+| `ww checkout <branch>` | Smart checkout + cd (switch or create, tmux-aware) |
+| `wwn <branch>` | Shorthand for `ww new` |
+| `wwc <branch>` | Shorthand for `ww checkout` |
 | `www` | cd to `~/.willow/worktrees/` |
 
 **Optional:** Set terminal tab title to the current worktree name:
@@ -127,13 +129,13 @@ Installs hooks into `~/.claude/settings.json` that write per-session agent statu
 ww clone git@github.com:org/myrepo.git
 
 # Create a worktree and cd into it
-wwn auth-refactor
+ww new auth-refactor
 
 # Start Claude Code
 claude
 
 # In another terminal — create a second worktree
-wwn payments-fix
+ww new payments-fix
 claude
 
 # Switch between worktrees (fzf picker with agent status)
@@ -170,7 +172,7 @@ ww new -e                              # pick from remote branches (fzf)
 ww new --pr 123                        # checkout PR #123
 ww new https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww new feature/auth -r myrepo          # target a specific repo
-wwn feature/auth                       # create + cd (shell integration)
+ww new feature/auth                    # auto-cd via shell integration (tmux-aware)
 ```
 
 | Flag | Description |
@@ -192,7 +194,7 @@ ww checkout --pr 123                     # checkout PR #123
 ww checkout https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww checkout brand-new-feature            # creates new branch + worktree
 ww checkout brand-new -b develop         # new branch from develop
-wwc auth-refactor                        # checkout + cd (shell integration)
+ww checkout auth-refactor                # auto-cd via shell integration (tmux-aware)
 ```
 
 | Flag | Description |

--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -55,6 +55,16 @@ ww() {
     cd "$dir" || return
     return
   fi
+  if [ "$1" = "new" ] || [ "$1" = "n" ]; then
+    local dir
+    dir="$(command willow new "${@:2}" --cd)" || return
+    if [ -n "$TMUX" ] && [ -n "$dir" ]; then
+      command willow tmux sw "$dir"
+      return
+    fi
+    cd "$dir" || return
+    return
+  fi
   if [ "$1" = "rm" ]; then
     local cwd="$PWD"
     command willow "$@"
@@ -160,6 +170,16 @@ ww() {
     cd "$dir" || return
     return
   fi
+  if [ "$1" = "new" ] || [ "$1" = "n" ]; then
+    local dir
+    dir="$(command willow new "${@:2}" --cd)" || return
+    if [ -n "$TMUX" ] && [ -n "$dir" ]; then
+      command willow tmux sw "$dir"
+      return
+    fi
+    cd "$dir" || return
+    return
+  fi
   if [ "$1" = "rm" ]; then
     local cwd="$PWD"
     command willow "$@"
@@ -246,6 +266,16 @@ function ww
   end
   if test (count $argv) -gt 0; and test "$argv[1]" = "checkout" -o "$argv[1]" = "co"
     set -l dir (command willow checkout $argv[2..] --cd)
+    or return
+    if test -n "$TMUX"; and test -n "$dir"
+      command willow tmux sw "$dir"
+      return
+    end
+    cd $dir
+    return
+  end
+  if test (count $argv) -gt 0; and test "$argv[1]" = "new" -o "$argv[1]" = "n"
+    set -l dir (command willow new $argv[2..] --cd)
     or return
     if test -n "$TMUX"; and test -n "$dir"
       command willow tmux sw "$dir"

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -35,7 +35,7 @@ ww new -e                              # pick from remote branches (fzf)
 ww new --pr 123                        # checkout PR #123
 ww new https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww new feature/auth -r myrepo          # target a specific repo
-wwn feature/auth                       # create + cd (shell integration)
+ww new feature/auth                    # auto-cd via shell integration (tmux-aware)
 ```
 
 | Flag | Description | Default |
@@ -77,7 +77,7 @@ ww checkout --pr 123                     # checkout PR #123
 ww checkout https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww checkout brand-new-feature            # creates new branch + worktree
 ww checkout brand-new -b develop         # new branch forked from develop
-wwc auth-refactor                        # checkout + cd (shell integration)
+ww checkout auth-refactor                # auto-cd via shell integration (tmux-aware)
 ```
 
 | Flag | Description | Default |


### PR DESCRIPTION
## Description of the change

Closes #94. The `ww` shell function already handled auto-cd for `sw`, `checkout`/`co`, and `rm`, but `new`/`n` was missing — users had to use the separate `wwn` alias or manually cd.

Adds `new`/`n` handling to the `ww` function in all three shell scripts (bash, zsh, fish), following the same pattern as the existing `checkout`/`co` handler:
- Runs `command willow new --cd` to get the worktree path
- If in tmux, switches via `willow tmux sw` 
- Otherwise, cds directly

`wwn`/`wwc` aliases are kept for backwards compatibility.

## Test plan

- `eval "$(./bin/willow shell-init)"` in bash/zsh, verify `ww new test-branch` creates and cds
- Verify `ww new` in tmux switches to the new worktree pane
- Verify `wwn` still works as before
- Build succeeds, all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)