### PR TITLE
🐛 fix(cli): run setup hooks in --cd mode

### DIFF
--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -24,12 +24,12 @@ func repoNameFromDir(bareDir string) string {
 	return strings.TrimSuffix(filepath.Base(bareDir), ".git")
 }
 
-func runHooks(commands []string, dir string, u *ui.UI) error {
+func runHooks(commands []string, dir string, u *ui.UI, stdout *os.File) error {
 	for _, c := range commands {
 		u.Info(fmt.Sprintf("  → %s", c))
 		sh := exec.Command("sh", "-c", c)
 		sh.Dir = dir
-		sh.Stdout = os.Stdout
+		sh.Stdout = stdout
 		sh.Stderr = os.Stderr
 		if err := sh.Run(); err != nil {
 			return fmt.Errorf("hook failed: %s: %w", c, err)
@@ -344,10 +344,15 @@ func finishWorktree(tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, 
 	}
 	done()
 
+	hookOut := os.Stdout
+	if cdOnly {
+		hookOut = os.Stderr
+	}
+
 	done = tr.Start("setup hooks")
-	if len(cfg.Setup) > 0 && !cdOnly {
+	if len(cfg.Setup) > 0 {
 		u.Info("Running setup hooks...")
-		if err := runHooks(cfg.Setup, wtPath, u); err != nil {
+		if err := runHooks(cfg.Setup, wtPath, u, hookOut); err != nil {
 			return err
 		}
 	}
@@ -362,7 +367,7 @@ func finishWorktree(tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, 
 	if len(cfg.Tmux.Panes) > 0 && !cdOnly {
 		for i, p := range cfg.Tmux.Panes {
 			if p.Command != "" {
-				if err := runHooks([]string{p.Command}, wtPath, u); err != nil {
+				if err := runHooks([]string{p.Command}, wtPath, u, hookOut); err != nil {
 					return errs.User(fmt.Errorf("pane %d command failed: %w", i, err))
 				}
 			}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -232,7 +232,7 @@ func removeWorktree(tr *trace.Tracer, u *ui.UI, repoGit *git.Git, wt *worktree.W
 	if len(cfg.Teardown) > 0 {
 		done := tr.Start("teardown hooks " + wt.Branch)
 		u.Info(fmt.Sprintf("Running teardown hooks for %s...", u.Bold(wt.Branch)))
-		if err := runHooks(cfg.Teardown, wt.Path, u); err != nil {
+		if err := runHooks(cfg.Teardown, wt.Path, u, os.Stdout); err != nil {
 			return err
 		}
 		done()


### PR DESCRIPTION
## Summary
- Setup hooks (`config.Setup`) were skipped when `cdOnly` was true, which is the mode the shell wrapper uses for `ww new`
- This meant config like `"setup": ["mise trust"]` never ran, forcing users to manually run `mise trust` after every new worktree
- Hook stdout is redirected to stderr in `--cd` mode to avoid contaminating the worktree path output

## Test plan
- [ ] `ww new <test-branch>` with `"setup": ["mise trust"]` in willow.json — verify no mise trust errors
- [ ] `ww rm <test-branch>` — verify teardown hooks still work
- [ ] `go test ./... -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)