### PR TITLE
🐛 fix(ls): use rune count for branch column alignment

### DIFF
--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
@@ -240,8 +241,8 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, rep
 		if row.merged {
 			display += " [merged]"
 		}
-		if len(display) > branchW {
-			branchW = len(display)
+		if utf8.RuneCountInString(display) > branchW {
+			branchW = utf8.RuneCountInString(display)
 		}
 		if len(row.wt.Path) > pathW {
 			pathW = len(row.wt.Path)
@@ -270,7 +271,7 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, rep
 			branchDisplay += " " + u.Dim("[merged]")
 		}
 		// Pad based on plain text width to avoid ANSI code miscount
-		padding := branchW - len(branchPlain)
+		padding := branchW - utf8.RuneCountInString(branchPlain)
 		if padding < 0 {
 			padding = 0
 		}


### PR DESCRIPTION
Tree-drawing prefixes (└─, ├─, │) are multi-byte UTF-8 but single display-width characters. `len()` counted bytes, causing child rows to misalign STATUS/PATH/AGE columns by 4 chars per prefix level.

Switches to `utf8.RuneCountInString()` for branch column width calculation and per-row padding.