### PR TITLE
🐛 fix: status persistence, stack locking, atomic writes, clone cleanup

### DIFF
--- a/internal/claude/status.go
+++ b/internal/claude/status.go
@@ -43,7 +43,8 @@ func StatusDir() string {
 
 // ReadAllSessions reads all session status files from the directory-based layout:
 // ~/.willow/status/<repo>/<worktree>/*.json
-// Stale sessions (>30 min) and corrupt files are cleaned up in the same pass.
+// This is a read-only operation — it never deletes files. Use CleanStaleSessions
+// for explicit cleanup.
 func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 	dir := filepath.Join(StatusDir(), repoName, worktreeDir)
 	entries, err := os.ReadDir(dir)
@@ -63,11 +64,6 @@ func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 		}
 		var ss SessionStatus
 		if err := json.Unmarshal(data, &ss); err != nil {
-			os.Remove(path)
-			continue
-		}
-		if time.Since(ss.Timestamp) > cleanupTimeout {
-			os.Remove(path)
 			continue
 		}
 		sessions = append(sessions, &ss)

--- a/internal/claude/status_test.go
+++ b/internal/claude/status_test.go
@@ -172,6 +172,31 @@ func TestReadStatus_AggregatesBusyOverDone(t *testing.T) {
 	}
 }
 
+func TestReadAllSessions_PreservesOldFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "old-sessions"
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	os.MkdirAll(sessDir, 0o755)
+
+	// Write a session file with a timestamp older than 30 minutes
+	old := SessionStatus{Status: StatusDone, SessionID: "old-sess", Timestamp: time.Now().UTC().Add(-2 * time.Hour)}
+	data, _ := json.Marshal(old)
+	os.WriteFile(filepath.Join(sessDir, old.SessionID+".json"), data, 0o644)
+
+	got := ReadAllSessions(repoName, wtName)
+	if len(got) != 1 {
+		t.Fatalf("ReadAllSessions returned %d sessions, want 1 (should preserve old files)", len(got))
+	}
+
+	// Verify file still exists on disk
+	if _, err := os.Stat(filepath.Join(sessDir, "old-sess.json")); os.IsNotExist(err) {
+		t.Error("ReadAllSessions deleted old session file, but should only read")
+	}
+}
+
 func TestCleanStaleSessions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -227,9 +227,9 @@ func checkoutCmd() *cli.Command {
 
 			// Record parent in stack
 			done = tr.Start("record stack parent")
-			st := stack.Load(repo.BareDir)
-			st.SetParent(branch, baseBranch)
-			if err := st.Save(repo.BareDir); err != nil {
+			if err := stack.Update(repo.BareDir, func(s *stack.Stack) {
+				s.SetParent(branch, baseBranch)
+			}); err != nil {
 				u.Warn(fmt.Sprintf("Failed to save stack: %v", err))
 			}
 			done()

--- a/internal/cli/clone.go
+++ b/internal/cli/clone.go
@@ -76,15 +76,7 @@ func cloneCmd() *cli.Command {
 				return fmt.Errorf("failed to create worktrees directory: %w", err)
 			}
 
-			// Bare clone
-			u.Info(fmt.Sprintf("Cloning %s into %s...", url, u.Bold(bareDir)))
-			done := tr.Start("git clone --bare")
-			if _, err := g.Run("clone", "--bare", url, bareDir); err != nil {
-				return fmt.Errorf("failed to clone repository: %w", err)
-			}
-			done()
-
-			// If anything below fails (or Ctrl-C), clean up the partial clone
+			// Clean up partial state on failure or Ctrl-C
 			cleanup := func() {
 				os.RemoveAll(bareDir)
 				os.RemoveAll(worktreesDir)
@@ -104,6 +96,15 @@ func cloneCmd() *cli.Command {
 			}()
 			defer close(cleanupDone)
 			defer signal.Stop(sigCh)
+
+			// Bare clone
+			u.Info(fmt.Sprintf("Cloning %s into %s...", url, u.Bold(bareDir)))
+			done := tr.Start("git clone --bare")
+			if _, err := g.Run("clone", "--bare", url, bareDir); err != nil {
+				cleanup()
+				return fmt.Errorf("failed to clone repository: %w", err)
+			}
+			done()
 
 			// Bare clones don't set up remote tracking by default.
 			// Configure the fetch refspec so `git fetch` populates refs/remotes/origin/*.

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -318,9 +318,9 @@ func newCmd() *cli.Command {
 
 			// Record parent in stack for stacked PRs
 			done = tr.Start("record stack parent")
-			st := stack.Load(bareDir)
-			st.SetParent(branch, baseBranch)
-			if err := st.Save(bareDir); err != nil {
+			if err := stack.Update(bareDir, func(s *stack.Stack) {
+				s.SetParent(branch, baseBranch)
+			}); err != nil {
 				u.Warn(fmt.Sprintf("Failed to save stack: %v", err))
 			}
 			done()

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -288,8 +288,9 @@ func removeWorktree(tr *trace.Tracer, u *ui.UI, repoGit *git.Git, wt *worktree.W
 
 	// Remove from stack (re-parents children to this branch's parent)
 	if st.IsTracked(wt.Branch) {
-		st.Remove(wt.Branch)
-		if err := st.Save(bareDir); err != nil {
+		if err := stack.Update(bareDir, func(s *stack.Stack) {
+			s.Remove(wt.Branch)
+		}); err != nil {
 			u.Warn(fmt.Sprintf("Failed to save stack: %v", err))
 		}
 	}

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -3,9 +3,11 @@ package stack
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"syscall"
 )
 
 // Stack tracks parent-child relationships between branches for stacked PRs.
@@ -73,6 +75,26 @@ func atomicWrite(path string, data []byte) error {
 		return err
 	}
 	return os.Rename(tmp, path)
+}
+
+// Update performs a locked read-modify-write cycle on branches.json.
+// The lock prevents concurrent willow commands from corrupting the file.
+func Update(bareDir string, fn func(*Stack)) error {
+	lockPath := filePath(bareDir) + ".lock"
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("open lock file: %w", err)
+	}
+	defer f.Close()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("lock branches.json: %w", err)
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+
+	s := Load(bareDir)
+	fn(s)
+	return s.Save(bareDir)
 }
 
 func (s *Stack) SetParent(branch, parent string) {

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -124,6 +124,31 @@ func TestSubtreeSort(t *testing.T) {
 	}
 }
 
+func TestUpdate(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed initial state
+	s := &Stack{Parents: map[string]string{"a": "main"}}
+	if err := s.Save(dir); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+
+	// Use Update to add a new branch under the lock
+	if err := Update(dir, func(s *Stack) {
+		s.SetParent("b", "a")
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	loaded := Load(dir)
+	if loaded.Parent("b") != "a" {
+		t.Errorf("expected b parent=a, got %q", loaded.Parent("b"))
+	}
+	if loaded.Parent("a") != "main" {
+		t.Errorf("expected a parent=main, got %q", loaded.Parent("a"))
+	}
+}
+
 func TestRemoveReparentsChildren(t *testing.T) {
 	s := &Stack{Parents: map[string]string{
 		"a": "main",

--- a/internal/tmux/notify.go
+++ b/internal/tmux/notify.go
@@ -43,7 +43,12 @@ func loadState() StatusBarState {
 
 func saveState(state StatusBarState) {
 	data, _ := json.Marshal(state)
-	os.WriteFile(stateFilePath(), data, 0o644)
+	path := stateFilePath()
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return
+	}
+	os.Rename(tmp, path)
 }
 
 // CheckTransitions compares current statuses against saved state and returns


### PR DESCRIPTION
## Description of the change

Four hardening fixes:

1. **Status disappearance** — `ReadAllSessions()` was deleting status files older than 30min during every read (picker, dashboard, status bar). If Claude ran without triggering hooks for 30+ minutes (long thinking, complex tool use), status would vanish on next view. Now reads are read-only; only `CleanStaleSessions()` (called by `refresh-status` and status-bar self-healing) handles explicit cleanup.

2. **Stack file locking** — Added `stack.Update()` with `flock`-based exclusive locking for the read-modify-write cycle on `branches.json`. Two concurrent `ww new` commands can no longer corrupt the stack.

3. **Atomic tmux state** — `saveState()` now writes to a temp file and renames, matching `stack.Save()` pattern. Prevents corruption from concurrent status-bar refreshes.

4. **Clone Ctrl-C cleanup** — Moved signal handler before the bare clone. Previously, Ctrl-C during `git clone --bare` left partial bare repos behind.

## Test plan

- Unit tests: 2 new tests added (`TestReadAllSessions_PreservesOldFiles`, `TestUpdate`), full suite passes (315 tests)
- Manual: verified `go build` and `go test ./...` on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)