### PR TITLE
🐛 fix(tmux): prevent picker hscroll when query contains dashes

### DIFF
--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -97,6 +97,8 @@ func tmuxPickCmd() *cli.Command {
 					fzf.WithAnsi(),
 					fzf.WithReverse(),
 					fzf.WithNoSort(),
+					fzf.WithDelimiter("\\|"),
+					fzf.WithNth("1,2"),
 					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-B: New (stacked) | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-S: Sync | Ctrl-D: Delete"),
 					fzf.WithExpectKeys("ctrl-n", "ctrl-b", "ctrl-e", "ctrl-p", "ctrl-s", "ctrl-d"),
 					fzf.WithPrintQuery(),

--- a/internal/fzf/fzf.go
+++ b/internal/fzf/fzf.go
@@ -19,6 +19,8 @@ type config struct {
 	printQuery bool
 	query      string
 	bindings   []string
+	delimiter  string
+	nth        string
 }
 
 func defaults() *config {
@@ -70,6 +72,14 @@ func WithBind(bindings ...string) Option {
 	return func(c *config) { c.bindings = append(c.bindings, bindings...) }
 }
 
+func WithDelimiter(d string) Option {
+	return func(c *config) { c.delimiter = d }
+}
+
+func WithNth(n string) Option {
+	return func(c *config) { c.nth = n }
+}
+
 func buildArgs(cfg *config) []string {
 	var args []string
 	if cfg.ansi {
@@ -104,6 +114,12 @@ func buildArgs(cfg *config) []string {
 	}
 	for _, b := range cfg.bindings {
 		args = append(args, "--bind", b)
+	}
+	if cfg.delimiter != "" {
+		args = append(args, "--delimiter", cfg.delimiter)
+	}
+	if cfg.nth != "" {
+		args = append(args, "--nth", cfg.nth)
 	}
 	return args
 }


### PR DESCRIPTION
## Description of the change

Restrict fzf matching to status + branch name columns (`--nth 1,2` with `--delimiter`) in the tmux picker. Previously, fuzzy matches extending into the path column caused fzf to horizontally scroll the display left when the query contained dashes.

## Test plan

Manual — type a query with dashes (e.g. `side-`) in the tmux picker and verify columns stay aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)