### PR TITLE
:sparkles: feat(cli): add ww doctor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,14 @@ ww log --json                   # raw JSON output
 
 One-time hook installation for Claude Code status tracking.
 
+### `ww doctor`
+
+Check your willow setup for common issues. Verifies git version, optional tools (`gh`, `tmux`), Claude Code hooks, willow directories, stale sessions, and config validity.
+
+```bash
+ww doctor
+```
+
 ### `ww shell-init [flags]`
 
 Print shell integration script.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -94,6 +94,7 @@ func NewApp() *cli.Command {
 			setupCmd(),
 			shellInitCmd(),
 			gcCmd(),
+			doctorCmd(),
 			refreshStatusCmd(),
 		},
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,177 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/urfave/cli/v3"
+)
+
+func doctorCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "doctor",
+		Usage: "Check your willow setup for common issues",
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			u := flags.NewUI()
+
+			checkGitVersion(u)
+			checkBinary(u, "gh", "gh CLI", "https://cli.github.com")
+			checkBinary(u, "tmux", "tmux", "https://github.com/tmux/tmux")
+			checkClaudeHooks(u)
+			checkWillowDirs(u)
+			checkStaleSessions(u)
+			checkConfig(u)
+
+			return nil
+		},
+	}
+}
+
+func checkGitVersion(u interface{ Success(string); Warn(string); Red(string) string }) {
+	out, err := exec.Command("git", "--version").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "%s git not found\n", u.Red("\u2717"))
+		return
+	}
+
+	major, minor, patch, err := parseGitVersion(strings.TrimSpace(string(out)))
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "%s git version could not be parsed\n", u.Red("\u2717"))
+		return
+	}
+
+	version := fmt.Sprintf("%d.%d.%d", major, minor, patch)
+	if major < 2 || (major == 2 && minor < 30) {
+		u.Warn(fmt.Sprintf("git %s (recommend >= 2.30)", version))
+		return
+	}
+	u.Success(fmt.Sprintf("git %s", version))
+}
+
+func parseGitVersion(output string) (major, minor, patch int, err error) {
+	// "git version 2.45.0" or "git version 2.39.3 (Apple Git-146)"
+	// Extract the version token right after "version", or fall back to the
+	// first token that looks like a dotted number.
+	parts := strings.Fields(output)
+	if len(parts) == 0 {
+		return 0, 0, 0, fmt.Errorf("empty version string")
+	}
+
+	versionStr := ""
+	for i, p := range parts {
+		if p == "version" && i+1 < len(parts) {
+			versionStr = parts[i+1]
+			break
+		}
+	}
+	if versionStr == "" {
+		versionStr = parts[len(parts)-1]
+	}
+
+	segments := strings.SplitN(versionStr, ".", 4) // at most major.minor.patch, ignore rest
+	if len(segments) < 2 {
+		return 0, 0, 0, fmt.Errorf("unexpected version format: %s", versionStr)
+	}
+
+	major, err = strconv.Atoi(segments[0])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid major version: %s", segments[0])
+	}
+	minor, err = strconv.Atoi(segments[1])
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("invalid minor version: %s", segments[1])
+	}
+	if len(segments) >= 3 {
+		patch, err = strconv.Atoi(segments[2])
+		if err != nil {
+			return 0, 0, 0, fmt.Errorf("invalid patch version: %s", segments[2])
+		}
+	}
+
+	return major, minor, patch, nil
+}
+
+type binaryChecker interface {
+	Success(string)
+	Warn(string)
+	Red(string) string
+}
+
+func checkBinary(u binaryChecker, name, label, installURL string) {
+	if _, err := exec.LookPath(name); err != nil {
+		u.Warn(fmt.Sprintf("%s not found (install: %s)", label, installURL))
+		return
+	}
+	u.Success(fmt.Sprintf("%s installed", label))
+}
+
+func checkClaudeHooks(u interface{ Success(string); Warn(string) }) {
+	if claude.IsInstalled() {
+		u.Success("Claude Code hooks installed")
+		return
+	}
+	u.Warn("Claude Code hooks not installed (run: ww cc-setup)")
+}
+
+func checkWillowDirs(u interface {
+	Success(string)
+	Red(string) string
+}) {
+	dirs := []struct {
+		path string
+		name string
+	}{
+		{config.WillowHome(), "~/.willow"},
+		{config.ReposDir(), "~/.willow/repos"},
+		{config.WorktreesDir(), "~/.willow/worktrees"},
+	}
+
+	for _, d := range dirs {
+		if _, err := os.Stat(d.path); err != nil {
+			fmt.Fprintf(os.Stdout, "%s %s missing (run: ww clone)\n", u.Red("\u2717"), d.name)
+			continue
+		}
+		u.Success(fmt.Sprintf("%s exists", d.name))
+	}
+}
+
+func checkStaleSessions(u interface{ Success(string); Warn(string) }) {
+	sessions, err := claude.ScanAllSessions()
+	if err != nil {
+		u.Warn(fmt.Sprintf("could not scan sessions: %v", err))
+		return
+	}
+
+	staleCount := 0
+	for _, s := range sessions {
+		if time.Since(s.Session.Timestamp) > 30*time.Minute {
+			staleCount++
+		}
+	}
+
+	if staleCount > 0 {
+		u.Warn(fmt.Sprintf("%d stale session file(s) (run: ww refresh-status)", staleCount))
+		return
+	}
+	u.Success("no stale session files")
+}
+
+func checkConfig(u interface{ Success(string); Warn(string) }) {
+	cfg := config.Load("")
+	warnings := cfg.Validate()
+	if len(warnings) == 0 {
+		u.Success("config valid")
+		return
+	}
+	for _, w := range warnings {
+		u.Warn(fmt.Sprintf("config: %s", w))
+	}
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import "testing"
+
+func TestDoctorCmd(t *testing.T) {
+	cmd := doctorCmd()
+	if cmd.Name != "doctor" {
+		t.Errorf("expected command name %q, got %q", "doctor", cmd.Name)
+	}
+	if cmd.Action == nil {
+		t.Error("expected non-nil action")
+	}
+}
+
+func TestParseGitVersion(t *testing.T) {
+	tests := []struct {
+		input               string
+		major, minor, patch int
+		wantErr             bool
+	}{
+		{"git version 2.45.0", 2, 45, 0, false},
+		{"git version 2.30.1", 2, 30, 1, false},
+		{"git version 1.8.5", 1, 8, 5, false},
+		{"git version 2.39.3 (Apple Git-146)", 2, 39, 3, false},
+		{"git version 2.43.0.windows.1", 2, 43, 0, false},
+		{"2.45.0", 2, 45, 0, false},
+		{"", 0, 0, 0, true},
+		{"git version abc.def.ghi", 0, 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			major, minor, patch, err := parseGitVersion(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if major != tt.major || minor != tt.minor || patch != tt.patch {
+				t.Errorf("got %d.%d.%d, want %d.%d.%d", major, minor, patch, tt.major, tt.minor, tt.patch)
+			}
+		})
+	}
+}

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -271,6 +271,36 @@ The hook also tracks enriched session data:
 - **`start_time`** — when the session first became active
 - **`files_touched`** — files written/edited by the agent (stored in a `.files` sidecar)
 
+## `ww doctor`
+
+Check your willow setup for common issues. Runs a series of checks and prints a checklist:
+
+```bash
+ww doctor
+```
+
+```
+✔ git 2.45.0
+✔ gh CLI installed
+✔ tmux installed
+✔ Claude Code hooks installed
+✔ ~/.willow exists
+✔ ~/.willow/repos exists
+✔ ~/.willow/worktrees exists
+✔ no stale session files
+✔ config valid
+```
+
+| Check | Details |
+|-------|---------|
+| git version | Warns if < 2.30 |
+| gh CLI | Optional — warns if missing |
+| tmux | Optional — warns if missing |
+| Claude Code hooks | Checks `~/.claude/settings.json` for willow hooks |
+| Willow directories | `~/.willow`, `repos/`, `worktrees/` |
+| Stale sessions | Session files older than 30 minutes |
+| Config validity | Validates merged config for common issues |
+
 ## `ww shell-init [flags]`
 
 Print shell integration script.


### PR DESCRIPTION
## Description of the change
Add `ww doctor` command that diagnoses setup issues with a checklist output. Checks git version, gh CLI, tmux, Claude hooks, willow directories, stale sessions, and config validity.

## Test plan
- Unit tests for git version parsing
- Manual: run `ww doctor` and verify output