### PR TITLE
:sparkles: feat(cli): add ww config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,19 @@ Check your willow setup for common issues. Verifies git version, optional tools 
 ww doctor
 ```
 
+### `ww config`
+
+View, edit, and initialize willow configuration.
+
+```bash
+ww config show               # show merged config with sources
+ww config show --json        # raw JSON output
+ww config edit               # open global config in $EDITOR
+ww config edit --local       # open local (per-repo) config
+ww config init               # create default global config
+ww config init --local       # create default local config
+```
+
 ### `ww shell-init [flags]`
 
 Print shell integration script.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -95,6 +95,7 @@ func NewApp() *cli.Command {
 			shellInitCmd(),
 			gcCmd(),
 			doctorCmd(),
+			configCmd(),
 			refreshStatusCmd(),
 		},
 	}

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -1,0 +1,307 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
+	"github.com/urfave/cli/v3"
+)
+
+func configCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "config",
+		Usage: "View, edit, and initialize willow configuration",
+		Commands: []*cli.Command{
+			configShowCmd(),
+			configEditCmd(),
+			configInitCmd(),
+		},
+	}
+}
+
+func configShowCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "show",
+		Usage: "Show merged config with source annotations",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "json",
+				Usage: "Output raw JSON",
+			},
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target repo by name",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			u := flags.NewUI()
+
+			bareDir := ""
+			if repoName := cmd.String("repo"); repoName != "" {
+				dir, err := config.ResolveRepo(repoName)
+				if err != nil {
+					return err
+				}
+				bareDir = dir
+			} else {
+				g := flags.NewGit()
+				dir, err := requireWillowRepo(g)
+				if err == nil {
+					bareDir = dir
+				}
+			}
+
+			merged := config.Load(bareDir)
+
+			if cmd.Bool("json") {
+				data, err := json.MarshalIndent(merged, "", "  ")
+				if err != nil {
+					return fmt.Errorf("failed to marshal config: %w", err)
+				}
+				fmt.Println(string(data))
+				return nil
+			}
+
+			def := config.DefaultConfig()
+			global, _ := config.LoadFile(config.GlobalConfigPath())
+			if global == nil {
+				global = &config.Config{}
+			}
+			var local *config.Config
+			if bareDir != "" {
+				local, _ = config.LoadFile(config.LocalConfigPath(bareDir))
+			}
+			if local == nil {
+				local = &config.Config{}
+			}
+
+			printField("baseBranch", merged.BaseBranch, fieldSource(local.BaseBranch, global.BaseBranch, def.BaseBranch))
+			printField("branchPrefix", merged.BranchPrefix, fieldSource(local.BranchPrefix, global.BranchPrefix, def.BranchPrefix))
+			printField("postCheckoutHook", merged.PostCheckoutHook, fieldSource(local.PostCheckoutHook, global.PostCheckoutHook, def.PostCheckoutHook))
+			printField("setup", merged.Setup, fieldSourceSlice(local.Setup, global.Setup, def.Setup))
+			printField("teardown", merged.Teardown, fieldSourceSlice(local.Teardown, global.Teardown, def.Teardown))
+			printField("defaults.fetch", merged.Defaults.Fetch, fieldSourceBoolPtr(local.Defaults.Fetch, global.Defaults.Fetch, def.Defaults.Fetch))
+			printField("defaults.autoSetupRemote", merged.Defaults.AutoSetupRemote, fieldSourceBoolPtr(local.Defaults.AutoSetupRemote, global.Defaults.AutoSetupRemote, def.Defaults.AutoSetupRemote))
+			printField("tmux.reloadInterval", merged.Tmux.ReloadInterval, fieldSource(local.Tmux.ReloadInterval, global.Tmux.ReloadInterval, def.Tmux.ReloadInterval))
+			printField("tmux.notification", merged.Tmux.Notification, fieldSourceBoolPtr(local.Tmux.Notification, global.Tmux.Notification, def.Tmux.Notification))
+			printField("tmux.notifyCommand", merged.Tmux.NotifyCommand, fieldSource(local.Tmux.NotifyCommand, global.Tmux.NotifyCommand, def.Tmux.NotifyCommand))
+			printField("tmux.notifyWaitCommand", merged.Tmux.NotifyWaitCommand, fieldSource(local.Tmux.NotifyWaitCommand, global.Tmux.NotifyWaitCommand, def.Tmux.NotifyWaitCommand))
+			printField("tmux.switcherPreview", merged.Tmux.SwitcherPreview, fieldSourceBoolPtr(local.Tmux.SwitcherPreview, global.Tmux.SwitcherPreview, def.Tmux.SwitcherPreview))
+			printField("tmux.layout", merged.Tmux.Layout, fieldSourceSlice(local.Tmux.Layout, global.Tmux.Layout, def.Tmux.Layout))
+			printField("tmux.panes", merged.Tmux.Panes, fieldSourceSlice(local.Tmux.Panes, global.Tmux.Panes, def.Tmux.Panes))
+			printField("telemetry", merged.Telemetry, fieldSourceBoolPtr(local.Telemetry, global.Telemetry, def.Telemetry))
+
+			if warnings := merged.Validate(); len(warnings) > 0 {
+				fmt.Println()
+				for _, w := range warnings {
+					u.Warn(w)
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+func configEditCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "edit",
+		Usage: "Open config file in $EDITOR",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "global",
+				Usage: "Edit global config (default)",
+			},
+			&cli.BoolFlag{
+				Name:  "local",
+				Usage: "Edit local (per-repo) config",
+			},
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target repo by name",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			path := config.GlobalConfigPath()
+
+			if cmd.Bool("local") {
+				bareDir := ""
+				if repoName := cmd.String("repo"); repoName != "" {
+					dir, err := config.ResolveRepo(repoName)
+					if err != nil {
+						return err
+					}
+					bareDir = dir
+				} else {
+					g := flags.NewGit()
+					dir, err := requireWillowRepo(g)
+					if err != nil {
+						return err
+					}
+					bareDir = dir
+				}
+				path = config.LocalConfigPath(bareDir)
+			}
+
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				return fmt.Errorf("failed to create directory: %w", err)
+			}
+
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				if err := os.WriteFile(path, []byte("{}\n"), 0o644); err != nil {
+					return fmt.Errorf("failed to create config file: %w", err)
+				}
+			}
+
+			editor := os.Getenv("VISUAL")
+			if editor == "" {
+				editor = os.Getenv("EDITOR")
+			}
+			if editor == "" {
+				editor = "vi"
+			}
+
+			c := exec.Command(editor, path)
+			c.Stdin = os.Stdin
+			c.Stdout = os.Stdout
+			c.Stderr = os.Stderr
+			return c.Run()
+		},
+	}
+}
+
+func configInitCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "init",
+		Usage: "Create a default config file",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "local",
+				Usage: "Create local (per-repo) config",
+			},
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target repo by name",
+			},
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "Overwrite existing config",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			u := flags.NewUI()
+			path := config.GlobalConfigPath()
+
+			if cmd.Bool("local") {
+				bareDir := ""
+				if repoName := cmd.String("repo"); repoName != "" {
+					dir, err := config.ResolveRepo(repoName)
+					if err != nil {
+						return err
+					}
+					bareDir = dir
+				} else {
+					g := flags.NewGit()
+					dir, err := requireWillowRepo(g)
+					if err != nil {
+						return err
+					}
+					bareDir = dir
+				}
+				path = config.LocalConfigPath(bareDir)
+			}
+
+			if _, err := os.Stat(path); err == nil && !cmd.Bool("force") {
+				return errs.Userf("config already exists at %s (use --force to overwrite)", path)
+			}
+
+			cfg := config.DefaultConfig()
+			if err := config.Save(cfg, path); err != nil {
+				return fmt.Errorf("failed to write config: %w", err)
+			}
+
+			u.Success(fmt.Sprintf("Created config at %s", path))
+			return nil
+		},
+	}
+}
+
+func printField(name string, value any, source string) {
+	fmt.Printf("%-30s %s  # %s\n", name+":", formatValue(value), source)
+}
+
+func formatValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", val)
+	case *bool:
+		if val == nil {
+			return "<nil>"
+		}
+		return fmt.Sprintf("%v", *val)
+	case []string:
+		if val == nil {
+			return "[]"
+		}
+		return fmt.Sprintf("%v", val)
+	case []config.PaneConfig:
+		if val == nil {
+			return "[]"
+		}
+		if len(val) == 0 {
+			return "[]"
+		}
+		return fmt.Sprintf("[%d panes]", len(val))
+	case int:
+		return fmt.Sprintf("%d", val)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// fieldSource determines the source of a string or int field value.
+func fieldSource[T comparable](localVal, globalVal, defaultVal T) string {
+	var zero T
+	if localVal != zero {
+		return "local"
+	}
+	if globalVal != zero {
+		return "global"
+	}
+	return "default"
+}
+
+func fieldSourceBoolPtr(localVal, globalVal, defaultVal *bool) string {
+	if localVal != nil {
+		return "local"
+	}
+	if globalVal != nil {
+		return "global"
+	}
+	if defaultVal != nil {
+		return "default"
+	}
+	return "default"
+}
+
+func fieldSourceSlice[T any](localVal, globalVal, defaultVal []T) string {
+	if localVal != nil {
+		return "local"
+	}
+	if globalVal != nil {
+		return "global"
+	}
+	return "default"
+}

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -1,0 +1,162 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+)
+
+func TestConfigCmd_Structure(t *testing.T) {
+	cmd := configCmd()
+
+	if cmd.Name != "config" {
+		t.Errorf("Name = %q, want %q", cmd.Name, "config")
+	}
+
+	if len(cmd.Commands) != 3 {
+		t.Fatalf("expected 3 subcommands, got %d", len(cmd.Commands))
+	}
+
+	names := map[string]bool{}
+	for _, sub := range cmd.Commands {
+		names[sub.Name] = true
+	}
+	for _, want := range []string{"show", "edit", "init"} {
+		if !names[want] {
+			t.Errorf("missing subcommand %q", want)
+		}
+	}
+}
+
+func TestFieldSource_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		local    string
+		global   string
+		def      string
+		wantSrc  string
+	}{
+		{"local set", "val", "", "", "local"},
+		{"global set", "", "val", "", "global"},
+		{"default set", "", "", "val", "default"},
+		{"local wins over global", "local", "global", "def", "local"},
+		{"global wins over default", "", "global", "def", "global"},
+		{"all empty", "", "", "", "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fieldSource(tt.local, tt.global, tt.def)
+			if got != tt.wantSrc {
+				t.Errorf("fieldSource(%q, %q, %q) = %q, want %q",
+					tt.local, tt.global, tt.def, got, tt.wantSrc)
+			}
+		})
+	}
+}
+
+func TestFieldSource_Int(t *testing.T) {
+	tests := []struct {
+		name    string
+		local   int
+		global  int
+		def     int
+		wantSrc string
+	}{
+		{"local set", 5, 0, 0, "local"},
+		{"global set", 0, 3, 0, "global"},
+		{"all zero", 0, 0, 0, "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fieldSource(tt.local, tt.global, tt.def)
+			if got != tt.wantSrc {
+				t.Errorf("fieldSource(%d, %d, %d) = %q, want %q",
+					tt.local, tt.global, tt.def, got, tt.wantSrc)
+			}
+		})
+	}
+}
+
+func TestFieldSourceBoolPtr(t *testing.T) {
+	tr := config.BoolPtr(true)
+	fa := config.BoolPtr(false)
+
+	tests := []struct {
+		name    string
+		local   *bool
+		global  *bool
+		def     *bool
+		wantSrc string
+	}{
+		{"local set", tr, nil, nil, "local"},
+		{"global set", nil, fa, nil, "global"},
+		{"default set", nil, nil, tr, "default"},
+		{"local wins", fa, tr, tr, "local"},
+		{"all nil", nil, nil, nil, "default"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fieldSourceBoolPtr(tt.local, tt.global, tt.def)
+			if got != tt.wantSrc {
+				t.Errorf("fieldSourceBoolPtr = %q, want %q", got, tt.wantSrc)
+			}
+		})
+	}
+}
+
+func TestFieldSourceSlice(t *testing.T) {
+	tests := []struct {
+		name    string
+		local   []string
+		global  []string
+		def     []string
+		wantSrc string
+	}{
+		{"local set", []string{"a"}, nil, nil, "local"},
+		{"global set", nil, []string{"b"}, nil, "global"},
+		{"all nil", nil, nil, nil, "default"},
+		{"local empty slice", []string{}, nil, nil, "local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fieldSourceSlice(tt.local, tt.global, tt.def)
+			if got != tt.wantSrc {
+				t.Errorf("fieldSourceSlice = %q, want %q", got, tt.wantSrc)
+			}
+		})
+	}
+}
+
+func TestFormatValue(t *testing.T) {
+	tests := []struct {
+		name string
+		val  any
+		want string
+	}{
+		{"string", "hello", `"hello"`},
+		{"empty string", "", `""`},
+		{"nil bool ptr", (*bool)(nil), "<nil>"},
+		{"true bool ptr", config.BoolPtr(true), "true"},
+		{"false bool ptr", config.BoolPtr(false), "false"},
+		{"nil slice", ([]string)(nil), "[]"},
+		{"empty slice", []string{}, "[]"},
+		{"string slice", []string{"a", "b"}, "[a b]"},
+		{"int", 42, "42"},
+		{"zero int", 0, "0"},
+		{"nil panes", ([]config.PaneConfig)(nil), "[]"},
+		{"panes", []config.PaneConfig{{}, {Command: "x"}}, "[2 panes]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatValue(tt.val)
+			if got != tt.want {
+				t.Errorf("formatValue(%v) = %q, want %q", tt.val, got, tt.want)
+			}
+		})
+	}
+}

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -301,6 +301,47 @@ ww doctor
 | Stale sessions | Session files older than 30 minutes |
 | Config validity | Validates merged config for common issues |
 
+## `ww config`
+
+View, edit, and initialize willow configuration. Merges global (`~/.config/willow/config.json`) and local (per-repo `willow.json`) configs, showing the effective value and source for each field.
+
+```bash
+ww config show               # show merged config with source annotations
+ww config show --json        # raw JSON output
+ww config show -r myrepo     # show config for a specific repo
+ww config edit               # open global config in $EDITOR
+ww config edit --local       # open local (per-repo) config
+ww config edit --local -r myrepo  # open specific repo's local config
+ww config init               # create default global config
+ww config init --local       # create default local config
+ww config init --force       # overwrite existing config
+```
+
+### `ww config show`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--json` | Output raw JSON | `false` |
+| `-r, --repo` | Target repo by name | Auto-detected from cwd |
+
+### `ww config edit`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--global` | Edit global config (default) | `true` |
+| `--local` | Edit local (per-repo) config | `false` |
+| `-r, --repo` | Target repo by name | Auto-detected from cwd |
+
+Editor resolution: `$VISUAL` > `$EDITOR` > `vi`.
+
+### `ww config init`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--local` | Create local (per-repo) config | `false` |
+| `-r, --repo` | Target repo by name | Auto-detected from cwd |
+| `--force` | Overwrite existing config | `false` |
+
 ## `ww shell-init [flags]`
 
 Print shell integration script.


### PR DESCRIPTION
## Description of the change
Add `ww config` command with `show`, `edit`, and `init` subcommands. `show` displays merged config with source annotations (default/global/local). `edit` opens config in $EDITOR. `init` scaffolds a default config file.

## Test plan
- Unit tests for field source detection and value formatting
- Manual: run `ww config show`, `ww config edit`, `ww config init`