### PR TITLE
:sparkles: feat(dashboard): add timeline sparkline view

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,21 @@ Rich view of Claude Code agent status. Shows per-session rows when multiple agen
 
 ### `ww dashboard` (alias: `dash`, `d`)
 
-Live-refreshing TUI showing all Claude Code sessions across all repos. Includes diff stats, unread counts, and per-session activity.
+Live-refreshing TUI showing all Claude Code sessions across all repos. Includes diff stats, unread counts, per-session activity, and a timeline sparkline showing agent status transitions over the last 60 minutes.
 
 ```bash
-ww dashboard          # default 2s refresh
-ww dash -i 5          # 5s refresh interval
+ww dashboard              # default 2s refresh
+ww dash -i 5              # 5s refresh interval
+ww dash --no-timeline     # hide the timeline column
 ```
+
+| Key | Action |
+|-----|--------|
+| `j/k` | Navigate rows |
+| `Enter` | Switch to tmux session |
+| `t` | Toggle timeline column |
+| `r` | Refresh |
+| `q` | Quit |
 
 ![ww dashboard](screenshots/demo-dashboard.gif)
 

--- a/internal/claude/hook.go
+++ b/internal/claude/hook.go
@@ -97,6 +97,7 @@ case "$HOOK_EVENT" in
   SessionEnd)
     rm -f "$DEST_DIR/$SESSION_ID.json"
     rm -f "$DEST_DIR/$SESSION_ID.files"
+    rm -f "$DEST_DIR/$SESSION_ID.timeline"
     exit 0
     ;;
   UserPromptSubmit)
@@ -173,6 +174,16 @@ esac
 cat > "$DEST_FILE" <<STATUSEOF
 {"status":"$STATUS",${TOOL_FIELD}"session_id":"$SESSION_ID","timestamp":"$NOW","worktree":"$WT_NAME","tool_count":$TOOL_COUNT,"start_time":"$START_TIME"}
 STATUSEOF
+
+# Append timeline entry (only on status change)
+TIMELINE_FILE="$DEST_DIR/$SESSION_ID.timeline"
+LAST_TIMELINE_STATUS=""
+if [ -f "$TIMELINE_FILE" ]; then
+  LAST_TIMELINE_STATUS="$(tail -1 "$TIMELINE_FILE" | sed -n 's/.*"s":"\([^"]*\)".*/\1/p')"
+fi
+if [ "$STATUS" != "$LAST_TIMELINE_STATUS" ]; then
+  echo "{\"s\":\"$STATUS\",\"t\":\"$NOW\"}" >> "$TIMELINE_FILE"
+fi
 `
 }
 

--- a/internal/claude/status.go
+++ b/internal/claude/status.go
@@ -162,6 +162,9 @@ func CleanStaleSessions(repoName, worktreeDir string) {
 		}
 		if time.Since(ss.Timestamp) > cleanupTimeout {
 			os.Remove(filepath.Join(dir, e.Name()))
+			// Also remove the companion timeline file
+			sessionID := strings.TrimSuffix(e.Name(), ".json")
+			os.Remove(filepath.Join(dir, sessionID+".timeline"))
 		}
 	}
 }
@@ -212,9 +215,10 @@ type SessionFileInfo struct {
 	Session     SessionStatus
 }
 
-// RemoveSessionFile removes a single session file.
+// RemoveSessionFile removes a single session file and its companion timeline.
 func RemoveSessionFile(repoName, worktreeDir, sessionID string) error {
 	path := filepath.Join(StatusDir(), repoName, worktreeDir, sessionID+".json")
+	os.Remove(TimelinePath(repoName, worktreeDir, sessionID))
 	return os.Remove(path)
 }
 

--- a/internal/claude/timeline.go
+++ b/internal/claude/timeline.go
@@ -1,0 +1,118 @@
+package claude
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type TimelineEntry struct {
+	Status Status    `json:"s"`
+	Time   time.Time `json:"t"`
+}
+
+// TimelinePath returns the path to the timeline JSONL file for a session.
+func TimelinePath(repoName, worktreeDir, sessionID string) string {
+	return filepath.Join(StatusDir(), repoName, worktreeDir, sessionID+".timeline")
+}
+
+// ReadTimeline reads timeline entries within a time window.
+func ReadTimeline(repoName, worktreeDir, sessionID string, since time.Time) ([]TimelineEntry, error) {
+	path := TimelinePath(repoName, worktreeDir, sessionID)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var entries []TimelineEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry TimelineEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if !entry.Time.Before(since) {
+			entries = append(entries, entry)
+		}
+	}
+	return entries, scanner.Err()
+}
+
+// Sparkline renders a compact sparkline string from timeline entries.
+// buckets is the number of character positions, window is the total time span.
+// Returns a string of ANSI-colored block elements. The visual width is always
+// equal to buckets, but the byte length is larger due to escape codes.
+func Sparkline(entries []TimelineEntry, buckets int, window time.Duration) string {
+	if len(entries) == 0 {
+		return strings.Repeat("\033[2m\u00b7\033[0m", buckets)
+	}
+
+	now := time.Now()
+	start := now.Add(-window)
+	bucketDur := window / time.Duration(buckets)
+
+	var b strings.Builder
+	for i := 0; i < buckets; i++ {
+		bucketStart := start.Add(time.Duration(i) * bucketDur)
+		bucketEnd := bucketStart.Add(bucketDur)
+
+		dominant := dominantStatus(entries, bucketStart, bucketEnd)
+		switch dominant {
+		case StatusBusy:
+			b.WriteString("\033[32m\u2588\033[0m")
+		case StatusWait:
+			b.WriteString("\033[33m\u2593\033[0m")
+		case StatusDone:
+			b.WriteString("\033[36m\u2591\033[0m")
+		default:
+			b.WriteString("\033[2m\u00b7\033[0m")
+		}
+	}
+	return b.String()
+}
+
+// dominantStatus finds the status that occupies the most time in [start, end).
+func dominantStatus(entries []TimelineEntry, start, end time.Time) Status {
+	// Find the most recent entry at or before start as the initial status
+	var currentStatus Status
+	for _, e := range entries {
+		if !e.Time.After(start) {
+			currentStatus = e.Status
+		}
+	}
+
+	durations := make(map[Status]time.Duration)
+	cursor := start
+
+	for _, e := range entries {
+		if e.Time.Before(start) || !e.Time.Before(end) {
+			continue
+		}
+		if currentStatus != "" {
+			durations[currentStatus] += e.Time.Sub(cursor)
+		}
+		currentStatus = e.Status
+		cursor = e.Time
+	}
+	// Remainder of bucket
+	if currentStatus != "" {
+		durations[currentStatus] += end.Sub(cursor)
+	}
+
+	var maxStatus Status
+	var maxDur time.Duration
+	for s, d := range durations {
+		if d > maxDur {
+			maxDur = d
+			maxStatus = s
+		}
+	}
+	return maxStatus
+}

--- a/internal/claude/timeline_test.go
+++ b/internal/claude/timeline_test.go
@@ -1,0 +1,191 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSparkline_AllBusy(t *testing.T) {
+	now := time.Now()
+	entries := []TimelineEntry{
+		{Status: StatusBusy, Time: now.Add(-60 * time.Minute)},
+	}
+	result := Sparkline(entries, 10, 60*time.Minute)
+	// Each bucket should be a green full block + ANSI codes
+	// Visual width = 10, all full blocks
+	plain := stripANSI(result)
+	if plain != strings.Repeat("\u2588", 10) {
+		t.Errorf("all BUSY sparkline = %q, want 10 full blocks", plain)
+	}
+}
+
+func TestSparkline_BusyThenWait(t *testing.T) {
+	now := time.Now()
+	entries := []TimelineEntry{
+		{Status: StatusBusy, Time: now.Add(-60 * time.Minute)},
+		{Status: StatusWait, Time: now.Add(-30 * time.Minute)},
+	}
+	result := Sparkline(entries, 10, 60*time.Minute)
+	plain := stripANSI(result)
+	// First 5 buckets should be full block (BUSY), last 5 should be dark shade (WAIT)
+	if len([]rune(plain)) != 10 {
+		t.Fatalf("sparkline has %d runes, want 10", len([]rune(plain)))
+	}
+	for i, r := range []rune(plain) {
+		if i < 5 {
+			if r != '\u2588' {
+				t.Errorf("bucket %d = %q, want full block (BUSY)", i, string(r))
+			}
+		} else {
+			if r != '\u2593' {
+				t.Errorf("bucket %d = %q, want dark shade (WAIT)", i, string(r))
+			}
+		}
+	}
+}
+
+func TestSparkline_Empty(t *testing.T) {
+	result := Sparkline(nil, 10, 60*time.Minute)
+	plain := stripANSI(result)
+	if plain != strings.Repeat("\u00b7", 10) {
+		t.Errorf("empty sparkline = %q, want 10 middle dots", plain)
+	}
+}
+
+func TestDominantStatus_FullBucket(t *testing.T) {
+	now := time.Now()
+	entries := []TimelineEntry{
+		{Status: StatusBusy, Time: now.Add(-10 * time.Minute)},
+	}
+	start := now.Add(-5 * time.Minute)
+	end := now
+
+	got := dominantStatus(entries, start, end)
+	if got != StatusBusy {
+		t.Errorf("dominantStatus = %q, want BUSY", got)
+	}
+}
+
+func TestDominantStatus_SplitBucket(t *testing.T) {
+	now := time.Now()
+	entries := []TimelineEntry{
+		{Status: StatusBusy, Time: now.Add(-10 * time.Minute)},
+		{Status: StatusWait, Time: now.Add(-3 * time.Minute)},
+	}
+	start := now.Add(-10 * time.Minute)
+	end := now
+
+	got := dominantStatus(entries, start, end)
+	// BUSY occupies 7 min, WAIT occupies 3 min
+	if got != StatusBusy {
+		t.Errorf("dominantStatus = %q, want BUSY (7min vs 3min)", got)
+	}
+}
+
+func TestDominantStatus_EmptyBucket(t *testing.T) {
+	now := time.Now()
+	start := now.Add(-5 * time.Minute)
+	end := now
+
+	got := dominantStatus(nil, start, end)
+	if got != "" {
+		t.Errorf("dominantStatus = %q, want empty", got)
+	}
+}
+
+func TestReadTimeline(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtDir := "feat-auth"
+	sessionID := "sess-1"
+
+	dir := filepath.Join(home, ".willow", "status", repoName, wtDir)
+	os.MkdirAll(dir, 0o755)
+
+	now := time.Now().UTC()
+	entries := []TimelineEntry{
+		{Status: StatusBusy, Time: now.Add(-30 * time.Minute)},
+		{Status: StatusWait, Time: now.Add(-15 * time.Minute)},
+		{Status: StatusDone, Time: now.Add(-5 * time.Minute)},
+	}
+
+	path := filepath.Join(dir, sessionID+".timeline")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		data, _ := json.Marshal(e)
+		f.Write(data)
+		f.Write([]byte("\n"))
+	}
+	f.Close()
+
+	// Read all entries (since 1 hour ago)
+	got, err := ReadTimeline(repoName, wtDir, sessionID, now.Add(-60*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("ReadTimeline returned %d entries, want 3", len(got))
+	}
+
+	// Read only recent entries (since 20 min ago)
+	got, err = ReadTimeline(repoName, wtDir, sessionID, now.Add(-20*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ReadTimeline (since 20m) returned %d entries, want 2", len(got))
+	}
+}
+
+func TestReadTimeline_MissingFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := ReadTimeline("norepo", "nowt", "nosess", time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil entries for missing file, got %v", got)
+	}
+}
+
+func TestTimelinePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := TimelinePath("myrepo", "feat-auth", "sess-1")
+	want := filepath.Join(home, ".willow", "status", "myrepo", "feat-auth", "sess-1.timeline")
+	if path != want {
+		t.Errorf("TimelinePath = %q, want %q", path, want)
+	}
+}
+
+// stripANSI removes ANSI escape sequences for plain-text comparison.
+func stripANSI(s string) string {
+	var b strings.Builder
+	inEsc := false
+	for _, r := range s {
+		if r == '\033' {
+			inEsc = true
+			continue
+		}
+		if inEsc {
+			if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
+				inEsc = false
+			}
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -20,11 +20,16 @@ func dashboardCmd() *cli.Command {
 				Usage:   "Refresh interval in seconds",
 				Value:   2,
 			},
+			&cli.BoolFlag{
+				Name:  "no-timeline",
+				Usage: "Hide the timeline column",
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			interval := time.Duration(cmd.Int("interval")) * time.Second
 			return dashboard.Run(ctx, dashboard.Config{
 				RefreshInterval: interval,
+				ShowTimeline:    !cmd.Bool("no-timeline"),
 			})
 		},
 	}

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -23,6 +23,7 @@ import (
 
 type Config struct {
 	RefreshInterval time.Duration
+	ShowTimeline    bool
 }
 
 type session struct {
@@ -35,6 +36,7 @@ type session struct {
 	Age       string
 	Unread    bool
 	WtDirName string
+	Timeline  string
 }
 
 type summary struct {
@@ -124,11 +126,12 @@ func Run(ctx context.Context, cfg Config) error {
 	defer ticker.Stop()
 
 	selectedIdx := 0
+	showTimeline := cfg.ShowTimeline
 	keyCh := readKey(tty)
 
 	// Initial render
 	sessions, sum := collectData()
-	output := render(sessions, sum, cols, selectedIdx)
+	output := render(sessions, sum, cols, selectedIdx, showTimeline)
 	fmt.Print(ui.CursorHome())
 	fmt.Print(output)
 	fmt.Print(ui.ClearToEnd())
@@ -146,7 +149,7 @@ func Run(ctx context.Context, cfg Config) error {
 			if selectedIdx >= len(sessions) && len(sessions) > 0 {
 				selectedIdx = len(sessions) - 1
 			}
-			output = render(sessions, sum, cols, selectedIdx)
+			output = render(sessions, sum, cols, selectedIdx, showTimeline)
 			fmt.Print(ui.CursorHome())
 			fmt.Print(output)
 			fmt.Print(ui.ClearToEnd())
@@ -167,6 +170,8 @@ func Run(ctx context.Context, cfg Config) error {
 				if selectedIdx >= len(sessions) && len(sessions) > 0 {
 					selectedIdx = len(sessions) - 1
 				}
+			case 't': // toggle timeline
+				showTimeline = !showTimeline
 			case 13: // Enter — switch to tmux session
 				if selectedIdx < len(sessions) {
 					s := sessions[selectedIdx]
@@ -178,7 +183,7 @@ func Run(ctx context.Context, cfg Config) error {
 					return nil
 				}
 			}
-			output = render(sessions, sum, cols, selectedIdx)
+			output = render(sessions, sum, cols, selectedIdx, showTimeline)
 			fmt.Print(ui.CursorHome())
 			fmt.Print(output)
 			fmt.Print(ui.ClearToEnd())
@@ -228,9 +233,12 @@ func collectData() ([]session, summary) {
 
 			diff := getDiffStats(wt.Path, baseBranch)
 
+			timelineSince := time.Now().Add(-60 * time.Minute)
+
 			if len(allSessions) > 0 {
 				for _, ss := range allSessions {
 					effective := claude.EffectiveStatus(ss.Status, ss.Timestamp)
+					timeline, _ := claude.ReadTimeline(repoName, wtDir, ss.SessionID, timelineSince)
 					s := session{
 						Repo:      repoName,
 						Branch:    wt.Branch,
@@ -241,6 +249,7 @@ func collectData() ([]session, summary) {
 						Age:       claude.TimeSince(ss.Timestamp),
 						Unread:    effective == claude.StatusDone && unread,
 						WtDirName: wtDir,
+						Timeline:  claude.Sparkline(timeline, 30, 60*time.Minute),
 					}
 					sessions = append(sessions, s)
 					if effective == claude.StatusBusy || effective == claude.StatusWait || effective == claude.StatusDone {
@@ -260,6 +269,7 @@ func collectData() ([]session, summary) {
 					Age:       claude.TimeSince(ws.Timestamp),
 					Unread:    ws.Status == claude.StatusDone && unread,
 					WtDirName: wtDir,
+					Timeline:  strings.Repeat("\033[2m\u00b7\033[0m", 30),
 				}
 				sessions = append(sessions, s)
 				sum.Agents++
@@ -270,7 +280,7 @@ func collectData() ([]session, summary) {
 	return sessions, sum
 }
 
-func render(sessions []session, sum summary, width int, selectedIdx int) string {
+func render(sessions []session, sum summary, width int, selectedIdx int, showTimeline bool) string {
 	var b strings.Builder
 	u := &ui.UI{}
 
@@ -322,8 +332,14 @@ func render(sessions []session, sum summary, width int, selectedIdx int) string 
 		}
 	}
 
+	// Timeline column has a fixed visual width of 30, but string length is longer due to ANSI
+	timelineW := 30
+
 	// Table width: 2 (indent) + 2 (icon) + 1 (space) + statusW + 2 + repoW + 2 + branchW + 2 + diffW + 2 + 8 (AGE)
 	tableW := 2 + 2 + 1 + statusW + 2 + repoW + 2 + branchW + 2 + diffW + 2 + 8
+	if showTimeline {
+		tableW += 2 + timelineW // 2 for gap + column width
+	}
 
 	// Title centered over the table
 	title := "willow dashboard"
@@ -340,6 +356,9 @@ func render(sessions []session, sum summary, width int, selectedIdx int) string 
 	// Header row — icon placeholder is 2 spaces to match emoji visual width (2 columns)
 	headerLine := fmt.Sprintf("  %-2s %-*s  %-*s  %-*s  %-*s  %s",
 		"", statusW, "STATUS", repoW, "REPO", branchW, "BRANCH", diffW, "DIFF", "AGE")
+	if showTimeline {
+		headerLine += fmt.Sprintf("  %-*s", timelineW, "TIMELINE")
+	}
 	b.WriteString(u.Bold(headerLine))
 	b.WriteString("\n")
 
@@ -361,6 +380,10 @@ func render(sessions []session, sum summary, width int, selectedIdx int) string 
 			branchW, s.Branch,
 			diffW, s.DiffStats,
 			u.Dim(s.Age))
+		if showTimeline {
+			// Sparkline already contains ANSI codes; append it raw after a gap
+			line += "  " + s.Timeline
+		}
 		if i == selectedIdx {
 			b.WriteString("\033[7m") // inverse video
 			b.WriteString(line)
@@ -372,7 +395,7 @@ func render(sessions []session, sum summary, width int, selectedIdx int) string 
 	}
 
 	b.WriteString("\n")
-	b.WriteString(u.Dim("  j/k: navigate | Enter: switch | r: refresh | q: quit"))
+	b.WriteString(u.Dim("  j/k: navigate | Enter: switch | t: timeline | r: refresh | q: quit"))
 	b.WriteString("\n")
 
 	return b.String()

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -51,7 +51,7 @@ func TestParseShortstat(t *testing.T) {
 }
 
 func TestRenderNoSessions(t *testing.T) {
-	out := render(nil, summary{Repos: 2, Agents: 0, Unread: 0}, 120, 0)
+	out := render(nil, summary{Repos: 2, Agents: 0, Unread: 0}, 120, 0, false)
 	if !strings.Contains(out, "No active sessions") {
 		t.Errorf("expected 'No active sessions' in output, got:\n%s", out)
 	}
@@ -71,7 +71,7 @@ func TestRenderSingleSession(t *testing.T) {
 			WtDirName: "feat--thing",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false)
 
 	if !strings.Contains(out, "myrepo") {
 		t.Errorf("expected 'myrepo' in output, got:\n%s", out)
@@ -97,7 +97,7 @@ func TestRenderUnreadMarker(t *testing.T) {
 			WtDirName: "feat--done",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 1}, 120, 0)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 1}, 120, 0, false)
 
 	if !strings.Contains(out, "\u25CF") {
 		t.Errorf("expected unread marker (bullet) in output, got:\n%s", out)
@@ -118,7 +118,7 @@ func TestRenderBusyWithTool(t *testing.T) {
 			WtDirName: "feat--edit",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false)
 
 	if !strings.Contains(out, "(Edit)") {
 		t.Errorf("expected '(Edit)' tool label in output, got:\n%s", out)
@@ -144,7 +144,7 @@ func TestRenderSelectedRow(t *testing.T) {
 			WtDirName: "branch-b",
 		},
 	}
-	out := render(sessions, summary{Repos: 2, Agents: 2, Unread: 0}, 120, 1)
+	out := render(sessions, summary{Repos: 2, Agents: 2, Unread: 0}, 120, 1, false)
 
 	if !strings.Contains(out, "\033[7m") {
 		t.Errorf("expected inverse video escape sequence for selected row, got:\n%s", out)
@@ -162,9 +162,56 @@ func TestRenderKeybindingHint(t *testing.T) {
 			WtDirName: "main",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false)
 
 	if !strings.Contains(out, "j/k: navigate") {
 		t.Errorf("expected keybinding hint 'j/k: navigate' in output, got:\n%s", out)
+	}
+}
+
+func TestRenderTimelineColumn(t *testing.T) {
+	sparkline := strings.Repeat("\033[32m\u2588\033[0m", 30)
+	sessions := []session{
+		{
+			Repo:      "myrepo",
+			Branch:    "feat--thing",
+			Status:    claude.StatusBusy,
+			DiffStats: "--",
+			Age:       "2m",
+			WtDirName: "feat--thing",
+			Timeline:  sparkline,
+		},
+	}
+
+	// With timeline enabled
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 200, 0, true)
+	if !strings.Contains(out, "TIMELINE") {
+		t.Errorf("expected 'TIMELINE' header when showTimeline=true, got:\n%s", out)
+	}
+	if !strings.Contains(out, "\u2588") {
+		t.Errorf("expected sparkline blocks in output when showTimeline=true")
+	}
+
+	// With timeline disabled
+	out = render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 200, 0, false)
+	if strings.Contains(out, "TIMELINE") {
+		t.Errorf("expected no 'TIMELINE' header when showTimeline=false, got:\n%s", out)
+	}
+}
+
+func TestRenderTimelineKeybindingHint(t *testing.T) {
+	sessions := []session{
+		{
+			Repo:      "myrepo",
+			Branch:    "main",
+			Status:    claude.StatusBusy,
+			DiffStats: "--",
+			Age:       "1m",
+			WtDirName: "main",
+		},
+	}
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, true)
+	if !strings.Contains(out, "t: timeline") {
+		t.Errorf("expected 't: timeline' in keybinding hint, got:\n%s", out)
 	}
 }

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -212,11 +212,12 @@ The `●` indicator marks completed sessions you haven't reviewed yet. Switching
 
 ## `ww dashboard` (alias: `dash`, `d`)
 
-Live-refreshing TUI showing all Claude Code sessions across all repos. Renders in an alternate screen buffer with no flicker.
+Live-refreshing TUI showing all Claude Code sessions across all repos. Renders in an alternate screen buffer with no flicker. Includes a timeline sparkline showing BUSY/WAIT/DONE transitions over the last 60 minutes.
 
 ```bash
-ww dashboard          # default 2s refresh
-ww dash -i 5          # 5s refresh interval
+ww dashboard              # default 2s refresh
+ww dash -i 5              # 5s refresh interval
+ww dash --no-timeline     # hide the timeline column
 ```
 
 ![ww dashboard](/demo-dashboard.gif)
@@ -224,8 +225,17 @@ ww dash -i 5          # 5s refresh interval
 | Flag | Description |
 |------|-------------|
 | `-i, --interval` | Refresh interval in seconds (default: 2) |
+| `--no-timeline` | Hide the timeline sparkline column |
 
-Press `Ctrl-C` to exit.
+| Key | Action |
+|-----|--------|
+| `j/k` | Navigate rows |
+| `Enter` | Switch to tmux session |
+| `t` | Toggle timeline column |
+| `r` | Refresh |
+| `q` / `Ctrl-C` | Quit |
+
+The timeline requires `ww cc-setup` to be re-run to install the updated hook that records status transitions.
 
 ## `ww log`
 


### PR DESCRIPTION
## Description of the change
Add a sparkline timeline column to the dashboard showing agent activity over the last 60 minutes. BUSY/WAIT/DONE transitions are recorded as append-only JSONL sidecar files via the hook script. Dashboard renders 30-char ANSI-colored sparklines. Toggle with `t` key or `--no-timeline` flag.

Requires `ww cc-setup` re-run to update hooks.

## Test plan
- Unit tests for sparkline rendering, dominant status calculation, timeline reading
- Manual: run agents, check `ww dashboard` for sparkline display, toggle with `t`