### PR TITLE
:sparkles: feat(cli): add cost estimation tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,15 +282,17 @@ Rich view of Claude Code agent status. Shows per-session rows when multiple agen
 | Flag | Description |
 |------|-------------|
 | `--json` | JSON output |
+| `--cost` | Show estimated token cost per session |
 
 ### `ww dashboard` (alias: `dash`, `d`)
 
-Live-refreshing TUI showing all Claude Code sessions across all repos. Includes diff stats, unread counts, per-session activity, and a timeline sparkline showing agent status transitions over the last 60 minutes.
+Live-refreshing TUI showing all Claude Code sessions across all repos. Includes diff stats, unread counts, per-session activity, a timeline sparkline showing agent status transitions over the last 60 minutes, and estimated token cost. Press `c` to toggle the cost column.
 
 ```bash
 ww dashboard              # default 2s refresh
 ww dash -i 5              # 5s refresh interval
 ww dash --no-timeline     # hide the timeline column
+ww dash --no-cost         # hide cost column
 ```
 
 | Key | Action |
@@ -410,6 +412,10 @@ Config merges two tiers (local wins):
       { "command": "cd website" },
       { "command": "cd website" }
     ]
+  },
+  "cost": {
+    "inputRate": 3.0,   // $/M tokens (default: Sonnet 4)
+    "outputRate": 15.0  // $/M tokens (default: Sonnet 4)
   }
 }
 ```

--- a/internal/claude/cost.go
+++ b/internal/claude/cost.go
@@ -1,0 +1,71 @@
+package claude
+
+import (
+	"fmt"
+)
+
+// Default pricing (Sonnet 4)
+const (
+	defaultInputRate  = 3.0  // $/M tokens
+	defaultOutputRate = 15.0 // $/M tokens
+)
+
+type CostEstimate struct {
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalUSD     float64 `json:"estimated_usd"`
+	Method       string  `json:"method"` // "estimate"
+}
+
+// EstimateFromSession produces a rough cost estimate based on tool count and session duration.
+//
+// Model: each tool invocation ~ 2000 input tokens (context) + 500 output tokens.
+// Session startup ~ 5000 input tokens for the initial prompt.
+// Duration adds a small baseline for thinking/reasoning between tool calls.
+func EstimateFromSession(ss *SessionStatus, inputRate, outputRate float64) *CostEstimate {
+	if ss == nil {
+		return nil
+	}
+	if inputRate <= 0 {
+		inputRate = defaultInputRate
+	}
+	if outputRate <= 0 {
+		outputRate = defaultOutputRate
+	}
+
+	toolCount := int64(ss.ToolCount)
+
+	// Duration-based component: ~500 input tokens per minute of active session
+	var durationMinutes float64
+	if !ss.StartTime.IsZero() {
+		dur := ss.Timestamp.Sub(ss.StartTime)
+		if dur < 0 {
+			dur = 0
+		}
+		durationMinutes = dur.Minutes()
+	}
+
+	inputTokens := int64(5000) + toolCount*2000 + int64(durationMinutes*500)
+	outputTokens := toolCount * 500
+
+	costInput := float64(inputTokens) / 1_000_000 * inputRate
+	costOutput := float64(outputTokens) / 1_000_000 * outputRate
+
+	return &CostEstimate{
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalUSD:     costInput + costOutput,
+		Method:       "estimate",
+	}
+}
+
+// FormatCost returns a compact cost string like "~$0.42".
+func FormatCost(c *CostEstimate) string {
+	if c == nil {
+		return "--"
+	}
+	if c.TotalUSD < 0.01 {
+		return "~$0.00"
+	}
+	return fmt.Sprintf("~$%.2f", c.TotalUSD)
+}

--- a/internal/claude/cost_test.go
+++ b/internal/claude/cost_test.go
@@ -1,0 +1,121 @@
+package claude
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEstimateFromSession(t *testing.T) {
+	t.Run("nil session returns nil", func(t *testing.T) {
+		got := EstimateFromSession(nil, 0, 0)
+		if got != nil {
+			t.Fatalf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("zero tool count gives base cost only", func(t *testing.T) {
+		ss := &SessionStatus{
+			Status:    StatusDone,
+			SessionID: "abc",
+			Timestamp: time.Now(),
+		}
+		got := EstimateFromSession(ss, 0, 0)
+		if got == nil {
+			t.Fatal("expected non-nil estimate")
+		}
+		if got.InputTokens != 5000 {
+			t.Errorf("input tokens = %d, want 5000", got.InputTokens)
+		}
+		if got.OutputTokens != 0 {
+			t.Errorf("output tokens = %d, want 0", got.OutputTokens)
+		}
+		if got.Method != "estimate" {
+			t.Errorf("method = %q, want %q", got.Method, "estimate")
+		}
+	})
+
+	t.Run("10 tool calls with 5 min duration", func(t *testing.T) {
+		now := time.Now()
+		ss := &SessionStatus{
+			Status:    StatusDone,
+			SessionID: "abc",
+			ToolCount: 10,
+			StartTime: now.Add(-5 * time.Minute),
+			Timestamp: now,
+		}
+		got := EstimateFromSession(ss, 0, 0)
+		if got == nil {
+			t.Fatal("expected non-nil estimate")
+		}
+		// 5000 + 10*2000 + 5*500 = 5000 + 20000 + 2500 = 27500
+		wantInput := int64(27500)
+		if got.InputTokens != wantInput {
+			t.Errorf("input tokens = %d, want %d", got.InputTokens, wantInput)
+		}
+		// 10 * 500 = 5000
+		wantOutput := int64(5000)
+		if got.OutputTokens != wantOutput {
+			t.Errorf("output tokens = %d, want %d", got.OutputTokens, wantOutput)
+		}
+		// cost = 27500/1M * 3.0 + 5000/1M * 15.0 = 0.0825 + 0.075 = 0.1575
+		wantUSD := 0.1575
+		if got.TotalUSD < wantUSD-0.001 || got.TotalUSD > wantUSD+0.001 {
+			t.Errorf("total USD = %f, want ~%f", got.TotalUSD, wantUSD)
+		}
+	})
+
+	t.Run("custom rates override defaults", func(t *testing.T) {
+		ss := &SessionStatus{
+			Status:    StatusDone,
+			SessionID: "abc",
+			ToolCount: 10,
+			Timestamp: time.Now(),
+		}
+		got := EstimateFromSession(ss, 15.0, 75.0)
+		if got == nil {
+			t.Fatal("expected non-nil estimate")
+		}
+		// input: 5000 + 10*2000 = 25000, output: 10*500 = 5000
+		// cost = 25000/1M * 15.0 + 5000/1M * 75.0 = 0.375 + 0.375 = 0.75
+		wantUSD := 0.75
+		if got.TotalUSD < wantUSD-0.001 || got.TotalUSD > wantUSD+0.001 {
+			t.Errorf("total USD = %f, want ~%f", got.TotalUSD, wantUSD)
+		}
+	})
+
+	t.Run("zero rates use defaults", func(t *testing.T) {
+		ss := &SessionStatus{
+			Status:    StatusDone,
+			SessionID: "abc",
+			Timestamp: time.Now(),
+		}
+		gotZero := EstimateFromSession(ss, 0, 0)
+		gotNeg := EstimateFromSession(ss, -1, -1)
+		if gotZero.TotalUSD != gotNeg.TotalUSD {
+			t.Errorf("zero rates (%f) != negative rates (%f), both should use defaults",
+				gotZero.TotalUSD, gotNeg.TotalUSD)
+		}
+	})
+}
+
+func TestFormatCost(t *testing.T) {
+	tests := []struct {
+		name string
+		est  *CostEstimate
+		want string
+	}{
+		{"nil", nil, "--"},
+		{"very small cost", &CostEstimate{TotalUSD: 0.001}, "~$0.00"},
+		{"normal cost", &CostEstimate{TotalUSD: 0.42}, "~$0.42"},
+		{"larger cost", &CostEstimate{TotalUSD: 1.23}, "~$1.23"},
+		{"exactly zero", &CostEstimate{TotalUSD: 0.0}, "~$0.00"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatCost(tt.est)
+			if got != tt.want {
+				t.Errorf("FormatCost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/claude/status.go
+++ b/internal/claude/status.go
@@ -32,10 +32,10 @@ type SessionStatus struct {
 	Status    Status    `json:"status"`
 	SessionID string    `json:"session_id"`
 	Tool      string    `json:"tool,omitempty"`
-	Timestamp time.Time `json:"timestamp"`
-	Worktree  string    `json:"worktree,omitempty"`
 	ToolCount int       `json:"tool_count,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
 	StartTime time.Time `json:"start_time,omitempty"`
+	Worktree  string    `json:"worktree,omitempty"`
 }
 
 func StatusDir() string {

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -24,12 +24,17 @@ func dashboardCmd() *cli.Command {
 				Name:  "no-timeline",
 				Usage: "Hide the timeline column",
 			},
+			&cli.BoolFlag{
+				Name:  "no-cost",
+				Usage: "Hide the cost column",
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			interval := time.Duration(cmd.Int("interval")) * time.Second
 			return dashboard.Run(ctx, dashboard.Config{
 				RefreshInterval: interval,
 				ShowTimeline:    !cmd.Bool("no-timeline"),
+				ShowCost:        !cmd.Bool("no-cost"),
 			})
 		},
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -8,19 +8,21 @@ import (
 	"path/filepath"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
 
 type sessionEntry struct {
-	Repo      string `json:"repo,omitempty"`
-	Branch    string `json:"branch"`
-	SessionID string `json:"session_id,omitempty"`
-	Status    string `json:"status"`
-	Timestamp string `json:"timestamp,omitempty"`
-	Unread    bool   `json:"unread,omitempty"`
-	Path      string `json:"path"`
+	Repo      string              `json:"repo,omitempty"`
+	Branch    string              `json:"branch"`
+	SessionID string              `json:"session_id,omitempty"`
+	Status    string              `json:"status"`
+	Timestamp string              `json:"timestamp,omitempty"`
+	Unread    bool                `json:"unread,omitempty"`
+	Path      string              `json:"path"`
+	Cost      *claude.CostEstimate `json:"cost,omitempty"`
 }
 
 type repoStatus struct {
@@ -31,7 +33,7 @@ type repoStatus struct {
 	UnreadCount   int
 }
 
-func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatus {
+func collectRepoStatus(repoName string, worktrees []worktree.Worktree, costCfg *config.CostConfig) repoStatus {
 	rs := repoStatus{Name: repoName, WorktreeCount: len(worktrees)}
 	for _, wt := range worktrees {
 		wtDir := filepath.Base(wt.Path)
@@ -56,6 +58,9 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 				}
 				if effective == claude.StatusDone && unread {
 					entry.Unread = true
+				}
+				if costCfg != nil {
+					entry.Cost = claude.EstimateFromSession(ss, costCfg.InputRate, costCfg.OutputRate)
 				}
 				rs.Entries = append(rs.Entries, entry)
 
@@ -99,15 +104,26 @@ func statusCmd() *cli.Command {
 				Aliases: []string{"r"},
 				Usage:   "Target a willow-managed repo by name",
 			},
+			&cli.BoolFlag{
+				Name:  "cost",
+				Usage: "Show estimated token cost per session",
+			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
 			g := flags.NewGit()
 			u := flags.NewUI()
+			showCost := cmd.Bool("cost")
 
 			repos, err := resolveRepos(g, cmd.String("repo"))
 			if err != nil {
 				return err
+			}
+
+			var costCfg *config.CostConfig
+			if showCost {
+				cfg := config.Load("")
+				costCfg = &cfg.Cost
 			}
 
 			var allStatuses []repoStatus
@@ -118,7 +134,7 @@ func statusCmd() *cli.Command {
 					continue
 				}
 				filtered := filterBareWorktrees(wts)
-				allStatuses = append(allStatuses, collectRepoStatus(r.Name, filtered))
+				allStatuses = append(allStatuses, collectRepoStatus(r.Name, filtered, costCfg))
 			}
 
 			if cmd.Bool("json") {
@@ -150,6 +166,8 @@ func statusCmd() *cli.Command {
 					}
 				}
 
+				// Compute total cost across entries if showing cost
+				var totalCost float64
 				for _, e := range rs.Entries {
 					icon := claude.StatusIcon(claude.Status(e.Status))
 					label := e.Status
@@ -164,7 +182,16 @@ func statusCmd() *cli.Command {
 						line = fmt.Sprintf("  %s %-*s  %s",
 							icon, branchW, e.Branch, label)
 					}
+					if showCost && e.Cost != nil {
+						line += "  " + u.Dim(claude.FormatCost(e.Cost))
+						totalCost += e.Cost.TotalUSD
+					}
 					u.Info(line)
+				}
+
+				if showCost {
+					u.Info("")
+					u.Info(fmt.Sprintf("  Total: ~$%.2f", totalCost))
 				}
 			}
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -20,7 +20,7 @@ func TestCollectRepoStatus_NoSessions(t *testing.T) {
 		{Branch: "feature", Path: "/wt/repo/feature"},
 	}
 
-	rs := collectRepoStatus("repo", wts)
+	rs := collectRepoStatus("repo", wts, nil)
 	if rs.WorktreeCount != 2 {
 		t.Errorf("WorktreeCount = %d, want 2", rs.WorktreeCount)
 	}
@@ -65,7 +65,7 @@ func TestCollectRepoStatus_WithSessions(t *testing.T) {
 		{Branch: "feature", Path: "/wt/myrepo/" + wtName},
 	}
 
-	rs := collectRepoStatus(repoName, wts)
+	rs := collectRepoStatus(repoName, wts, nil)
 	if rs.ActiveCount != 2 {
 		t.Errorf("ActiveCount = %d, want 2", rs.ActiveCount)
 	}
@@ -85,7 +85,7 @@ func TestCollectRepoStatus_RepoNameSet(t *testing.T) {
 		{Branch: "main", Path: "/wt/myrepo/main"},
 	}
 
-	rs := collectRepoStatus("myrepo", wts)
+	rs := collectRepoStatus("myrepo", wts, nil)
 	if rs.Name != "myrepo" {
 		t.Errorf("Name = %q, want %q", rs.Name, "myrepo")
 	}
@@ -119,7 +119,7 @@ func TestCollectRepoStatus_UnreadMarking(t *testing.T) {
 		{Branch: "done-branch", Path: "/wt/myrepo/" + wtName},
 	}
 
-	rs := collectRepoStatus(repoName, wts)
+	rs := collectRepoStatus(repoName, wts, nil)
 	if len(rs.Entries) != 1 {
 		t.Fatalf("Entries = %d, want 1", len(rs.Entries))
 	}
@@ -129,7 +129,7 @@ func TestCollectRepoStatus_UnreadMarking(t *testing.T) {
 
 	// Mark as read, then re-collect
 	claude.MarkRead(repoName, wtName)
-	rs = collectRepoStatus(repoName, wts)
+	rs = collectRepoStatus(repoName, wts, nil)
 	if rs.Entries[0].Unread {
 		t.Error("DONE session should not be unread after MarkRead")
 	}
@@ -142,7 +142,7 @@ func TestCollectRepoStatus_EmptyWorktrees(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
-	rs := collectRepoStatus("empty", nil)
+	rs := collectRepoStatus("empty", nil, nil)
 	if rs.WorktreeCount != 0 {
 		t.Errorf("WorktreeCount = %d, want 0", rs.WorktreeCount)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	Tmux             TmuxConfig   `json:"tmux,omitempty"`
 	Notify           NotifyConfig `json:"notify,omitempty"`
 	Telemetry        *bool        `json:"telemetry,omitempty"`
+	Cost             CostConfig   `json:"cost,omitempty"`
 }
 
 type NotifyConfig struct {
@@ -44,6 +45,11 @@ type PaneConfig struct {
 type Defaults struct {
 	Fetch           *bool `json:"fetch,omitempty"`
 	AutoSetupRemote *bool `json:"autoSetupRemote,omitempty"`
+}
+
+type CostConfig struct {
+	InputRate  float64 `json:"inputRate,omitempty"`  // $/M tokens, default 3.0 (Sonnet 4)
+	OutputRate float64 `json:"outputRate,omitempty"` // $/M tokens, default 15.0 (Sonnet 4)
 }
 
 func BoolPtr(v bool) *bool { return &v }
@@ -244,6 +250,12 @@ func merge(base, overlay *Config) {
 	}
 	if overlay.Notify.Command != "" {
 		base.Notify.Command = overlay.Notify.Command
+	}
+	if overlay.Cost.InputRate != 0 {
+		base.Cost.InputRate = overlay.Cost.InputRate
+	}
+	if overlay.Cost.OutputRate != 0 {
+		base.Cost.OutputRate = overlay.Cost.OutputRate
 	}
 }
 

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -24,6 +24,7 @@ import (
 type Config struct {
 	RefreshInterval time.Duration
 	ShowTimeline    bool
+	ShowCost        bool
 }
 
 type session struct {
@@ -37,6 +38,7 @@ type session struct {
 	Unread    bool
 	WtDirName string
 	Timeline  string
+	Cost      string
 }
 
 type summary struct {
@@ -127,11 +129,12 @@ func Run(ctx context.Context, cfg Config) error {
 
 	selectedIdx := 0
 	showTimeline := cfg.ShowTimeline
+	showCost := cfg.ShowCost
 	keyCh := readKey(tty)
 
 	// Initial render
-	sessions, sum := collectData()
-	output := render(sessions, sum, cols, selectedIdx, showTimeline)
+	sessions, sum := collectData(showCost)
+	output := render(sessions, sum, cols, selectedIdx, showTimeline, showCost)
 	fmt.Print(ui.CursorHome())
 	fmt.Print(output)
 	fmt.Print(ui.ClearToEnd())
@@ -145,11 +148,11 @@ func Run(ctx context.Context, cfg Config) error {
 		case <-winchCh:
 			cols = termWidth()
 		case <-ticker.C:
-			sessions, sum = collectData()
+			sessions, sum = collectData(showCost)
 			if selectedIdx >= len(sessions) && len(sessions) > 0 {
 				selectedIdx = len(sessions) - 1
 			}
-			output = render(sessions, sum, cols, selectedIdx, showTimeline)
+			output = render(sessions, sum, cols, selectedIdx, showTimeline, showCost)
 			fmt.Print(ui.CursorHome())
 			fmt.Print(output)
 			fmt.Print(ui.ClearToEnd())
@@ -166,12 +169,14 @@ func Run(ctx context.Context, cfg Config) error {
 			case 'q', 3: // q or Ctrl+C
 				return nil
 			case 'r': // refresh
-				sessions, sum = collectData()
+				sessions, sum = collectData(showCost)
 				if selectedIdx >= len(sessions) && len(sessions) > 0 {
 					selectedIdx = len(sessions) - 1
 				}
 			case 't': // toggle timeline
 				showTimeline = !showTimeline
+			case 'c': // toggle cost column
+				showCost = !showCost
 			case 13: // Enter — switch to tmux session
 				if selectedIdx < len(sessions) {
 					s := sessions[selectedIdx]
@@ -183,7 +188,7 @@ func Run(ctx context.Context, cfg Config) error {
 					return nil
 				}
 			}
-			output = render(sessions, sum, cols, selectedIdx, showTimeline)
+			output = render(sessions, sum, cols, selectedIdx, showTimeline, showCost)
 			fmt.Print(ui.CursorHome())
 			fmt.Print(output)
 			fmt.Print(ui.ClearToEnd())
@@ -191,7 +196,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 }
 
-func collectData() ([]session, summary) {
+func collectData(computeCost bool) ([]session, summary) {
 	repos, err := config.ListRepos()
 	if err != nil {
 		return nil, summary{}
@@ -251,6 +256,10 @@ func collectData() ([]session, summary) {
 						WtDirName: wtDir,
 						Timeline:  claude.Sparkline(timeline, 30, 60*time.Minute),
 					}
+					if computeCost {
+						estimate := claude.EstimateFromSession(ss, cfg.Cost.InputRate, cfg.Cost.OutputRate)
+						s.Cost = claude.FormatCost(estimate)
+					}
 					sessions = append(sessions, s)
 					if effective == claude.StatusBusy || effective == claude.StatusWait || effective == claude.StatusDone {
 						sum.Agents++
@@ -280,7 +289,7 @@ func collectData() ([]session, summary) {
 	return sessions, sum
 }
 
-func render(sessions []session, sum summary, width int, selectedIdx int, showTimeline bool) string {
+func render(sessions []session, sum summary, width int, selectedIdx int, showTimeline bool, showCost bool) string {
 	var b strings.Builder
 	u := &ui.UI{}
 
@@ -309,6 +318,15 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	repoW := len("REPO")
 	branchW := len("BRANCH")
 	diffW := len("DIFF")
+	costW := 0
+	if showCost {
+		costW = len("COST")
+		for _, s := range sessions {
+			if len(s.Cost) > costW {
+				costW = len(s.Cost)
+			}
+		}
+	}
 	for i, s := range sessions {
 		text := string(s.Status)
 		if s.Unread {
@@ -340,6 +358,9 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	if showTimeline {
 		tableW += 2 + timelineW // 2 for gap + column width
 	}
+	if showCost {
+		tableW += 2 + costW
+	}
 
 	// Title centered over the table
 	title := "willow dashboard"
@@ -354,8 +375,12 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	b.WriteString("\n\n")
 
 	// Header row — icon placeholder is 2 spaces to match emoji visual width (2 columns)
-	headerLine := fmt.Sprintf("  %-2s %-*s  %-*s  %-*s  %-*s  %s",
-		"", statusW, "STATUS", repoW, "REPO", branchW, "BRANCH", diffW, "DIFF", "AGE")
+	headerLine := fmt.Sprintf("  %-2s %-*s  %-*s  %-*s  %-*s",
+		"", statusW, "STATUS", repoW, "REPO", branchW, "BRANCH", diffW, "DIFF")
+	if showCost {
+		headerLine += fmt.Sprintf("  %-*s", costW, "COST")
+	}
+	headerLine += "  AGE"
 	if showTimeline {
 		headerLine += fmt.Sprintf("  %-*s", timelineW, "TIMELINE")
 	}
@@ -374,12 +399,15 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	// Rows — status is padded as plain text, no ANSI inside padded fields
 	for i, s := range sessions {
 		icon := claude.StatusIcon(s.Status)
-		line := fmt.Sprintf("  %s %-*s  %-*s  %-*s  %-*s  %s",
+		line := fmt.Sprintf("  %s %-*s  %-*s  %-*s  %-*s",
 			icon, statusW, labels[i].text,
 			repoW, s.Repo,
 			branchW, s.Branch,
-			diffW, s.DiffStats,
-			u.Dim(s.Age))
+			diffW, s.DiffStats)
+		if showCost {
+			line += fmt.Sprintf("  %-*s", costW, s.Cost)
+		}
+		line += "  " + u.Dim(s.Age)
 		if showTimeline {
 			// Sparkline already contains ANSI codes; append it raw after a gap
 			line += "  " + s.Timeline
@@ -395,7 +423,7 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	}
 
 	b.WriteString("\n")
-	b.WriteString(u.Dim("  j/k: navigate | Enter: switch | t: timeline | r: refresh | q: quit"))
+	b.WriteString(u.Dim("  j/k: navigate | Enter: switch | t: timeline | c: cost | r: refresh | q: quit"))
 	b.WriteString("\n")
 
 	return b.String()

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -51,7 +51,7 @@ func TestParseShortstat(t *testing.T) {
 }
 
 func TestRenderNoSessions(t *testing.T) {
-	out := render(nil, summary{Repos: 2, Agents: 0, Unread: 0}, 120, 0, false)
+	out := render(nil, summary{Repos: 2, Agents: 0, Unread: 0}, 120, 0, false, false)
 	if !strings.Contains(out, "No active sessions") {
 		t.Errorf("expected 'No active sessions' in output, got:\n%s", out)
 	}
@@ -71,7 +71,7 @@ func TestRenderSingleSession(t *testing.T) {
 			WtDirName: "feat--thing",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false, false)
 
 	if !strings.Contains(out, "myrepo") {
 		t.Errorf("expected 'myrepo' in output, got:\n%s", out)
@@ -97,7 +97,7 @@ func TestRenderUnreadMarker(t *testing.T) {
 			WtDirName: "feat--done",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 1}, 120, 0, false)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 1}, 120, 0, false, false)
 
 	if !strings.Contains(out, "\u25CF") {
 		t.Errorf("expected unread marker (bullet) in output, got:\n%s", out)
@@ -118,7 +118,7 @@ func TestRenderBusyWithTool(t *testing.T) {
 			WtDirName: "feat--edit",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false, false)
 
 	if !strings.Contains(out, "(Edit)") {
 		t.Errorf("expected '(Edit)' tool label in output, got:\n%s", out)
@@ -144,7 +144,7 @@ func TestRenderSelectedRow(t *testing.T) {
 			WtDirName: "branch-b",
 		},
 	}
-	out := render(sessions, summary{Repos: 2, Agents: 2, Unread: 0}, 120, 1, false)
+	out := render(sessions, summary{Repos: 2, Agents: 2, Unread: 0}, 120, 1, false, false)
 
 	if !strings.Contains(out, "\033[7m") {
 		t.Errorf("expected inverse video escape sequence for selected row, got:\n%s", out)
@@ -162,7 +162,7 @@ func TestRenderKeybindingHint(t *testing.T) {
 			WtDirName: "main",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false, false)
 
 	if !strings.Contains(out, "j/k: navigate") {
 		t.Errorf("expected keybinding hint 'j/k: navigate' in output, got:\n%s", out)
@@ -184,7 +184,7 @@ func TestRenderTimelineColumn(t *testing.T) {
 	}
 
 	// With timeline enabled
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 200, 0, true)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 200, 0, true, false)
 	if !strings.Contains(out, "TIMELINE") {
 		t.Errorf("expected 'TIMELINE' header when showTimeline=true, got:\n%s", out)
 	}
@@ -193,7 +193,7 @@ func TestRenderTimelineColumn(t *testing.T) {
 	}
 
 	// With timeline disabled
-	out = render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 200, 0, false)
+	out = render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 200, 0, false, false)
 	if strings.Contains(out, "TIMELINE") {
 		t.Errorf("expected no 'TIMELINE' header when showTimeline=false, got:\n%s", out)
 	}
@@ -210,7 +210,7 @@ func TestRenderTimelineKeybindingHint(t *testing.T) {
 			WtDirName: "main",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, true)
+	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, true, false)
 	if !strings.Contains(out, "t: timeline") {
 		t.Errorf("expected 't: timeline' in keybinding hint, got:\n%s", out)
 	}

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -209,6 +209,7 @@ The `●` indicator marks completed sessions you haven't reviewed yet. Switching
 | Flag | Description |
 |------|-------------|
 | `--json` | JSON output |
+| `--cost` | Show estimated token cost per session |
 
 ## `ww dashboard` (alias: `dash`, `d`)
 
@@ -218,6 +219,7 @@ Live-refreshing TUI showing all Claude Code sessions across all repos. Renders i
 ww dashboard              # default 2s refresh
 ww dash -i 5              # 5s refresh interval
 ww dash --no-timeline     # hide the timeline column
+ww dash --no-cost         # hide cost column
 ```
 
 ![ww dashboard](/demo-dashboard.gif)
@@ -226,12 +228,14 @@ ww dash --no-timeline     # hide the timeline column
 |------|-------------|
 | `-i, --interval` | Refresh interval in seconds (default: 2) |
 | `--no-timeline` | Hide the timeline sparkline column |
+| `--no-cost` | Hide the cost column |
 
 | Key | Action |
 |-----|--------|
 | `j/k` | Navigate rows |
 | `Enter` | Switch to tmux session |
 | `t` | Toggle timeline column |
+| `c` | Toggle cost column |
 | `r` | Refresh |
 | `q` / `Ctrl-C` | Quit |
 


### PR DESCRIPTION
## Description of the change
Estimate token usage and cost per Claude session based on tool count and session duration. Display in `ww status --cost` and as a toggleable column in `ww dashboard` (press `c`). Pricing defaults to Sonnet 4 rates, configurable via `cost.inputRate` / `cost.outputRate`.

## Test plan
- Unit tests for estimation model, formatting, and edge cases
- Manual: run `ww status --cost`, check dashboard cost column