### PR TITLE
:sparkles: feat(cli): add ww stack status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,29 @@ ww new feature-c -b feature-b         # third layer
 
 Stacked branches are shown as a tree in `ww ls` and the tmux picker. Parent relationships are tracked in `branches.json` per repo.
 
+### `ww stack status` (alias: `ww stack s`)
+
+Show CI, review, and merge status for every PR in a stack at a glance. Fetches all PR data in a single `gh pr list` call.
+
+```bash
+ww stack status                    # current repo
+ww stack status -r myrepo          # target a specific repo
+ww stack status --json             # JSON output
+```
+
+```
+  feature-a              #42  ✓ CI  ✓ Review  MERGEABLE  +100 -20
+  └─ feature-b           #43  ✗ CI  ◯ Review  CONFLICTING  +50 -10
+     └─ feature-c        (no PR)
+```
+
+| Flag | Description |
+|------|-------------|
+| `-r, --repo` | Target repo by name |
+| `--json` | JSON output |
+
+Requires the [GitHub CLI](https://cli.github.com/) (`gh`).
+
 ### `ww sync [branch]`
 
 Rebase stacked worktrees onto their parents in topological order.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -97,6 +97,7 @@ func NewApp() *cli.Command {
 			gcCmd(),
 			doctorCmd(),
 			configCmd(),
+			stackCmd(),
 			refreshStatusCmd(),
 		},
 	}

--- a/internal/cli/stack_cmd.go
+++ b/internal/cli/stack_cmd.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
+	"github.com/iamrajjoshi/willow/internal/gh"
+	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/ui"
+	"github.com/urfave/cli/v3"
+)
+
+func stackCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "stack",
+		Usage: "Manage stacked branches",
+		Commands: []*cli.Command{
+			stackStatusCmd(),
+		},
+	}
+}
+
+func stackStatusCmd() *cli.Command {
+	return &cli.Command{
+		Name:    "status",
+		Aliases: []string{"s"},
+		Usage:   "Show CI and PR status for branches in a stack",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target a willow-managed repo by name",
+			},
+			&cli.BoolFlag{
+				Name:  "json",
+				Usage: "Output as JSON",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			var bareDir string
+			var err error
+			if repoFlag := cmd.String("repo"); repoFlag != "" {
+				bareDir, err = config.ResolveRepo(repoFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				bareDir, err = requireWillowRepo(g)
+				if err != nil {
+					return err
+				}
+			}
+
+			st := stack.Load(bareDir)
+			if st.IsEmpty() {
+				return errs.Userf("no stacked branches found")
+			}
+
+			branches := st.TopoSort()
+
+			branchSet := make(map[string]bool, len(branches))
+			for _, b := range branches {
+				branchSet[b] = true
+			}
+			treeLines := st.TreeLines(branchSet)
+
+			// Find a worktree path to run gh in
+			repoName := repoNameFromDir(bareDir)
+			wtDir := filepath.Join(config.WorktreesDir(), repoName)
+			ghDir, err := findGHDir(wtDir)
+			if err != nil {
+				return errs.Userf("no worktree found to run gh in (need at least one worktree)")
+			}
+
+			prMap, err := gh.BatchPRInfo(ghDir, branches)
+			if err != nil {
+				return err
+			}
+
+			if cmd.Bool("json") {
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(prMap)
+			}
+
+			// Compute max display width for branch column alignment
+			maxBranchWidth := 0
+			for _, tl := range treeLines {
+				w := utf8.RuneCountInString(tl.Prefix) + utf8.RuneCountInString(tl.Branch)
+				if w > maxBranchWidth {
+					maxBranchWidth = w
+				}
+			}
+
+			for _, tl := range treeLines {
+				branchDisplay := tl.Prefix + tl.Branch
+				plainWidth := utf8.RuneCountInString(branchDisplay)
+				padding := maxBranchWidth - plainWidth
+				if padding < 0 {
+					padding = 0
+				}
+
+				pr := prMap[tl.Branch]
+				var annotation string
+				if pr == nil {
+					annotation = u.Dim("(no PR)")
+				} else {
+					annotation = formatPRAnnotation(u, pr)
+				}
+
+				line := fmt.Sprintf("  %s%s  %s", branchDisplay, strings.Repeat(" ", padding), annotation)
+				u.Info(line)
+			}
+
+			return nil
+		},
+	}
+}
+
+func formatPRAnnotation(u *ui.UI, pr *gh.PRInfo) string {
+	prNum := fmt.Sprintf("#%d", pr.Number)
+
+	var ciLabel string
+	switch pr.CIStatus() {
+	case "pass":
+		ciLabel = u.Green("\u2713 CI")
+	case "fail":
+		ciLabel = u.Red("\u2717 CI")
+	case "pending":
+		ciLabel = u.Yellow("\u25CB CI")
+	default:
+		ciLabel = u.Dim("- CI")
+	}
+
+	var reviewLabel string
+	switch pr.ReviewStatus {
+	case "APPROVED":
+		reviewLabel = u.Green("\u2713 Review")
+	case "CHANGES_REQUESTED":
+		reviewLabel = u.Red("\u2717 Review")
+	case "REVIEW_REQUIRED":
+		reviewLabel = u.Yellow("\u25CB Review")
+	default:
+		reviewLabel = u.Dim("- Review")
+	}
+
+	var mergeLabel string
+	switch pr.Mergeable {
+	case "MERGEABLE":
+		mergeLabel = u.Green("MERGEABLE")
+	case "CONFLICTING":
+		mergeLabel = u.Red("CONFLICTING")
+	default:
+		mergeLabel = u.Yellow("UNKNOWN")
+	}
+
+	diffStat := fmt.Sprintf("%s %s", u.Green(fmt.Sprintf("+%d", pr.Additions)), u.Red(fmt.Sprintf("-%d", pr.Deletions)))
+
+	return fmt.Sprintf("%s  %s  %s  %s  %s", prNum, ciLabel, reviewLabel, mergeLabel, diffStat)
+}
+
+// findGHDir finds any existing directory under the worktrees dir to use as
+// a working directory for gh commands.
+func findGHDir(wtDir string) (string, error) {
+	entries, err := os.ReadDir(wtDir)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			return filepath.Join(wtDir, e.Name()), nil
+		}
+	}
+	return "", fmt.Errorf("no directories in %s", wtDir)
+}

--- a/internal/cli/stack_cmd_test.go
+++ b/internal/cli/stack_cmd_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import "testing"
+
+func TestStackCmd(t *testing.T) {
+	cmd := stackCmd()
+	if cmd.Name != "stack" {
+		t.Errorf("Name = %q, want %q", cmd.Name, "stack")
+	}
+	if len(cmd.Commands) == 0 {
+		t.Fatal("expected subcommands, got none")
+	}
+
+	var found bool
+	for _, sub := range cmd.Commands {
+		if sub.Name == "status" {
+			found = true
+			if len(sub.Aliases) == 0 || sub.Aliases[0] != "s" {
+				t.Errorf("status aliases = %v, want [s]", sub.Aliases)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'status' subcommand")
+	}
+}

--- a/internal/gh/pr.go
+++ b/internal/gh/pr.go
@@ -1,0 +1,106 @@
+package gh
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+
+	"github.com/iamrajjoshi/willow/internal/errs"
+)
+
+type checkRun struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`     // COMPLETED, IN_PROGRESS, QUEUED
+	Conclusion string `json:"conclusion"` // SUCCESS, FAILURE, NEUTRAL, SKIPPED, etc.
+}
+
+type ghPR struct {
+	Number       int        `json:"number"`
+	Title        string     `json:"title"`
+	Branch       string     `json:"headRefName"`
+	State        string     `json:"state"`
+	ReviewStatus string     `json:"reviewDecision"`
+	Mergeable    string     `json:"mergeable"`
+	Additions    int        `json:"additions"`
+	Deletions    int        `json:"deletions"`
+	URL          string     `json:"url"`
+	Checks       []checkRun `json:"statusCheckRollup"`
+}
+
+type PRInfo struct {
+	Number       int    `json:"number"`
+	Title        string `json:"title"`
+	Branch       string `json:"headRefName"`
+	State        string `json:"state"`         // OPEN, MERGED, CLOSED
+	ReviewStatus string `json:"reviewDecision"` // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, ""
+	Mergeable    string `json:"mergeable"`      // MERGEABLE, CONFLICTING, UNKNOWN
+	Additions    int    `json:"additions"`
+	Deletions    int    `json:"deletions"`
+	URL          string `json:"url"`
+	Checks       []checkRun
+}
+
+// CIStatus returns the aggregate CI status: "pass", "fail", "pending", or "none".
+func (p *PRInfo) CIStatus() string {
+	if len(p.Checks) == 0 {
+		return "none"
+	}
+	for _, c := range p.Checks {
+		if c.Conclusion == "FAILURE" {
+			return "fail"
+		}
+	}
+	for _, c := range p.Checks {
+		if c.Status != "COMPLETED" {
+			return "pending"
+		}
+	}
+	return "pass"
+}
+
+// BatchPRInfo fetches PR info for multiple branches in a single gh call.
+func BatchPRInfo(dir string, branches []string) (map[string]*PRInfo, error) {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return nil, errs.Userf("gh CLI required for stack status (install: https://cli.github.com)")
+	}
+
+	cmd := exec.Command("gh", "pr", "list",
+		"--json", "number,title,headRefName,state,reviewDecision,mergeable,additions,deletions,url,statusCheckRollup",
+		"--limit", "100",
+		"--state", "all",
+	)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh pr list failed: %w", err)
+	}
+
+	var prs []ghPR
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("failed to parse gh output: %w", err)
+	}
+
+	branchSet := make(map[string]bool, len(branches))
+	for _, b := range branches {
+		branchSet[b] = true
+	}
+
+	result := make(map[string]*PRInfo)
+	for _, pr := range prs {
+		if branchSet[pr.Branch] {
+			result[pr.Branch] = &PRInfo{
+				Number:       pr.Number,
+				Title:        pr.Title,
+				Branch:       pr.Branch,
+				State:        pr.State,
+				ReviewStatus: pr.ReviewStatus,
+				Mergeable:    pr.Mergeable,
+				Additions:    pr.Additions,
+				Deletions:    pr.Deletions,
+				URL:          pr.URL,
+				Checks:       pr.Checks,
+			}
+		}
+	}
+	return result, nil
+}

--- a/internal/gh/pr_test.go
+++ b/internal/gh/pr_test.go
@@ -1,0 +1,150 @@
+package gh
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCIStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		checks []checkRun
+		want   string
+	}{
+		{
+			name:   "no checks",
+			checks: nil,
+			want:   "none",
+		},
+		{
+			name: "all pass",
+			checks: []checkRun{
+				{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "lint", Status: "COMPLETED", Conclusion: "SUCCESS"},
+			},
+			want: "pass",
+		},
+		{
+			name: "one failure",
+			checks: []checkRun{
+				{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "lint", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			want: "fail",
+		},
+		{
+			name: "one pending",
+			checks: []checkRun{
+				{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "deploy", Status: "IN_PROGRESS", Conclusion: ""},
+			},
+			want: "pending",
+		},
+		{
+			name: "queued",
+			checks: []checkRun{
+				{Name: "test", Status: "QUEUED", Conclusion: ""},
+			},
+			want: "pending",
+		},
+		{
+			name: "failure takes priority over pending",
+			checks: []checkRun{
+				{Name: "test", Status: "IN_PROGRESS", Conclusion: ""},
+				{Name: "lint", Status: "COMPLETED", Conclusion: "FAILURE"},
+			},
+			want: "fail",
+		},
+		{
+			name: "skipped and neutral count as pass",
+			checks: []checkRun{
+				{Name: "test", Status: "COMPLETED", Conclusion: "SUCCESS"},
+				{Name: "optional", Status: "COMPLETED", Conclusion: "SKIPPED"},
+				{Name: "neutral", Status: "COMPLETED", Conclusion: "NEUTRAL"},
+			},
+			want: "pass",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pr := &PRInfo{Checks: tt.checks}
+			got := pr.CIStatus()
+			if got != tt.want {
+				t.Errorf("CIStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGHPRJSONParsing(t *testing.T) {
+	raw := `[
+		{
+			"number": 42,
+			"title": "Add feature X",
+			"headRefName": "feature-x",
+			"state": "OPEN",
+			"reviewDecision": "APPROVED",
+			"mergeable": "MERGEABLE",
+			"additions": 100,
+			"deletions": 20,
+			"url": "https://github.com/org/repo/pull/42",
+			"statusCheckRollup": [
+				{"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
+				{"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"}
+			]
+		},
+		{
+			"number": 43,
+			"title": "Fix bug Y",
+			"headRefName": "fix-y",
+			"state": "MERGED",
+			"reviewDecision": "",
+			"mergeable": "UNKNOWN",
+			"additions": 5,
+			"deletions": 3,
+			"url": "https://github.com/org/repo/pull/43",
+			"statusCheckRollup": []
+		}
+	]`
+
+	var prs []ghPR
+	if err := json.Unmarshal([]byte(raw), &prs); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	if len(prs) != 2 {
+		t.Fatalf("expected 2 PRs, got %d", len(prs))
+	}
+
+	pr := prs[0]
+	if pr.Number != 42 {
+		t.Errorf("Number = %d, want 42", pr.Number)
+	}
+	if pr.Branch != "feature-x" {
+		t.Errorf("Branch = %q, want %q", pr.Branch, "feature-x")
+	}
+	if pr.State != "OPEN" {
+		t.Errorf("State = %q, want %q", pr.State, "OPEN")
+	}
+	if pr.ReviewStatus != "APPROVED" {
+		t.Errorf("ReviewStatus = %q, want %q", pr.ReviewStatus, "APPROVED")
+	}
+	if pr.Mergeable != "MERGEABLE" {
+		t.Errorf("Mergeable = %q, want %q", pr.Mergeable, "MERGEABLE")
+	}
+	if len(pr.Checks) != 2 {
+		t.Errorf("Checks count = %d, want 2", len(pr.Checks))
+	}
+	if pr.Checks[0].Name != "test" || pr.Checks[0].Conclusion != "SUCCESS" {
+		t.Errorf("first check = %+v, want test/SUCCESS", pr.Checks[0])
+	}
+
+	pr2 := prs[1]
+	if pr2.State != "MERGED" {
+		t.Errorf("PR2 State = %q, want %q", pr2.State, "MERGED")
+	}
+	if len(pr2.Checks) != 0 {
+		t.Errorf("PR2 Checks count = %d, want 0", len(pr2.Checks))
+	}
+}

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -110,6 +110,36 @@ When `--base` points to a local branch (another worktree), willow forks from it 
 
 Removing a stacked branch re-parents its children to the removed branch's parent. Use `--force` if the branch has children.
 
+## `ww stack status` (alias: `ww stack s`)
+
+Show CI, review, and merge status for every PR in a stack at a glance. Fetches all data in a single `gh pr list` call, so it's O(1) regardless of stack depth.
+
+```bash
+ww stack status                    # current repo
+ww stack status -r myrepo          # target a specific repo
+ww stack status --json             # machine-readable output
+```
+
+```
+  feature-a              #42  ✓ CI  ✓ Review  MERGEABLE  +100 -20
+  └─ feature-b           #43  ✗ CI  ◯ Review  CONFLICTING  +50 -10
+     └─ feature-c        (no PR)
+```
+
+Each branch shows:
+- **PR number** — links to the GitHub PR
+- **CI status** — aggregate of all checks: `✓ CI` (pass), `✗ CI` (fail), `◯ CI` (pending), `- CI` (none)
+- **Review status** — `✓ Review` (approved), `✗ Review` (changes requested), `◯ Review` (required), `- Review` (none)
+- **Mergeable** — `MERGEABLE`, `CONFLICTING`, or `UNKNOWN`
+- **Diff stats** — additions and deletions
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-r, --repo` | Target repo by name | Auto-detected from cwd |
+| `--json` | Output as JSON | `false` |
+
+Requires the [GitHub CLI](https://cli.github.com/) (`gh`).
+
 ## `ww sync [branch]`
 
 Rebase stacked worktrees onto their parents in topological order. Like `git machete traverse` but for worktrees.
@@ -428,6 +458,7 @@ Setup: `ww tmux install` prints the config to add to `~/.tmux.conf`, including a
 | `ww l` | `ww ls` |
 | `ww s` | `ww status` |
 | `ww dash` / `ww d` | `ww dashboard` |
+| `ww stack s` | `ww stack status` |
 
 ## Global flags
 


### PR DESCRIPTION
## Description of the change
Add `ww stack status` command showing CI, review, and merge status for every PR in a stack at a glance. New `internal/gh` package wraps `gh pr list` with a single batch call (O(1) not O(n)). Tree view with colored annotations for CI pass/fail, review status, mergeability, and diff stats.

## Test plan
- Unit tests for CIStatus aggregation and JSON parsing
- Manual: create stacked PRs, run `ww stack status`, verify tree output