### PR TITLE
✨ feat(cli): add ww dispatch command and Ctrl-G tmux keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,25 @@ ww notify status               # check if running
 
 Desktop notifications are off by default. Enable with `"notify": {"desktop": true}` in config. This applies to both `ww notify` and the tmux status bar widget.
 
+### `ww dispatch <prompt> [flags]`
+
+Create a worktree and launch Claude Code with a prompt. From the terminal, Claude runs interactively in the foreground. From the tmux picker (`Ctrl-G`), it launches in a background session.
+
+```bash
+ww dispatch "Fix the login validation bug"                  # auto-name branch
+ww dispatch "Add retry logic" --name add-retries             # explicit branch name
+ww dispatch "Write tests for auth" --base feature/auth       # stacked on a branch
+ww dispatch "Refactor payments" --repo myrepo                # target specific repo
+```
+
+| Flag | Description |
+|------|-------------|
+| `--name` | Worktree/branch name (default: auto-generated from prompt) |
+| `-r, --repo` | Target repo by name |
+| `-b, --base` | Base branch to fork from |
+| `--no-fetch` | Skip fetching from remote |
+| `--yolo` | Run Claude with `--dangerously-skip-permissions` |
+
 ### `ww cc-setup`
 
 One-time hook installation for Claude Code status tracking.

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -90,6 +90,7 @@ func NewApp() *cli.Command {
 			statusCmd(),
 			dashboardCmd(),
 			logCmd(),
+			dispatchCmd(),
 			notifyCmd(),
 			tmuxCmd(),
 			setupCmd(),

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errs"
+	"github.com/iamrajjoshi/willow/internal/log"
+	"github.com/iamrajjoshi/willow/internal/tmux"
+	"github.com/iamrajjoshi/willow/internal/ui"
+	"github.com/urfave/cli/v3"
+)
+
+func dispatchCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "dispatch",
+		Usage: "Create a worktree and launch Claude Code with a prompt",
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "prompt",
+				UsageText: "<prompt>",
+			},
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "name",
+				Usage: "Worktree/branch name (default: auto-generated from prompt)",
+			},
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target a willow-managed repo by name",
+			},
+			&cli.StringFlag{
+				Name:    "base",
+				Aliases: []string{"b"},
+				Usage:   "Base branch to fork from",
+			},
+			&cli.BoolFlag{
+				Name:  "no-fetch",
+				Usage: "Skip fetching from remote",
+			},
+			&cli.BoolFlag{
+				Name:  "yolo",
+				Usage: "Run Claude with --dangerously-skip-permissions",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			prompt := cmd.StringArg("prompt")
+			if prompt == "" {
+				return errs.Userf("prompt is required\n\nUsage: ww dispatch <prompt> [flags]")
+			}
+
+			// Resolve repo
+			var bareDir string
+			var err error
+			if repoFlag := cmd.String("repo"); repoFlag != "" {
+				bareDir, err = config.ResolveRepo(repoFlag)
+				if err != nil {
+					return err
+				}
+			} else {
+				bareDir, err = requireWillowRepo(g)
+				if err != nil {
+					return err
+				}
+			}
+			repoName := repoNameFromDir(bareDir)
+
+			// Determine branch name
+			branch := cmd.String("name")
+			if branch == "" {
+				branch = "dispatch--" + slugify(prompt)
+			}
+
+			// Find willow binary for subprocess
+			self, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("failed to find willow binary: %w", err)
+			}
+
+			// Create worktree via willow new --cd
+			args := []string{"new", "--cd", "--repo", repoName}
+			if base := cmd.String("base"); base != "" {
+				args = append(args, "--base", base)
+			}
+			if cmd.Bool("no-fetch") {
+				args = append(args, "--no-fetch")
+			}
+			args = append(args, "--", branch)
+
+			u.Info(fmt.Sprintf("Creating worktree %s...", u.Bold(branch)))
+			newCmd := exec.Command(self, args...)
+			newCmd.Stderr = os.Stderr
+			out, err := newCmd.Output()
+			if err != nil {
+				return fmt.Errorf("failed to create worktree: %w", err)
+			}
+			wtPath := strings.TrimSpace(string(out))
+			if wtPath == "" {
+				return fmt.Errorf("no path returned from willow new")
+			}
+
+			// Write prompt to file (avoids shell quoting issues)
+			promptFile := filepath.Join(wtPath, ".willow-prompt")
+			if err := os.WriteFile(promptFile, []byte(prompt), 0o644); err != nil {
+				return fmt.Errorf("failed to write prompt file: %w", err)
+			}
+
+			// Log dispatch event
+			meta := map[string]string{"prompt": truncatePrompt(prompt)}
+			_ = log.Append(log.Event{Action: "dispatch", Repo: repoName, Branch: branch, Metadata: meta})
+
+			// Launch Claude in the current terminal.
+			// The tmux picker can use dispatchTmux for background dispatch.
+			return dispatchForeground(u, wtPath, branch, prompt, cmd.Bool("yolo"))
+		},
+	}
+}
+
+func dispatchTmux(u *ui.UI, repoName, wtDir, wtPath, bareDir, branch string, yolo bool) error {
+	cfg := config.Load(bareDir)
+	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
+
+	if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.Panes); err != nil {
+		return fmt.Errorf("failed to create tmux session: %w", err)
+	}
+
+	claudeCmd := `claude "$(cat .willow-prompt)"`
+	if yolo {
+		claudeCmd += " --dangerously-skip-permissions"
+	}
+	if err := tmux.SendKeys(sessName, claudeCmd, "Enter"); err != nil {
+		return fmt.Errorf("failed to send claude command: %w", err)
+	}
+
+	u.Success(fmt.Sprintf("Dispatched agent on %s", u.Bold(branch)))
+	u.Info(fmt.Sprintf("  session: %s", u.Dim(sessName)))
+	u.Info(fmt.Sprintf("  switch:  %s", u.Dim("ww sw")))
+	return nil
+}
+
+func dispatchForeground(u *ui.UI, wtPath, branch, prompt string, yolo bool) error {
+	if _, err := exec.LookPath("claude"); err != nil {
+		return errs.Userf("'claude' CLI not found — install Claude Code first")
+	}
+
+	u.Success(fmt.Sprintf("Dispatched agent on %s (foreground)", u.Bold(branch)))
+	u.Info(fmt.Sprintf("  path: %s", u.Dim(wtPath)))
+	u.Info("")
+
+	claudeArgs := "claude " + shellQuote(prompt)
+	if yolo {
+		claudeArgs += " --dangerously-skip-permissions"
+	}
+	// Run through login shell so .zshrc/.zprofile env vars are loaded
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/zsh"
+	}
+	cmd := exec.Command(shell, "-l", "-c", claudeArgs)
+	cmd.Dir = wtPath
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+var slugRe = regexp.MustCompile(`[^a-z0-9-]`)
+
+func slugify(s string) string {
+	words := strings.Fields(strings.ToLower(s))
+	if len(words) > 5 {
+		words = words[:5]
+	}
+	slug := strings.Join(words, "-")
+	slug = slugRe.ReplaceAllString(slug, "")
+	if len(slug) > 50 {
+		slug = slug[:50]
+	}
+	return strings.TrimRight(slug, "-")
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+func truncatePrompt(s string) string {
+	if len(s) > 80 {
+		return s[:77] + "..."
+	}
+	return s
+}

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import "testing"
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Fix the login validation bug", "fix-the-login-validation-bug"},
+		{"Add retry logic to the API client", "add-retry-logic-to-the"},
+		{"simple", "simple"},
+		{"UPPERCASE WORDS HERE", "uppercase-words-here"},
+		{"special! chars@ here#", "special-chars-here"},
+		{"", ""},
+		{"a b c d e f g h", "a-b-c-d-e"},
+		{"a-very-long-word-that-exceeds-the-fifty-character-limit-by-quite-a-bit", "a-very-long-word-that-exceeds-the-fifty-character"},
+	}
+	for _, tt := range tests {
+		got := slugify(tt.input)
+		if got != tt.want {
+			t.Errorf("slugify(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestTruncatePrompt(t *testing.T) {
+	short := "Fix the bug"
+	if got := truncatePrompt(short); got != short {
+		t.Errorf("truncatePrompt(%q) = %q, want unchanged", short, got)
+	}
+
+	long := "This is a very long prompt that exceeds the eighty character limit and should be truncated with an ellipsis at the end"
+	got := truncatePrompt(long)
+	if len(got) != 80 {
+		t.Errorf("truncatePrompt(long) length = %d, want 80", len(got))
+	}
+	if got[77:] != "..." {
+		t.Errorf("truncatePrompt(long) should end with '...', got %q", got[77:])
+	}
+}

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/errs"
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/log"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -99,8 +100,8 @@ func tmuxPickCmd() *cli.Command {
 					fzf.WithNoSort(),
 					fzf.WithDelimiter("\\|"),
 					fzf.WithNth("1,2"),
-					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-B: New (stacked) | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-S: Sync | Ctrl-D: Delete"),
-					fzf.WithExpectKeys("ctrl-n", "ctrl-b", "ctrl-e", "ctrl-p", "ctrl-s", "ctrl-d"),
+					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-B: Stacked | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-G: Dispatch | Ctrl-S: Sync | Ctrl-D: Delete"),
+					fzf.WithExpectKeys("ctrl-n", "ctrl-b", "ctrl-e", "ctrl-p", "ctrl-g", "ctrl-s", "ctrl-d"),
 					fzf.WithPrintQuery(),
 					fzf.WithBind(startBind),
 				}
@@ -142,6 +143,13 @@ func tmuxPickCmd() *cli.Command {
 
 				case "ctrl-p":
 					if err := tmuxPickPR(self, repoFilter, sessionName, items); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						continue
+					}
+					return nil
+
+				case "ctrl-g":
+					if err := tmuxPickDispatch(self, result.Query, repoFilter, sessionName, items); err != nil {
 						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 						continue
 					}
@@ -508,6 +516,55 @@ func extractBranchFromPRLine(line string) string {
 		return ""
 	}
 	return line[start+1 : end]
+}
+
+func tmuxPickDispatch(self, query, repoFilter, sessionName string, items []tmux.PickerItem) error {
+	if query == "" {
+		return errs.Userf("type a prompt first")
+	}
+
+	repo, err := resolveRepo(repoFilter, sessionName, items)
+	if err != nil {
+		return err
+	}
+
+	branch := "dispatch--" + slugify(query)
+	args := []string{"new", "--cd", "--repo", repo, "--", branch}
+
+	cmd := exec.Command(self, args...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to create worktree: %w", err)
+	}
+
+	wtPath := strings.TrimSpace(string(out))
+	if wtPath == "" {
+		return fmt.Errorf("no path returned from willow new")
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, ".willow-prompt"), []byte(query), 0o644); err != nil {
+		return fmt.Errorf("failed to write prompt file: %w", err)
+	}
+
+	meta := map[string]string{"prompt": truncatePrompt(query)}
+	_ = log.Append(log.Event{Action: "dispatch", Repo: repo, Branch: branch, Metadata: meta})
+
+	wtDir := filepath.Base(wtPath)
+	repoName := filepath.Base(filepath.Dir(wtPath))
+
+	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
+	cfg := loadRepoConfig(repoName)
+	if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.Panes); err != nil {
+		return fmt.Errorf("failed to create tmux session: %w", err)
+	}
+
+	claudeCmd := `claude "$(cat .willow-prompt)"`
+	if err := tmux.SendKeys(sessName, claudeCmd, "Enter"); err != nil {
+		return fmt.Errorf("failed to send claude command: %w", err)
+	}
+
+	return tmux.SwitchClient(sessName)
 }
 
 func tmuxPickSync(self, repoFilter, sessionName string, items []tmux.PickerItem, branch string) error {

--- a/website/docs/commands/index.md
+++ b/website/docs/commands/index.md
@@ -322,6 +322,33 @@ ww notify status               # check if running
 
 **Custom notification command:** Set `notify.command` in config to run your own script instead of `osascript`. The command receives `WILLOW_NOTIFY_TITLE` and `WILLOW_NOTIFY_BODY` as environment variables.
 
+## `ww dispatch <prompt>`
+
+Create a worktree and launch Claude Code with a prompt. From the terminal, Claude runs interactively in the foreground. From the tmux picker (`Ctrl-G`), it launches in a background session.
+
+```bash
+ww dispatch "Fix the login validation bug"                  # auto-name branch
+ww dispatch "Add retry logic" --name add-retries             # explicit branch name
+ww dispatch "Write tests for auth" --base feature/auth       # stacked on a branch
+ww dispatch "Refactor payments" --repo myrepo                # target specific repo
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--name` | Worktree/branch name | Auto-slugified from prompt (e.g. `dispatch--fix-the-login-validation`) |
+| `-r, --repo` | Target repo by name | Auto-detected from cwd |
+| `-b, --base` | Base branch to fork from | Config default |
+| `--no-fetch` | Skip fetching from remote | `false` |
+| `--yolo` | Run Claude with `--dangerously-skip-permissions` | `false` |
+
+**How it works:**
+1. Creates a new worktree (reuses `ww new` internally)
+2. Writes the prompt to `.willow-prompt` in the worktree
+3. Launches `claude "<prompt>"` (interactive session with prompt pre-loaded)
+4. Logs a `dispatch` event (visible in `ww log`)
+
+The agent appears in `ww status`, `ww dashboard`, and the tmux picker. Switch to it anytime with `ww sw`.
+
 ## `ww cc-setup`
 
 One-time hook installation for Claude Code status tracking.

--- a/website/docs/tmux/index.md
+++ b/website/docs/tmux/index.md
@@ -35,9 +35,14 @@ The right panel shows a live preview of the tmux pane content (Claude Code outpu
 | `Ctrl-B` | Create new worktree stacked on a base branch (opens branch picker) |
 | `Ctrl-E` | Browse existing remote branches and create a worktree |
 | `Ctrl-P` | Browse open PRs and create a worktree for the selected one |
+| `Ctrl-G` | Dispatch: create worktree from query text as prompt, launch Claude Code |
 | `Ctrl-S` | Sync stacked worktrees (selected branch's subtree, or all) |
 | `Ctrl-D` | Delete selected worktree and its tmux session |
 | `Esc` | Close picker |
+
+### Dispatch
+
+Type a prompt in the query field and press `Ctrl-G` to dispatch a Claude Code agent. This creates a worktree (branch auto-named from the prompt, e.g. `dispatch--fix-the-login-bug`), opens a tmux session, and launches `claude` with your prompt. You're switched to the session immediately.
 
 ### PR picker
 


### PR DESCRIPTION
## Description of the change

Add `ww dispatch <prompt>` — create a worktree and launch Claude Code with a prompt in one command.

**Terminal:** Runs Claude interactively in the foreground via login shell (env vars from .zshrc loaded).
**Tmux picker (Ctrl-G):** Type a prompt, hit Ctrl-G → creates worktree, tmux session, launches Claude in background, switches you to it.

- Branch auto-named from prompt (`dispatch--<slug>`) or explicit via `--name`
- Prompt saved to `.willow-prompt` in worktree (avoids quoting issues, serves as record)
- `--yolo` flag opts into `--dangerously-skip-permissions`
- Logs `dispatch` events to `ww log`

## Test plan

- Unit tests for `slugify` and `truncatePrompt` helpers
- Full suite: 411 tests passing, `go vet` clean
- Manual: tested `ww dispatch` from terminal — creates worktree, launches interactive Claude session

🤖 Generated with [Claude Code](https://claude.com/claude-code)