### PR TITLE
♻️ ref(notify): consolidate transition detection into claude package

### DIFF
--- a/internal/claude/transitions.go
+++ b/internal/claude/transitions.go
@@ -1,0 +1,73 @@
+package claude
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// Transition describes a status change for a worktree.
+type Transition struct {
+	Key        string // "repo/wtDir"
+	FromStatus Status
+	ToStatus   Status
+}
+
+// TransitionState tracks the previous status of each worktree for transition detection.
+type TransitionState map[string]string // "repo/wtDir" -> status string
+
+func loadTransitionState(path string) TransitionState {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return make(TransitionState)
+	}
+	var state TransitionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return make(TransitionState)
+	}
+	return state
+}
+
+func saveTransitionState(state TransitionState, path string) {
+	data, _ := json.Marshal(state)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return
+	}
+	os.Rename(tmp, path)
+}
+
+// DetectTransitions compares current statuses against saved state at stateFile
+// and returns transitions from BUSY to a non-BUSY status.
+// Each caller should use its own stateFile to track independently.
+func DetectTransitions(current map[string]Status, stateFile string) []Transition {
+	prev := loadTransitionState(stateFile)
+	var transitions []Transition
+
+	newState := make(TransitionState)
+	for key, status := range current {
+		newState[key] = string(status)
+		if prevStatus, ok := prev[key]; ok {
+			if prevStatus == string(StatusBusy) && status != StatusBusy {
+				transitions = append(transitions, Transition{
+					Key:        key,
+					FromStatus: StatusBusy,
+					ToStatus:   status,
+				})
+			}
+		}
+	}
+
+	saveTransitionState(newState, stateFile)
+	return transitions
+}
+
+// TmuxStateFile returns the path to the tmux status bar's state file.
+func TmuxStateFile() string {
+	return filepath.Join(StatusDir(), "..", "tmux-states.json")
+}
+
+// NotifyStateFile returns the path to the notify daemon's state file.
+func NotifyStateFile() string {
+	return filepath.Join(StatusDir(), "..", "notify-states.json")
+}

--- a/internal/cli/notify_cmd.go
+++ b/internal/cli/notify_cmd.go
@@ -16,7 +16,6 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/notify"
-	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
@@ -182,7 +181,7 @@ func notifyRunCmd() *cli.Command {
 
 			check := func() {
 				statuses := collectStatuses()
-				transitions := tmux.CheckTransitions(statuses)
+				transitions := claude.DetectTransitions(statuses, claude.NotifyStateFile())
 				sendDesktopNotifications(transitions, cfg)
 			}
 
@@ -232,7 +231,7 @@ func collectStatuses() map[string]claude.Status {
 	return statuses
 }
 
-func sendDesktopNotifications(transitions []tmux.Transition, cfg *config.Config) {
+func sendDesktopNotifications(transitions []claude.Transition, cfg *config.Config) {
 	for _, t := range transitions {
 		title := "willow"
 		var body string

--- a/internal/tmux/notify.go
+++ b/internal/tmux/notify.go
@@ -1,10 +1,7 @@
 package tmux
 
 import (
-	"encoding/json"
-	"os"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
@@ -15,69 +12,14 @@ const (
 	defaultNotifyWaitCommand = "afplay /System/Library/Sounds/Funk.aiff"
 )
 
-// Transition describes a status change for a worktree.
-type Transition struct {
-	Key        string        // "repo/wtDir"
-	FromStatus claude.Status
-	ToStatus   claude.Status
+// CheckTransitions detects BUSY→non-BUSY transitions using the tmux state file.
+func CheckTransitions(current map[string]claude.Status) []claude.Transition {
+	return claude.DetectTransitions(current, claude.TmuxStateFile())
 }
 
-func stateFilePath() string {
-	return filepath.Join(config.WillowHome(), "tmux-states.json")
-}
-
-// StatusBarState tracks the previous status of each worktree for transition detection.
-type StatusBarState map[string]string // "repo/wtDir" -> status string
-
-func loadState() StatusBarState {
-	data, err := os.ReadFile(stateFilePath())
-	if err != nil {
-		return make(StatusBarState)
-	}
-	var state StatusBarState
-	if err := json.Unmarshal(data, &state); err != nil {
-		return make(StatusBarState)
-	}
-	return state
-}
-
-func saveState(state StatusBarState) {
-	data, _ := json.Marshal(state)
-	path := stateFilePath()
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return
-	}
-	os.Rename(tmp, path)
-}
-
-// CheckTransitions compares current statuses against saved state and returns
-// typed transitions from BUSY to a non-BUSY status.
-func CheckTransitions(current map[string]claude.Status) []Transition {
-	prev := loadState()
-	var transitions []Transition
-
-	newState := make(StatusBarState)
-	for key, status := range current {
-		newState[key] = string(status)
-		if prevStatus, ok := prev[key]; ok {
-			if prevStatus == string(claude.StatusBusy) && status != claude.StatusBusy {
-				transitions = append(transitions, Transition{
-					Key:        key,
-					FromStatus: claude.StatusBusy,
-					ToStatus:   status,
-				})
-			}
-		}
-	}
-
-	saveState(newState)
-	return transitions
-}
-
-// NotifyWithContext sends notifications for transitions, skipping the current
-// tmux session and using different sounds for WAIT vs DONE.
-func NotifyWithContext(transitions []Transition, cfg *config.Config) {
+// NotifyWithContext sends sound notifications for transitions, skipping the current
+// tmux session.
+func NotifyWithContext(transitions []claude.Transition, cfg *config.Config) {
 	currentSession, _ := CurrentSession()
 	for _, t := range transitions {
 		if t.Key == currentSession {


### PR DESCRIPTION
## Description of the change
Move Transition type and state detection logic from tmux package to claude/transitions.go. Tmux and notify daemon now use separate state files (tmux-states.json and notify-states.json) so they detect transitions independently — fixes the bug where the tmux status bar consumed transitions before the notify daemon could see them.

## Test plan
- Unit tests pass
- Manual: `ww notify on` now detects transitions independently from tmux