### PR TITLE
🐛 fix(notify): surface notification errors with logging and Sentry

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -25,6 +25,7 @@ func doctorCmd() *cli.Command {
 			checkGitVersion(u)
 			checkBinary(u, "gh", "gh CLI", "https://cli.github.com")
 			checkBinary(u, "tmux", "tmux", "https://github.com/tmux/tmux")
+			checkBinary(u, "terminal-notifier", "terminal-notifier", "brew install terminal-notifier")
 			checkClaudeHooks(u)
 			checkWillowDirs(u)
 			checkStaleSessions(u)

--- a/internal/cli/notify_cmd.go
+++ b/internal/cli/notify_cmd.go
@@ -12,6 +12,9 @@ import (
 	"syscall"
 	"time"
 
+	"log"
+
+	"github.com/getsentry/sentry-go"
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
@@ -24,14 +27,20 @@ func pidFilePath() string {
 	return filepath.Join(config.WillowHome(), "notify.pid")
 }
 
+func logFilePath() string {
+	return filepath.Join(config.WillowHome(), "notify.log")
+}
+
 func notifyCmd() *cli.Command {
 	return &cli.Command{
-		Name:  "notify",
-		Usage: "Desktop notifications for agent status changes",
+		Name:    "notify",
+		Aliases: []string{"notif"},
+		Usage:   "Desktop notifications for agent status changes",
 		Commands: []*cli.Command{
 			notifyOnCmd(),
 			notifyOffCmd(),
 			notifyStatusCmd(),
+			notifyLogCmd(),
 			notifyRunCmd(),
 		},
 	}
@@ -70,14 +79,21 @@ func notifyOnCmd() *cli.Command {
 
 			interval := cmd.Int("interval")
 			daemon := exec.Command(self, "notify", "run", "--interval", strconv.Itoa(int(interval)))
-			daemon.Stdout = nil
-			daemon.Stderr = nil
+
+			logFile, err := os.OpenFile(logFilePath(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+			if err != nil {
+				return fmt.Errorf("failed to open log file: %w", err)
+			}
+			daemon.Stdout = logFile
+			daemon.Stderr = logFile
 			daemon.Stdin = nil
 			daemon.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 
 			if err := daemon.Start(); err != nil {
+				logFile.Close()
 				return fmt.Errorf("failed to start daemon: %w", err)
 			}
+			logFile.Close()
 
 			// Write PID file
 			if err := os.WriteFile(pidFilePath(), []byte(strconv.Itoa(daemon.Process.Pid)), 0o644); err != nil {
@@ -152,6 +168,35 @@ func notifyStatusCmd() *cli.Command {
 	}
 }
 
+func notifyLogCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "log",
+		Usage: "Show notification daemon logs",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "follow",
+				Aliases: []string{"f"},
+				Usage:   "Follow log output (tail -f)",
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			lp := logFilePath()
+			if _, err := os.Stat(lp); os.IsNotExist(err) {
+				fmt.Println("No log file yet. Start the daemon with: ww notify on")
+				return nil
+			}
+			tailCmd := "tail -50"
+			if cmd.Bool("follow") {
+				tailCmd = "tail -50 -f"
+			}
+			c := exec.Command("sh", "-c", tailCmd+" "+lp)
+			c.Stdout = os.Stdout
+			c.Stderr = os.Stderr
+			return c.Run()
+		},
+	}
+}
+
 // notifyRunCmd is the actual long-running daemon (called by `notify on`).
 func notifyRunCmd() *cli.Command {
 	return &cli.Command{
@@ -168,6 +213,8 @@ func notifyRunCmd() *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			interval := time.Duration(cmd.Int("interval")) * time.Second
 
+			logger := log.New(os.Stderr, "", log.LstdFlags)
+
 			sigCh := make(chan os.Signal, 1)
 			signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
@@ -179,10 +226,12 @@ func notifyRunCmd() *cli.Command {
 
 			cfg := config.Load("")
 
+			logger.Printf("daemon started (interval=%s)", interval)
+
 			check := func() {
 				statuses := collectStatuses()
 				transitions := claude.DetectTransitions(statuses, claude.NotifyStateFile())
-				sendDesktopNotifications(transitions, cfg)
+				sendDesktopNotifications(logger, transitions, cfg)
 			}
 
 			check()
@@ -190,8 +239,10 @@ func notifyRunCmd() *cli.Command {
 			for {
 				select {
 				case <-ctx.Done():
+					logger.Println("daemon stopping (context cancelled)")
 					return nil
 				case <-sigCh:
+					logger.Println("daemon stopping (signal)")
 					return nil
 				case <-ticker.C:
 					check()
@@ -231,7 +282,7 @@ func collectStatuses() map[string]claude.Status {
 	return statuses
 }
 
-func sendDesktopNotifications(transitions []claude.Transition, cfg *config.Config) {
+func sendDesktopNotifications(logger *log.Logger, transitions []claude.Transition, cfg *config.Config) {
 	for _, t := range transitions {
 		title := "willow"
 		var body string
@@ -243,10 +294,21 @@ func sendDesktopNotifications(transitions []claude.Transition, cfg *config.Confi
 		default:
 			continue
 		}
+
+		var err error
 		if cfg.Notify.Command != "" {
-			notify.SendCustom(cfg.Notify.Command, title, body)
+			err = notify.SendCustom(cfg.Notify.Command, title, body)
 		} else {
-			notify.Send(title, body)
+			err = notify.Send(title, body)
+		}
+
+		if err != nil {
+			sentry.CaptureException(err)
+			if logger != nil {
+				logger.Printf("notification failed for %s: %v", t.Key, err)
+			}
+		} else if logger != nil {
+			logger.Printf("notified: %s", body)
 		}
 	}
 }

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -960,9 +960,6 @@ func tmuxStatusBarCmd() *cli.Command {
 				if cfg.Tmux.Notification == nil || *cfg.Tmux.Notification {
 					tmux.NotifyWithContext(transitions, cfg)
 				}
-				if cfg.Notify.Desktop != nil && *cfg.Notify.Desktop {
-					sendDesktopNotifications(transitions, cfg)
-				}
 			}
 
 			fmt.Printf("#[fg=#98be65]\U0001F333 %d #[fg=#51afef]\U0001F916 %d", totalWt, activeAgents)

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	_ "embed"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,25 +44,22 @@ func ensureIcon() string {
 
 // Send fires a desktop notification with the willow icon.
 // Works on macOS (terminal-notifier or osascript) and Linux (notify-send).
-// Non-blocking: runs the notification in a goroutine.
-func Send(title, body string) {
-	go func() {
-		beeep.AppName = "willow"
-		beeep.Notify(title, body, ensureIcon())
-	}()
+func Send(title, body string) error {
+	beeep.AppName = "willow"
+	return beeep.Notify(title, body, ensureIcon())
 }
 
 // SendCustom runs a user-provided command with title/body available as
 // WILLOW_NOTIFY_TITLE and WILLOW_NOTIFY_BODY env vars.
 func SendCustom(command, title, body string) error {
 	cmd := exec.Command("sh", "-c", command)
-	cmd.Env = append(os.Environ(),
+	cmd.Env = append(cmd.Environ(),
 		"WILLOW_NOTIFY_TITLE="+title,
 		"WILLOW_NOTIFY_BODY="+body,
 	)
-	if err := cmd.Start(); err != nil {
-		return err
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("custom notify command: %w: %s", err, out)
 	}
-	go cmd.Wait()
 	return nil
 }

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -3,8 +3,8 @@ package notify
 import "testing"
 
 func TestSend_NoPanic(t *testing.T) {
-	// Send is non-blocking (goroutine). Verify it doesn't panic.
-	Send("test title", "test body")
+	// Send may fail in CI (no display), just verify it doesn't panic.
+	_ = Send("test title", "test body")
 }
 
 func TestSendCustom_NoPanic(t *testing.T) {


### PR DESCRIPTION
## Description of the change

- `Send`/`SendCustom` now return errors instead of fire-and-forget
- Daemon logs to `~/.willow/notify.log` (startup, notifications, failures)
- Notification failures reported to Sentry via `CaptureException`
- Add `ww notify log [-f]` subcommand to tail daemon logs
- Add `notif` alias (`ww notif status`, `ww notif on`, etc.)
- `ww doctor` checks for `terminal-notifier`
- Remove duplicate desktop notification path from tmux status-bar — `ww notify on` is the single switch

## Test plan

- Unit tests pass (`go test ./... -count=1`)
- `ww doctor` shows terminal-notifier check
- `ww notif status` works via alias