### PR TITLE
:bug: fix(website): improve docs scroll-spy highlighting

### DIFF
--- a/website/src/app/(docs)/layout.tsx
+++ b/website/src/app/(docs)/layout.tsx
@@ -27,7 +27,7 @@ export default function DocsLayout({
             <MobileSidebar />
           </div>
 
-          <article className="prose prose-invert max-w-none">
+          <article className="prose prose-invert max-w-none pb-[50vh]">
             {children}
           </article>
           <PrevNextLinks />

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -76,6 +76,10 @@
   --tw-prose-pre-code: #a1a1aa;
 }
 
+.prose :is(h1, h2, h3, h4) {
+  scroll-margin-top: 6rem;
+}
+
 .prose h1 {
   font-family: var(--font-heading);
   font-weight: 700;

--- a/website/src/components/docs/Sidebar.tsx
+++ b/website/src/components/docs/Sidebar.tsx
@@ -1,42 +1,16 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { useState, useEffect } from "react";
-import { DOCS_NAV } from "@/lib/docs-nav";
+import { DOCS_NAV, getPageHeadings } from "@/lib/docs-nav";
 import { useScrollSpy } from "@/hooks/use-scroll-spy";
 import { cn } from "@/lib/cn";
 
-interface TocItem {
-  id: string;
-  text: string;
-  level: number;
-}
-
 export function Sidebar() {
   const pathname = usePathname();
-  const [headings, setHeadings] = useState<TocItem[]>([]);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      const article = document.querySelector("article");
-      if (!article) return;
-
-      const elements = article.querySelectorAll("h2[id], h3[id]");
-      const items: TocItem[] = Array.from(elements).map((el) => ({
-        id: el.id,
-        text: el.textContent || "",
-        level: el.tagName === "H2" ? 2 : 3,
-      }));
-
-      setHeadings(items);
-    }, 100);
-
-    return () => clearTimeout(timer);
-  }, [pathname]);
-
+  const headings = getPageHeadings(pathname);
   const activeId = useScrollSpy(
     headings.map((h) => h.id),
-    80,
+    0,
   );
 
   const currentPage = DOCS_NAV.flatMap((g) => g.items).find(

--- a/website/src/hooks/use-scroll-spy.ts
+++ b/website/src/hooks/use-scroll-spy.ts
@@ -2,33 +2,54 @@
 
 import { useState, useEffect } from "react";
 
-export function useScrollSpy(ids: string[], offset = 100) {
-  const [activeId, setActiveId] = useState<string>("");
+// Adapted from Docusaurus useTOCHighlight
+// https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-common/src/hooks/useTOCHighlight.ts
+
+function getActiveId(ids: string[], offset: number): string | null {
+  const anchors = ids
+    .map((id) => document.getElementById(id))
+    .filter(Boolean) as HTMLElement[];
+
+  if (anchors.length === 0) return null;
+
+  // Find the first anchor whose top is at or below the offset line
+  // (i.e. the next heading about to scroll into the active zone)
+  const nextVisible = anchors.find(
+    (el) => el.getBoundingClientRect().top >= offset,
+  );
+
+  if (nextVisible) {
+    // If this anchor is in the top half of the viewport, it's the active one
+    if (nextVisible.getBoundingClientRect().top < window.innerHeight / 2) {
+      return nextVisible.id;
+    }
+    // Otherwise the content on screen belongs to the previous heading
+    const idx = anchors.indexOf(nextVisible);
+    return idx > 0 ? anchors[idx - 1].id : anchors[0].id;
+  }
+
+  // No anchor below the offset — we're at the bottom of the page
+  return anchors[anchors.length - 1].id;
+}
+
+export function useScrollSpy(ids: string[], offset = 0) {
+  const [activeId, setActiveId] = useState<string>(ids[0] ?? "");
 
   useEffect(() => {
-    const observer = new IntersectionObserver(
-      (entries) => {
-        // Find the first heading that is intersecting
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            setActiveId(entry.target.id);
-            break;
-          }
-        }
-      },
-      {
-        rootMargin: `-${offset}px 0px -60% 0px`,
-        threshold: 0,
-      },
-    );
+    if (ids.length === 0) return;
 
-    const elements = ids
-      .map((id) => document.getElementById(id))
-      .filter(Boolean) as HTMLElement[];
+    function update() {
+      const id = getActiveId(ids, offset);
+      if (id) setActiveId(id);
+    }
 
-    elements.forEach((el) => observer.observe(el));
-
-    return () => observer.disconnect();
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
   }, [ids, offset]);
 
   return activeId;

--- a/website/src/lib/docs-nav.ts
+++ b/website/src/lib/docs-nav.ts
@@ -1,6 +1,13 @@
+export interface TocHeading {
+  id: string;
+  text: string;
+  level: 2 | 3;
+}
+
 export interface DocNavItem {
   title: string;
   href: string;
+  headings: TocHeading[];
 }
 
 export interface DocNavGroup {
@@ -11,19 +18,108 @@ export interface DocNavGroup {
 export const DOCS_NAV: DocNavGroup[] = [
   {
     label: "Getting Started",
-    items: [{ title: "Guide", href: "/guide/" }],
+    items: [
+      {
+        title: "Guide",
+        href: "/guide/",
+        headings: [
+          { id: "install", text: "Install", level: 2 },
+          { id: "homebrew", text: "Homebrew", level: 3 },
+          { id: "from-source", text: "From source", level: 3 },
+          { id: "requirements", text: "Requirements", level: 3 },
+          { id: "shell-integration-recommended", text: "Shell integration (recommended)", level: 2 },
+          { id: "terminal-tab-titles-optional", text: "Terminal tab titles (optional)", level: 3 },
+          { id: "claude-code-status-tracking", text: "Claude Code status tracking", level: 2 },
+          { id: "quick-start", text: "Quick start", level: 2 },
+          { id: "tmux-integration", text: "Tmux integration", level: 2 },
+          { id: "terminal-setup", text: "Terminal setup", level: 2 },
+        ],
+      },
+    ],
   },
   {
     label: "Reference",
     items: [
-      { title: "Commands", href: "/commands/" },
-      { title: "Tmux Integration", href: "/tmux/" },
-      { title: "Configuration", href: "/configuration/" },
+      {
+        title: "Commands",
+        href: "/commands/",
+        headings: [
+          { id: "ww-clone-url-name", text: "ww clone <url> [name]", level: 2 },
+          { id: "ww-new-branch-flags", text: "ww new <branch> [flags]", level: 2 },
+          { id: "existing-branch-picker", text: "Existing branch picker", level: 3 },
+          { id: "github-pr-support", text: "GitHub PR support", level: 3 },
+          { id: "ww-checkout-branch-or-pr-url-alias-co", text: "ww checkout <branch-or-pr-url>", level: 2 },
+          { id: "stacked-prs", text: "Stacked PRs", level: 2 },
+          { id: "ww-stack-status-alias-ww-stack-s", text: "ww stack status", level: 2 },
+          { id: "ww-sync-branch", text: "ww sync [branch]", level: 2 },
+          { id: "ww-sw", text: "ww sw", level: 2 },
+          { id: "ww-rm-branch-flags", text: "ww rm [branch] [flags]", level: 2 },
+          { id: "ww-ls-repo", text: "ww ls [repo]", level: 2 },
+          { id: "ww-status", text: "ww status", level: 2 },
+          { id: "ww-dashboard-alias-dash-d", text: "ww dashboard", level: 2 },
+          { id: "ww-log", text: "ww log", level: 2 },
+          { id: "ww-notify", text: "ww notify", level: 2 },
+          { id: "ww-dispatch-prompt", text: "ww dispatch <prompt>", level: 2 },
+          { id: "ww-cc-setup", text: "ww cc-setup", level: 2 },
+          { id: "ww-doctor", text: "ww doctor", level: 2 },
+          { id: "ww-config", text: "ww config", level: 2 },
+          { id: "ww-config-show", text: "ww config show", level: 3 },
+          { id: "ww-config-edit", text: "ww config edit", level: 3 },
+          { id: "ww-config-init", text: "ww config init", level: 3 },
+          { id: "ww-shell-init-flags", text: "ww shell-init [flags]", level: 2 },
+          { id: "agent-status", text: "Agent status", level: 2 },
+          { id: "ww-tmux", text: "ww tmux", level: 2 },
+          { id: "aliases", text: "Aliases", level: 2 },
+          { id: "global-flags", text: "Global flags", level: 2 },
+        ],
+      },
+      {
+        title: "Tmux Integration",
+        href: "/tmux/",
+        headings: [
+          { id: "setup", text: "Setup", level: 2 },
+          { id: "picker-prefix--w", text: "Picker (prefix + w)", level: 2 },
+          { id: "keybindings", text: "Keybindings", level: 3 },
+          { id: "dispatch", text: "Dispatch", level: 3 },
+          { id: "pr-picker", text: "PR picker", level: 3 },
+          { id: "existing-branch-picker", text: "Existing branch picker", level: 3 },
+          { id: "merged-worktree-indicator", text: "Merged worktree indicator", level: 3 },
+          { id: "features", text: "Features", level: 3 },
+          { id: "status-bar-widget", text: "Status bar widget", level: 2 },
+          { id: "configuration", text: "Configuration", level: 3 },
+          { id: "session-layout", text: "Session layout", level: 2 },
+          { id: "per-pane-commands", text: "Per-pane commands", level: 3 },
+          { id: "shell-integration", text: "Shell integration", level: 2 },
+          { id: "commands-reference", text: "Commands reference", level: 2 },
+          { id: "ww-tmux-pick", text: "ww tmux pick", level: 3 },
+          { id: "ww-tmux-list", text: "ww tmux list", level: 3 },
+          { id: "ww-tmux-status-bar", text: "ww tmux status-bar", level: 3 },
+          { id: "ww-tmux-install", text: "ww tmux install", level: 3 },
+        ],
+      },
+      {
+        title: "Configuration",
+        href: "/configuration/",
+        headings: [
+          { id: "config-file-locations", text: "Config file locations", level: 2 },
+          { id: "config-schema", text: "Config schema", level: 2 },
+          { id: "fields", text: "Fields", level: 3 },
+          { id: "directory-structure", text: "Directory structure", level: 2 },
+          { id: "willowrepos", text: "~/.willow/repos/", level: 3 },
+          { id: "willowworktrees", text: "~/.willow/worktrees/", level: 3 },
+          { id: "willowstatus", text: "~/.willow/status/", level: 3 },
+          { id: "willowhooks", text: "~/.willow/hooks/", level: 3 },
+        ],
+      },
     ],
   },
 ];
 
 const allPages = DOCS_NAV.flatMap((g) => g.items);
+
+export function getPageHeadings(pathname: string): TocHeading[] {
+  return allPages.find((p) => p.href === pathname)?.headings ?? [];
+}
 
 export function getPrevNext(currentPath: string) {
   const idx = allPages.findIndex((p) => p.href === currentPath);


### PR DESCRIPTION
## Description of the change

Replaces DOM-scanning scroll-spy with static heading data and a Docusaurus-inspired viewport-position algorithm. Fixes the bug where the last/near-bottom sidebar headings never highlighted because they couldn't scroll far enough into the detection zone.

**Changes:**
- Static heading definitions in `docs-nav.ts` (no more useEffect + DOM scanning + setTimeout hack)
- Scroll-spy algorithm: find next visible heading → if in top half of viewport it's active, otherwise previous heading is active → at page bottom, last heading is active
- `scroll-margin-top: 6rem` on prose headings so clicking a sidebar link doesn't land the heading under the sticky nav
- `pb-[50vh]` on article for scroll room at page bottom

## Test plan

Manual — click every sidebar heading on each doc page, verify it highlights correctly when scrolling through all sections including the last ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)