### PR TITLE
🐛 fix(readme): correct logo image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="website/docs/public/logo.svg" width="80" alt="willow logo" />
+  <img src="website/public/logo.svg" width="80" alt="willow logo" />
 </p>
 
 <h1 align="center">willow</h1>


### PR DESCRIPTION
## Description of the change

Fix broken logo in README — path was `website/docs/public/logo.svg` but the file lives at `website/public/logo.svg`.

## Test plan

Visual check on GitHub README.