### PR TITLE
📚 docs: add community standards files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+## Description of the change
+
+## Test plan

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at **raj@rajjoshi.me**. All complaints will
+be reviewed and investigated and will result in a response that is deemed
+necessary and appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for your interest in contributing to willow!
+
+## Getting Started
+
+Prerequisites: Go 1.26+
+
+```sh
+go build -o bin/willow ./cmd/willow
+go test ./... -count=1 -v
+```
+
+## Pull Requests
+
+1. Fork the repo and create a branch from `main`.
+2. If you've added code that should be tested, add tests.
+3. Make sure tests pass.
+4. Open a pull request.
+
+For new features, please open an issue first to discuss the change.
+
+## Bug Reports
+
+Open a [bug report](https://github.com/iamrajjoshi/willow/issues/new?template=bug_report.md) with steps to reproduce.
+
+## Code Style
+
+Follow standard Go conventions. Commit messages use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) with emoji prefixes.
+
+## License
+
+By submitting a contribution, you agree that your work will be licensed under the project's [MIT License](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Reporting
+
+If you wish to report a security vulnerability but not in a public issue — thank you! — we ask that you follow the following process.
+
+Please report security vulnerabilities by filling out the following template:
+
+- **PROJECT:** https://github.com/iamrajjoshi/willow
+- **PUBLIC:** Please let us know if this vulnerability has been made or discussed publicly already, and if so, please let us know where.
+- **DESCRIPTION:** Please provide precise description of the security vulnerability you have found with as much information as you are able and willing to provide.
+
+Please send the above info, along with any other information you feel is pertinent to: **raj@rajjoshi.me**.
+
+In addition, you may request that the project provide you a patched release in advance of the release announcement, however, we can not guarantee that such information will be provided to you in advance of the public release and announcement.
+
+We will let you know within a few weeks whether or not your report has been accepted or rejected. We ask that you please keep the report confidential until we have made a public announcement.


### PR DESCRIPTION
## Description of the change
Add the four missing community standards files flagged by GitHub's community profile checklist: code of conduct (Contributor Covenant v2.1), contributing guidelines, security policy, and PR template.

**Ticket:**

## Test plan
Manual — verify all four items show green checks on the repo's community profile page.

## Loom or screenshots

## Considerations