### PR TITLE
✨ feat(telemetry): make telemetry opt-in with interactive prompt

### DIFF
--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -228,6 +228,13 @@ func configInitCmd() *cli.Command {
 			}
 
 			cfg := config.DefaultConfig()
+
+			if u.Confirm("Enable anonymous telemetry (crash reports & usage stats)?") {
+				cfg.Telemetry = config.BoolPtr(true)
+			} else {
+				cfg.Telemetry = config.BoolPtr(false)
+			}
+
 			if err := config.Save(cfg, path); err != nil {
 				return fmt.Errorf("failed to write config: %w", err)
 			}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/urfave/cli/v3"
 )
 
@@ -33,6 +34,22 @@ func setupCmd() *cli.Command {
 			u.Info("")
 			u.Info("Claude Code will now report agent status for willow-managed worktrees.")
 			u.Info("Use 'ww status' or 'ww ls' to see agent status.")
+
+			cfg := config.Load("")
+			if cfg.Telemetry == nil {
+				u.Info("")
+				enabled := u.Confirm("Enable anonymous telemetry (crash reports & usage stats)?")
+				cfg.Telemetry = config.BoolPtr(enabled)
+				if err := config.Save(cfg, config.GlobalConfigPath()); err != nil {
+					return fmt.Errorf("failed to save telemetry preference: %w", err)
+				}
+				if enabled {
+					u.Success("Telemetry enabled")
+				} else {
+					u.Info("Telemetry disabled")
+				}
+			}
+
 			return nil
 		},
 	}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -22,7 +22,7 @@ var enabled bool
 func Init(version string) func() {
 	noop := func() {}
 
-	if isOptedOut() {
+	if !isEnabled() {
 		return noop
 	}
 
@@ -138,16 +138,14 @@ func machineID() string {
 	return fmt.Sprintf("%x", hash[:8])
 }
 
-func isOptedOut() bool {
+func isEnabled() bool {
 	if v := os.Getenv("WILLOW_TELEMETRY"); v != "" {
 		v = strings.ToLower(v)
-		if v == "off" || v == "false" || v == "0" {
-			return true
-		}
+		return v == "on" || v == "true" || v == "1"
 	}
 
 	cfg := config.Load("")
-	if cfg.Telemetry != nil && !*cfg.Telemetry {
+	if cfg.Telemetry != nil && *cfg.Telemetry {
 		return true
 	}
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -9,19 +9,19 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
-func TestIsOptedOut_EnvVar(t *testing.T) {
+func TestIsEnabled_EnvVar(t *testing.T) {
 	tests := []struct {
-		value    string
-		optedOut bool
+		value   string
+		enabled bool
 	}{
-		{"off", true},
-		{"OFF", true},
-		{"false", true},
-		{"False", true},
-		{"0", true},
-		{"on", false},
-		{"true", false},
-		{"1", false},
+		{"on", true},
+		{"ON", true},
+		{"true", true},
+		{"True", true},
+		{"1", true},
+		{"off", false},
+		{"false", false},
+		{"0", false},
 		{"", false},
 	}
 
@@ -30,9 +30,9 @@ func TestIsOptedOut_EnvVar(t *testing.T) {
 			os.Setenv("WILLOW_TELEMETRY", tt.value)
 			defer os.Unsetenv("WILLOW_TELEMETRY")
 
-			got := isOptedOut()
-			if got != tt.optedOut {
-				t.Errorf("isOptedOut() = %v, want %v", got, tt.optedOut)
+			got := isEnabled()
+			if got != tt.enabled {
+				t.Errorf("isEnabled() = %v, want %v", got, tt.enabled)
 			}
 		})
 	}
@@ -51,19 +51,16 @@ func TestInit_DisabledByEnvVar(t *testing.T) {
 	}
 }
 
-func TestInit_EnabledByDefault(t *testing.T) {
+func TestInit_DisabledByDefault(t *testing.T) {
 	enabled = false
 	os.Unsetenv("WILLOW_TELEMETRY")
 
 	cleanup := Init("dev")
 	defer cleanup()
 
-	if !enabled {
-		t.Error("expected telemetry to be enabled by default")
+	if enabled {
+		t.Error("expected telemetry to be disabled by default")
 	}
-
-	// Reset for other tests
-	enabled = false
 }
 
 func TestStartCommand_NoopWhenDisabled(t *testing.T) {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -67,6 +67,13 @@ func (u *UI) Dim(s string) string {
 	return dim + s + reset
 }
 
+func (u *UI) Confirm(prompt string) bool {
+	fmt.Fprintf(u.out(), "%s [y/N] ", prompt)
+	var answer string
+	fmt.Fscanf(os.Stdin, "%s", &answer)
+	return answer == "y" || answer == "Y"
+}
+
 func CursorHome() string    { return "\033[H" }
 func ClearToEnd() string    { return "\033[J" }
 func HideCursor() string    { return "\033[?25l" }


### PR DESCRIPTION
## Description of the change

Closes #84

Telemetry was previously opt-out (enabled by default). This flips it to opt-in:

- **Default is now off** — `isOptedOut()` replaced with `isEnabled()`, returns false unless explicitly enabled
- **`config init`** prompts the user to enable/disable telemetry when creating a new config
- **`cc-setup`** prompts for telemetry preference (if not already set) after installing Claude Code hooks
- `WILLOW_TELEMETRY` env var still works as an override (`on`/`true`/`1` to enable)
- Added `UI.Confirm()` helper for Y/N prompts

## Test plan

- `go test ./... -count=1` — all 393 tests pass
- Manual: `willow config init --force` prompts for telemetry, saves choice to config
- Manual: `willow cc-setup` prompts for telemetry when `Telemetry` is nil in config
- Manual: `WILLOW_TELEMETRY=on willow ls` enables telemetry via env override