### PR TITLE
🐛 fix(git): exclude trivial forks from merged detection

### DIFF
--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -75,7 +75,7 @@ func gcCmd() *cli.Command {
 
 				cfg := config.Load(bareDir)
 				repoGit := &git.Git{Dir: bareDir}
-				merged, err := repoGit.MergedBranches(cfg.ResolveBaseBranch())
+				merged, err := repoGit.MergedBranches(repoGit.ResolveBaseBranch(cfg.BaseBranch))
 				if err != nil {
 					u.Warn(fmt.Sprintf("Skipping repo %s: failed to get merged branches: %v", repoName, err))
 					continue

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -178,7 +178,7 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, rep
 	}
 
 	cfg := config.Load(repoGit.Dir)
-	mergedSet := repoGit.MergedBranchSet(cfg.ResolveBaseBranch())
+	mergedSet := repoGit.MergedBranchSet(repoGit.ResolveBaseBranch(cfg.BaseBranch))
 
 	st := stack.Load(repoGit.Dir)
 	branchSet := make(map[string]bool)

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -735,7 +735,8 @@ func tmuxPreviewCmd() *cli.Command {
 func printPreviewMetadata(wtPath, repoName string) {
 	g := &git.Git{Dir: wtPath}
 	repoCfg := loadRepoConfig(repoName)
-	baseBranch := repoCfg.ResolveBaseBranch()
+	bareDir, _ := config.ResolveRepo(repoName)
+	baseBranch := (&git.Git{Dir: bareDir}).ResolveBaseBranch(repoCfg.BaseBranch)
 
 	branch := ""
 	if b, err := g.Run("rev-parse", "--abbrev-ref", "HEAD"); err == nil {
@@ -743,7 +744,6 @@ func printPreviewMetadata(wtPath, repoName string) {
 		fmt.Printf("  \033[1mBranch:\033[0m  %s\n", branch)
 	}
 
-	bareDir, _ := config.ResolveRepo(repoName)
 	if bareDir != "" {
 		st := stack.Load(bareDir)
 		if st.IsTracked(branch) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,14 +54,6 @@ type CostConfig struct {
 
 func BoolPtr(v bool) *bool { return &v }
 
-// ResolveBaseBranch returns the configured base branch, or "main" as a default.
-func (cfg *Config) ResolveBaseBranch() string {
-	if cfg.BaseBranch != "" {
-		return cfg.BaseBranch
-	}
-	return "main"
-}
-
 func DefaultConfig() *Config {
 	return &Config{
 		Defaults: Defaults{

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -214,6 +214,7 @@ func collectData(computeCost bool) ([]session, summary) {
 		}
 
 		cfg := config.Load(bareDir)
+		baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
 
 		for _, wt := range wts {
 			if wt.IsBare {
@@ -227,7 +228,7 @@ func collectData(computeCost bool) ([]session, summary) {
 				sum.Unread++
 			}
 
-			diff := getDiffStats(wt.Path, cfg.ResolveBaseBranch())
+			diff := getDiffStats(wt.Path, baseBranch)
 
 			timelineSince := time.Now().Add(-60 * time.Minute)
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -90,6 +90,19 @@ func (g *Git) DefaultBranch() (string, error) {
 	return strings.TrimPrefix(ref, "refs/heads/"), nil
 }
 
+// ResolveBaseBranch picks the base branch to use for operations like merge
+// detection. It prefers an explicit configured value, then falls back to the
+// repo's HEAD symbolic ref (typically "main" or "master"), and finally "main".
+func (g *Git) ResolveBaseBranch(configured string) string {
+	if configured != "" {
+		return configured
+	}
+	if b, err := g.DefaultBranch(); err == nil && b != "" {
+		return b
+	}
+	return "main"
+}
+
 func (g *Git) IsDirty() (bool, error) {
 	out, err := g.Run("status", "--porcelain")
 	if err != nil {
@@ -99,20 +112,35 @@ func (g *Git) IsDirty() (bool, error) {
 }
 
 // MergedBranches returns branches that have been merged into origin/<base>.
+// Branches whose tip SHA equals origin/<base> are excluded — a brand-new
+// branch forked from origin/<base> has zero unique commits and would
+// otherwise be reported as "merged" before any work has happened.
 func (g *Git) MergedBranches(base string) ([]string, error) {
-	out, err := g.Run("branch", "--merged", "origin/"+base, "--format=%(refname:short)")
+	out, err := g.Run("branch", "--merged", "origin/"+base, "--format=%(refname:short) %(objectname)")
 	if err != nil {
 		return nil, err
 	}
 	if out == "" {
 		return nil, nil
 	}
+	baseSHA, _ := g.Run("rev-parse", "origin/"+base)
 	var branches []string
-	for _, b := range strings.Split(out, "\n") {
-		b = strings.TrimSpace(b)
-		if b != "" && b != base {
-			branches = append(branches, b)
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
 		}
+		name, sha, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		if name == base {
+			continue
+		}
+		if baseSHA != "" && sha == baseSHA {
+			continue
+		}
+		branches = append(branches, name)
 	}
 	return branches, nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,153 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// setupRemoteAndClone creates a bare "remote" repo with one commit on main
+// and clones it into a working dir. Returns the working dir path.
+func setupRemoteAndClone(t *testing.T, defaultBranch string) string {
+	t.Helper()
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	work := filepath.Join(root, "work")
+
+	run := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	run(root, "init", "--bare", "--initial-branch="+defaultBranch, remote)
+	run(root, "init", "--initial-branch="+defaultBranch, work)
+	run(work, "config", "user.email", "test@test")
+	run(work, "config", "user.name", "test")
+	run(work, "remote", "add", "origin", remote)
+
+	if err := os.WriteFile(filepath.Join(work, "seed"), []byte("seed"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	run(work, "add", "seed")
+	run(work, "commit", "-m", "seed")
+	run(work, "push", "-u", "origin", defaultBranch)
+	return work
+}
+
+func TestResolveBaseBranch(t *testing.T) {
+	work := setupRemoteAndClone(t, "master")
+	g := &Git{Dir: work}
+
+	if got := g.ResolveBaseBranch("develop"); got != "develop" {
+		t.Errorf("configured value ignored: got %q, want %q", got, "develop")
+	}
+	if got := g.ResolveBaseBranch(""); got != "master" {
+		t.Errorf("fallback to default branch failed: got %q, want %q", got, "master")
+	}
+
+	// Invalid dir: no symbolic-ref, falls back to hardcoded "main".
+	badGit := &Git{Dir: t.TempDir()}
+	if got := badGit.ResolveBaseBranch(""); got != "main" {
+		t.Errorf("fallback when no git repo: got %q, want %q", got, "main")
+	}
+}
+
+func TestMergedBranches_ExcludesTrivialMerges(t *testing.T) {
+	work := setupRemoteAndClone(t, "main")
+	g := &Git{Dir: work}
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = work
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// "trivial" branch: freshly forked from origin/main with zero commits.
+	// This is the case that was being falsely reported as merged.
+	runGit("branch", "feature-trivial", "origin/main")
+
+	// "unmerged" branch: has unique commits not in origin/main.
+	runGit("checkout", "-b", "feature-unmerged", "origin/main")
+	if err := os.WriteFile(filepath.Join(work, "b"), []byte("b"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "b")
+	runGit("commit", "-m", "unmerged work")
+
+	merged, err := g.MergedBranches("main")
+	if err != nil {
+		t.Fatalf("MergedBranches: %v", err)
+	}
+
+	set := make(map[string]bool)
+	for _, b := range merged {
+		set[b] = true
+	}
+	if set["feature-trivial"] {
+		t.Errorf("trivially-forked branch should not appear as merged, got %v", merged)
+	}
+	if set["feature-unmerged"] {
+		t.Errorf("unmerged branch should not appear as merged, got %v", merged)
+	}
+}
+
+func TestMergedBranches_IncludesRealMerges(t *testing.T) {
+	work := setupRemoteAndClone(t, "main")
+	g := &Git{Dir: work}
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = work
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	// Real merge: branch with commits merged back into main.
+	runGit("checkout", "-b", "feature-real", "origin/main")
+	if err := os.WriteFile(filepath.Join(work, "a"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "a")
+	runGit("commit", "-m", "feature work")
+	runGit("checkout", "main")
+	runGit("merge", "--no-ff", "feature-real", "-m", "merge")
+	runGit("push", "origin", "main")
+	runGit("fetch", "origin")
+
+	merged, err := g.MergedBranches("main")
+	if err != nil {
+		t.Fatalf("MergedBranches: %v", err)
+	}
+	var found bool
+	for _, b := range merged {
+		if b == "feature-real" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("real merged branch missing from %v", merged)
+	}
+}

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -62,7 +62,7 @@ func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
 		}
 
 		cfg := config.Load(bareDir)
-		mergedSet := repoGit.MergedBranchSet(cfg.ResolveBaseBranch())
+		mergedSet := repoGit.MergedBranchSet(repoGit.ResolveBaseBranch(cfg.BaseBranch))
 
 		for _, wt := range wts {
 			if wt.IsBare {


### PR DESCRIPTION
## Description of the change

Fresh worktrees created with `ww new` were showing `[merged]` in the tmux picker immediately — before any work had even happened. Two independent bugs combined to cause it:

**Bug 1** — `git branch --merged origin/<base>` in `MergedBranches` considers any branch whose tip is reachable from `origin/<base>` as merged. That includes a brand-new branch whose tip is literally the same commit as `origin/<base>` — which is exactly what `ww new` produces. So every new worktree was flagged as merged until its first commit landed.

**Bug 2** — `config.ResolveBaseBranch()` hardcoded `"main"` as the fallback when `baseBranch` wasn't set in `willow.json`. Repos whose default branch is `master` (like evergreen) silently failed: `git branch --merged origin/main` errored, `MergedBranches` swallowed the error and returned an empty set, so `[merged]` never appeared for those repos — masking the first bug.

`MergedBranches` now filters out branches whose tip SHA equals `origin/<base>`. Base-branch resolution moved to `git.ResolveBaseBranch(configured)` which falls back to the repo's HEAD symbolic ref via `git.DefaultBranch()` before defaulting to `"main"`. All five call sites updated.

## Test plan

Added unit tests in `internal/git/git_test.go` covering trivial-fork exclusion, real-merge inclusion, and the fallback chain (configured → repo HEAD → "main").