### PR TITLE
🐛 fix(claude): mark ExitPlanMode and AskUserQuestion as WAIT

### DIFF
--- a/internal/claude/hook.go
+++ b/internal/claude/hook.go
@@ -104,7 +104,14 @@ case "$HOOK_EVENT" in
     STATUS="BUSY"
     ;;
   PreToolUse)
-    STATUS="BUSY"
+    case "$TOOL_NAME" in
+      ExitPlanMode|AskUserQuestion)
+        STATUS="WAIT"
+        ;;
+      *)
+        STATUS="BUSY"
+        ;;
+    esac
     if [ -n "$TOOL_NAME" ]; then
       TOOL_FIELD="\"tool\":\"$TOOL_NAME\","
     fi


### PR DESCRIPTION
## Description of the change

The Claude status hook was leaving worktrees stuck in `BUSY` when the agent was actually blocked waiting for the user — specifically, when it called `ExitPlanMode` to request plan approval, or `AskUserQuestion` to prompt for input.

The `PreToolUse` event fires before those tools run, setting `STATUS=BUSY`. The tool then blocks indefinitely on user input, so no `PostToolUse` ever fires to move it forward. A `Notification` event can't correct this either — its handler short-circuits when the current status is already `BUSY`. After 2 minutes the stale timeout in `EffectiveStatus` flips `BUSY → IDLE`, which is why worktrees appear idle while actually waiting for plan approval.

The fix special-cases those two tools in `PreToolUse` to set `STATUS=WAIT`, mirroring the existing `PostToolUse` handling for `AskUserQuestion`.

## Test plan

Unit tests in `internal/claude` still pass. Verified by reproducing the original bug in a live worktree (`feat--landing-page-tweaks`): session file showed `"status":"BUSY","tool":"ExitPlanMode"` and the worktree flipped to IDLE after the stale timeout instead of showing WAIT.