### PR TITLE
🎨 style(website): soften hero bottom fade and drop scroll indicator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ CI runs this on both ubuntu and macos via `.github/workflows/test.yml`.
 - `internal/tmux/` - Tmux CLI primitives, picker logic, and notifications
 - `internal/stack/` - Stacked branch tracking (branches.json per repo, topo sort, tree display)
 - `internal/dashboard/` - Live TUI dashboard
-- `website/` - VitePress docs site (https://getwillow.dev)
+- `website/` - Next.js docs site (https://getwillow.dev). Use `pnpm` (not `npm`) for all website commands: `pnpm install`, `pnpm dev`, `pnpm build`.
 
 ## Conventions
 

--- a/website/src/components/ShaderGradientBg.tsx
+++ b/website/src/components/ShaderGradientBg.tsx
@@ -56,10 +56,10 @@ export default function ShaderGradientBg() {
       />
       {/* Bottom fade to page background */}
       <div
-        className="absolute inset-x-0 bottom-0 h-48"
+        className="absolute inset-x-0 bottom-0 h-[75vh]"
         style={{
           background:
-            "linear-gradient(to bottom, transparent, #0a0a0f)",
+            "linear-gradient(to bottom, transparent 0%, rgba(10,10,15,0.15) 25%, rgba(10,10,15,0.45) 50%, rgba(10,10,15,0.8) 75%, #0a0a0f 100%)",
         }}
       />
     </div>

--- a/website/src/components/landing/Hero.tsx
+++ b/website/src/components/landing/Hero.tsx
@@ -25,11 +25,6 @@ export function Hero() {
           }}
         />
         <ShaderGradientBg />
-        {/* Bottom fade to page bg (CSS fallback visible before shader loads) */}
-        <div
-          className="absolute inset-x-0 bottom-0 h-48"
-          style={{ background: "linear-gradient(to bottom, transparent, #0a0a0f)" }}
-        />
       </div>
 
       <motion.div
@@ -101,18 +96,6 @@ export function Hero() {
 
         <motion.div variants={fadeUp} className="mt-8">
           <InstallCommand />
-        </motion.div>
-
-        {/* Scroll indicator */}
-        <motion.div
-          variants={fadeUp}
-          className="mt-16"
-          animate={{ y: [0, 8, 0] }}
-          transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
-        >
-          <div className="mx-auto h-10 w-6 rounded-full border-2 border-willow-text-dim">
-            <div className="mx-auto mt-2 h-2 w-1 rounded-full bg-willow-text-3" />
-          </div>
         </motion.div>
       </motion.div>
     </section>


### PR DESCRIPTION
## Description of the change

Two small landing-page tweaks.

The hero's bottom fade was a short 48-unit `transparent → #0a0a0f` gradient, which produced a visible hard edge where the shader cut off. It now spans 75vh with multi-stop easing (0% → 25% → 50% → 75% → 100%) so the shader gradient blends gradually into the page background.

The animated mouse/scroll pill below the install command has been removed — the page is short enough that a scroll hint isn't doing useful work.

Also updated `AGENTS.md` to note that the website uses `pnpm`, not `npm`, and is Next.js rather than VitePress.

## Test plan

Manual: `pnpm dev` in `website/`, load the homepage, confirm the fade is smooth and the scroll pill is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)