### PR TITLE
🐛 fix(dispatch): write prompt file to ~/.willow, not repo root

### DIFF
--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -104,11 +103,6 @@ func dispatchCmd() *cli.Command {
 			wtPath := strings.TrimSpace(string(out))
 			if wtPath == "" {
 				return fmt.Errorf("no path returned from willow new")
-			}
-
-			promptFile := filepath.Join(wtPath, ".willow-prompt")
-			if err := os.WriteFile(promptFile, []byte(prompt), 0o644); err != nil {
-				return fmt.Errorf("failed to write prompt file: %w", err)
 			}
 
 			meta := map[string]string{"prompt": truncatePrompt(prompt)}

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -475,10 +475,6 @@ func tmuxPickDispatch(self, query, repoFilter, sessionName string, items []tmux.
 		return fmt.Errorf("no path returned from willow new")
 	}
 
-	if err := os.WriteFile(filepath.Join(wtPath, ".willow-prompt"), []byte(query), 0o644); err != nil {
-		return fmt.Errorf("failed to write prompt file: %w", err)
-	}
-
 	meta := map[string]string{"prompt": truncatePrompt(query)}
 	_ = log.Append(log.Event{Action: "dispatch", Repo: repo, Branch: branch, Metadata: meta})
 
@@ -486,12 +482,21 @@ func tmuxPickDispatch(self, query, repoFilter, sessionName string, items []tmux.
 	repoName := filepath.Base(filepath.Dir(wtPath))
 
 	sessName := tmux.SessionNameForWorktree(repoName, wtDir)
+
+	promptFile := filepath.Join(config.WillowHome(), "prompts", repoName, wtDir+".prompt")
+	if err := os.MkdirAll(filepath.Dir(promptFile), 0o755); err != nil {
+		return fmt.Errorf("failed to create prompts dir: %w", err)
+	}
+	if err := os.WriteFile(promptFile, []byte(query), 0o644); err != nil {
+		return fmt.Errorf("failed to write prompt file: %w", err)
+	}
+
 	cfg := loadRepoConfig(repoName)
 	if err := tmux.NewSession(sessName, wtPath, cfg.Tmux.Layout, cfg.Tmux.Panes); err != nil {
 		return fmt.Errorf("failed to create tmux session: %w", err)
 	}
 
-	claudeCmd := `claude "$(cat .willow-prompt)"`
+	claudeCmd := fmt.Sprintf(`claude "$(cat %s)"; rm -f %s`, shellQuote(promptFile), shellQuote(promptFile))
 	if err := tmux.SendKeys(sessName, claudeCmd, "Enter"); err != nil {
 		return fmt.Errorf("failed to send claude command: %w", err)
 	}

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -347,9 +347,8 @@ ww dispatch "Refactor payments" --repo myrepo                # target specific r
 
 **How it works:**
 1. Creates a new worktree (reuses `ww new` internally)
-2. Writes the prompt to `.willow-prompt` in the worktree
-3. Launches `claude "<prompt>"` (interactive session with prompt pre-loaded)
-4. Logs a `dispatch` event (visible in `ww log`)
+2. Launches `claude "<prompt>"` (interactive session with prompt pre-loaded)
+3. Logs a `dispatch` event (visible in `ww log`)
 
 The agent appears in `ww status`, `ww dashboard`, and the tmux picker. Switch to it anytime with `ww sw`.
 


### PR DESCRIPTION
## Description of the change

The `dispatch` command was writing a `.willow-prompt` file into the worktree root, which users could easily commit by accident (#121).

Two paths needed fixing:

- **Foreground mode** (`dispatch.go`): the file write was dead code — `dispatchForeground` passes the prompt directly via `shellQuote(prompt)`. Removed.
- **Tmux mode** (`tmux.go`): the file is actually read by the shell via `cat .willow-prompt`. Moved it to `~/.willow/prompts/<repo>/<wtDir>.prompt` and appended `rm -f` so it cleans up after claude consumes it.

Closes #121

## Test plan

`go build ./...` and `go test ./... -count=1` pass. Manual verification pending.