### PR TITLE
🐛 fix(tmux): fetch origin before listing remote branches in Ctrl-E picker

### DIFF
--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -323,6 +323,14 @@ func tmuxPickExisting(self, repoFilter, sessionName string, items []tmux.PickerI
 	}
 
 	repoGit := &git.Git{Dir: bareDir}
+	cfg := config.Load(bareDir)
+	if *cfg.Defaults.Fetch {
+		fmt.Fprintln(os.Stderr, "Fetching latest branches from origin...")
+		if _, err := repoGit.Run("fetch", "origin"); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to fetch: %v\n", err)
+		}
+	}
+
 	remoteBranches, err := repoGit.RemoteBranches()
 	if err != nil {
 		return fmt.Errorf("failed to list remote branches: %w", err)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/getsentry/sentry-go"
 )
 
+// isolateHome points HOME at a fresh temp dir so config.Load("") can't pick up
+// the developer's real ~/.config/willow/config.json during tests.
+func isolateHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+}
+
 func TestIsEnabled_EnvVar(t *testing.T) {
 	tests := []struct {
 		value   string
@@ -27,6 +34,7 @@ func TestIsEnabled_EnvVar(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("WILLOW_TELEMETRY=%q", tt.value), func(t *testing.T) {
+			isolateHome(t)
 			os.Setenv("WILLOW_TELEMETRY", tt.value)
 			defer os.Unsetenv("WILLOW_TELEMETRY")
 
@@ -39,6 +47,7 @@ func TestIsEnabled_EnvVar(t *testing.T) {
 }
 
 func TestInit_DisabledByEnvVar(t *testing.T) {
+	isolateHome(t)
 	enabled = false
 	os.Setenv("WILLOW_TELEMETRY", "off")
 	defer os.Unsetenv("WILLOW_TELEMETRY")
@@ -52,6 +61,7 @@ func TestInit_DisabledByEnvVar(t *testing.T) {
 }
 
 func TestInit_DisabledByDefault(t *testing.T) {
+	isolateHome(t)
 	enabled = false
 	os.Unsetenv("WILLOW_TELEMETRY")
 

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -52,7 +52,7 @@ You can also paste a PR URL into the query field and press `Ctrl-N` for quick on
 
 ### Existing branch picker
 
-Press `Ctrl-E` to open a secondary picker showing all remote branches that don't already have worktrees. Select one to create a worktree and switch to it immediately.
+Press `Ctrl-E` to open a secondary picker showing all remote branches that don't already have worktrees. Willow fetches from origin first (unless `defaults.fetch` is disabled) so freshly pushed branches show up. Select one to create a worktree and switch to it immediately.
 
 ### Merged worktree indicator
 


### PR DESCRIPTION
## Description of the change

The tmux switcher's Ctrl-E picker (\"Existing branch\") called \`RemoteBranches()\` straight against the bare repo without fetching, so branches pushed from other clones of the same remote never showed up. Meanwhile \`ww new -e\` from the CLI does fetch first — the inconsistency was the bug. Ctrl-E now runs \`git fetch origin\` first, gated on \`cfg.Defaults.Fetch\` so users who opt out still see the old behavior.

Along the way, rooted out three telemetry tests that fail locally for anyone with \`telemetry: true\` in \`~/.config/willow/config.json\`. \`isEnabled()\` falls through to \`config.Load(\"\")\`, which reads the real user config — CI only passes because GitHub runners have no config file. Fixed by pointing \`HOME\` at \`t.TempDir()\` in the affected tests so they're hermetic.

## Test plan

- Manually reproduced the Ctrl-E miss in tmux against a branch pushed from a different clone, confirmed the fix picks it up.
- \`go test ./...\` — all 396 tests pass (previously 3 telemetry tests failed locally).