### PR TITLE
:zap: perf(tmux): speed up picker on large repos

### DIFF
--- a/internal/claude/unread.go
+++ b/internal/claude/unread.go
@@ -39,8 +39,11 @@ func IsUnread(repoName, worktreeDir string) bool {
 
 // UnreadCount returns the number of DONE sessions whose timestamp is after .lastread.
 func UnreadCount(repoName, worktreeDir string) int {
+	return CountUnreadIn(repoName, worktreeDir, ReadAllSessions(repoName, worktreeDir))
+}
+
+func CountUnreadIn(repoName, worktreeDir string, sessions []*SessionStatus) int {
 	lr := lastReadTime(repoName, worktreeDir)
-	sessions := ReadAllSessions(repoName, worktreeDir)
 	count := 0
 	for _, ss := range sessions {
 		if ss.Status == StatusDone && (lr.IsZero() || ss.Timestamp.After(lr)) {

--- a/internal/claude/unread_test.go
+++ b/internal/claude/unread_test.go
@@ -78,3 +78,28 @@ func TestIsUnread_NoSessions(t *testing.T) {
 		t.Error("IsUnread = true for nonexistent dir, want false")
 	}
 }
+
+func TestCountUnreadIn_UsesProvidedSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repoName := "myrepo"
+	wtName := "wt-count"
+	past := time.Now().UTC().Add(-1 * time.Minute)
+	sessions := []*SessionStatus{
+		{Status: StatusDone, SessionID: "a", Timestamp: past},
+		{Status: StatusBusy, SessionID: "b", Timestamp: past},
+		{Status: StatusDone, SessionID: "c", Timestamp: past},
+	}
+
+	if got := CountUnreadIn(repoName, wtName, sessions); got != 2 {
+		t.Errorf("CountUnreadIn = %d, want 2", got)
+	}
+
+	if err := MarkRead(repoName, wtName); err != nil {
+		t.Fatalf("MarkRead: %v", err)
+	}
+	if got := CountUnreadIn(repoName, wtName, sessions); got != 0 {
+		t.Errorf("CountUnreadIn after MarkRead = %d, want 0", got)
+	}
+}

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -178,15 +178,19 @@ func printTable(flags Flags, worktrees []worktree.Worktree, repoName string, rep
 	}
 
 	cfg := config.Load(repoGit.Dir)
-	mergedSet := repoGit.MergedBranchSet(repoGit.ResolveBaseBranch(cfg.BaseBranch))
 
 	st := stack.Load(repoGit.Dir)
 	branchSet := make(map[string]bool)
 	wtMap := make(map[string]worktree.Worktree)
+	branches := make([]string, 0, len(worktrees))
 	for _, wt := range worktrees {
 		branchSet[wt.Branch] = true
 		wtMap[wt.Branch] = wt
+		if wt.Branch != "" {
+			branches = append(branches, wt.Branch)
+		}
 	}
+	mergedSet := repoGit.MergedBranchSet(repoGit.ResolveBaseBranch(cfg.BaseBranch), branches)
 
 	var rows []lsRow
 	stackedBranches := make(map[string]bool)

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -869,6 +869,7 @@ func tmuxStatusBarCmd() *cli.Command {
 			totalWt := 0
 			activeAgents := 0
 			currentStatuses := make(map[string]claude.Status)
+			sessionSet := tmux.ListSessions()
 
 			for _, repoName := range repos {
 				bareDir, err := config.ResolveRepo(repoName)
@@ -891,7 +892,7 @@ func tmuxStatusBarCmd() *cli.Command {
 
 					// Clean orphaned sessions whose tmux session no longer exists
 					sessName := tmux.SessionNameForWorktree(repoName, wtDir)
-					if (ws.Status == claude.StatusBusy || ws.Status == claude.StatusWait) && !tmux.SessionExists(sessName) {
+					if (ws.Status == claude.StatusBusy || ws.Status == claude.StatusWait) && !sessionSet[sessName] {
 						for _, ss := range sessions {
 							if ss.Status == claude.StatusBusy || ss.Status == claude.StatusWait {
 								claude.RemoveSessionFile(repoName, wtDir, ss.SessionID)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -145,12 +145,41 @@ func (g *Git) MergedBranches(base string) ([]string, error) {
 	return branches, nil
 }
 
-// MergedBranchSet returns a set of branches that have been merged into origin/<base>.
-func (g *Git) MergedBranchSet(base string) map[string]bool {
-	merged, _ := g.MergedBranches(base)
-	set := make(map[string]bool, len(merged))
-	for _, b := range merged {
-		set[b] = true
+// MergedBranchSet returns the subset of the given branches merged into
+// origin/<base>. Uses for-each-ref with exact refname paths rather than
+// `git branch --merged`, which scans every local ref and would take
+// hundreds of ms on repos with thousands of branches. Excludes trivial
+// forks whose tip SHA equals origin/<base> (same filter as MergedBranches).
+func (g *Git) MergedBranchSet(base string, branches []string) map[string]bool {
+	if len(branches) == 0 {
+		return map[string]bool{}
+	}
+	args := []string{"for-each-ref", "--merged=origin/" + base, "--format=%(refname:short) %(objectname)"}
+	for _, b := range branches {
+		args = append(args, "refs/heads/"+b)
+	}
+	out, err := g.Run(args...)
+	if err != nil || out == "" {
+		return map[string]bool{}
+	}
+	baseSHA, _ := g.Run("rev-parse", "origin/"+base)
+	set := make(map[string]bool)
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		name, sha, ok := strings.Cut(line, " ")
+		if !ok {
+			continue
+		}
+		if name == base {
+			continue
+		}
+		if baseSHA != "" && sha == baseSHA {
+			continue
+		}
+		set[name] = true
 	}
 	return set
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -151,3 +151,70 @@ func TestMergedBranches_IncludesRealMerges(t *testing.T) {
 		t.Errorf("real merged branch missing from %v", merged)
 	}
 }
+
+func TestMergedBranchSet_FiltersToGivenBranches(t *testing.T) {
+	work := setupRemoteAndClone(t, "main")
+	g := &Git{Dir: work}
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = work
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	runGit("checkout", "-b", "wt-merged", "origin/main")
+	if err := os.WriteFile(filepath.Join(work, "a"), []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "a")
+	runGit("commit", "-m", "wt-merged work")
+	runGit("checkout", "main")
+	runGit("merge", "--no-ff", "wt-merged", "-m", "merge wt-merged")
+	runGit("push", "origin", "main")
+	runGit("fetch", "origin")
+
+	runGit("checkout", "-b", "wt-unmerged", "origin/main")
+	if err := os.WriteFile(filepath.Join(work, "b"), []byte("b"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "b")
+	runGit("commit", "-m", "wt-unmerged work")
+
+	runGit("checkout", "-b", "other-merged", "origin/main")
+	if err := os.WriteFile(filepath.Join(work, "c"), []byte("c"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "c")
+	runGit("commit", "-m", "other work")
+	runGit("checkout", "main")
+	runGit("merge", "--no-ff", "other-merged", "-m", "merge other")
+	runGit("push", "origin", "main")
+	runGit("fetch", "origin")
+
+	set := g.MergedBranchSet("main", []string{"wt-merged", "wt-unmerged"})
+	if !set["wt-merged"] {
+		t.Errorf("wt-merged should be in set, got %v", set)
+	}
+	if set["wt-unmerged"] {
+		t.Errorf("wt-unmerged should not be in set, got %v", set)
+	}
+	if set["other-merged"] {
+		t.Errorf("other-merged not in input list, must not leak into set, got %v", set)
+	}
+}
+
+func TestMergedBranchSet_EmptyInput(t *testing.T) {
+	work := setupRemoteAndClone(t, "main")
+	g := &Git{Dir: work}
+	set := g.MergedBranchSet("main", nil)
+	if len(set) != 0 {
+		t.Errorf("empty input should return empty set, got %v", set)
+	}
+}

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -49,6 +49,8 @@ func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
 		}
 	}
 
+	sessionSet := ListSessions()
+
 	var items []PickerItem
 	for _, repoName := range repoNames {
 		bareDir, err := config.ResolveRepo(repoName)
@@ -75,8 +77,8 @@ func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
 				continue
 			}
 			wtDir := filepath.Base(wt.Path)
-			ws := claude.ReadStatus(repoName, wtDir)
 			sessions := claude.ReadAllSessions(repoName, wtDir)
+			ws := claude.AggregateStatus(sessions)
 			sessName := SessionNameForWorktree(repoName, wtDir)
 			items = append(items, PickerItem{
 				RepoName:   repoName,
@@ -84,8 +86,8 @@ func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
 				WtDirName:  wtDir,
 				WtPath:     wt.Path,
 				Status:     ws.Status,
-				Unread:     ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir),
-				HasSession: SessionExists(sessName),
+				Unread:     ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
+				HasSession: sessionSet[sessName],
 				Sessions:   sessions,
 				Merged:     mergedSet[wt.Branch],
 			})

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -62,7 +62,13 @@ func BuildPickerItems(repoFilter string) ([]PickerItem, error) {
 		}
 
 		cfg := config.Load(bareDir)
-		mergedSet := repoGit.MergedBranchSet(repoGit.ResolveBaseBranch(cfg.BaseBranch))
+		branches := make([]string, 0, len(wts))
+		for _, wt := range wts {
+			if !wt.IsBare && wt.Branch != "" {
+				branches = append(branches, wt.Branch)
+			}
+		}
+		mergedSet := repoGit.MergedBranchSet(repoGit.ResolveBaseBranch(cfg.BaseBranch), branches)
 
 		for _, wt := range wts {
 			if wt.IsBare {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -26,6 +26,23 @@ func SessionExists(name string) bool {
 	return err == nil
 }
 
+// ListSessions returns the set of tmux session names, or an empty set if
+// tmux isn't running.
+func ListSessions() map[string]bool {
+	out, err := run("list-sessions", "-F", "#{session_name}")
+	if err != nil {
+		return map[string]bool{}
+	}
+	names := strings.Split(out, "\n")
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		if n = strings.TrimSpace(n); n != "" {
+			set[n] = true
+		}
+	}
+	return set
+}
+
 func SendKeys(target string, keys ...string) error {
 	args := append([]string{"send-keys", "-t", target}, keys...)
 	_, err := run(args...)


### PR DESCRIPTION
## Description of the change

On repos with many local branches, opening the tmux picker (Ctrl-W) or running `willow tmux list` was noticeably slow. Profiling with a temporary `WILLOW_BENCH=1` hook against a ~10k-branch clone identified three hotspots:

1. `git branch --merged origin/<base>` walked every local branch to find the 2 of interest. Switching to `git for-each-ref --merged=origin/<base> refs/heads/<wt-branch>...` cuts the call from ~670ms to ~25ms and also gives exact refname matching (no glob semantics to worry about).

2. `tmux has-session` was forked once per worktree. `ListSessions()` batches into a single `tmux list-sessions` call, and both the picker and the status-bar widget now consult the returned set.

3. `ReadAllSessions` was called 3x per worktree (once by `ReadStatus`, once directly, once by `IsUnread` → `UnreadCount`). Each call does a `ReadDir` plus a JSON parse per file. `CountUnreadIn` lets callers thread an already-loaded slice through, so we read once.

End-to-end `willow tmux list` drops from ~870ms to ~380ms on my 10k-branch evergreen clone (~55% faster). Ctrl-W popup open time improves proportionally.

**Ticket:**

## Test plan

Unit tests added for `MergedBranchSet` (filters to the caller's branch list, empty input short-circuits, merged branches outside the input don't leak) and for `CountUnreadIn` (counts from a preloaded slice, respects `.lastread`). Full suite: 421 pass on ubuntu + macos.

## Loom or screenshots

## Considerations

`MergedBranchSet` signature changed — it now takes the caller's branch list. Both callers (`picker.go`, `ls.go`) updated; no external consumers.