### PR TITLE
🐛 fix(claude): preserve symlink in hook registration path

### DIFF
--- a/internal/claude/hook.go
+++ b/internal/claude/hook.go
@@ -27,17 +27,20 @@ var hookEvents = []string{
 
 // hookCommand returns the shell-quoted command string that Claude Code will
 // invoke for every registered hook event: `<abs path to willow> hook`.
-// The absolute path is resolved once at install time via os.Executable() so
-// the registration survives PATH changes.
+// Symlinks are intentionally preserved: Homebrew ships willow as a symlink at
+// /opt/homebrew/bin/willow -> ../Cellar/willow/<version>/bin/willow, and
+// resolving through it would pin hooks to a versioned Cellar path that
+// disappears on the next `brew upgrade`.
 func hookCommand() (string, error) {
 	exe, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("resolve willow executable: %w", err)
 	}
-	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
-		exe = resolved
-	}
-	return exe + " hook", nil
+	return hookCommandFor(exe), nil
+}
+
+func hookCommandFor(exe string) string {
+	return exe + " hook"
 }
 
 // Install registers the willow `hook` subcommand for every required Claude

--- a/internal/claude/hook_test.go
+++ b/internal/claude/hook_test.go
@@ -49,6 +49,19 @@ func TestInstall_WritesSettings(t *testing.T) {
 	}
 }
 
+// TestHookCommandFor_PreservesSymlinks guards against regressing to
+// filepath.EvalSymlinks. On Homebrew, the stable launcher at
+// /opt/homebrew/bin/willow is a symlink into a versioned Cellar path that
+// vanishes on `brew upgrade`, so hook registration must use the launcher path
+// verbatim instead of resolving through it.
+func TestHookCommandFor_PreservesSymlinks(t *testing.T) {
+	launcher := "/opt/homebrew/bin/willow"
+	got := hookCommandFor(launcher)
+	if got != launcher+" hook" {
+		t.Errorf("hookCommandFor(%q) = %q, want %q", launcher, got, launcher+" hook")
+	}
+}
+
 func TestIsInstalled_FalseWithNoSettings(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Description of the change

`hookCommand()` called `filepath.EvalSymlinks()` on `os.Executable()` before registering the Claude Code hook in `~/.claude/settings.json`. On Homebrew installs, `/opt/homebrew/bin/willow` is a symlink to `../Cellar/willow/<version>/bin/willow`. Resolving it pinned the hook to a versioned Cellar path that disappears on the next `brew upgrade`, and every Claude Code session then fails each registered hook with:

```
UserPromptSubmit hook error
Failed with non-blocking status code: /bin/sh: /opt/homebrew/Cellar/willow/<old-ver>/bin/willow: No such file or directory
```

…until the user reruns `ww cc-setup`.

Drop the `EvalSymlinks` call so the stable launcher path survives into `settings.json`. Split the string-building into a pure `hookCommandFor(exe)` helper so the no-symlink-resolution contract is directly testable.

## Test plan

Added a regression test (`TestHookCommandFor_PreservesSymlinks`) that locks in the behavior. Also manually reinstalled hooks from a local build, confirmed `settings.json` now holds `/opt/homebrew/bin/willow hook`, and verified `echo '{...}' | willow hook` exits 0.