### PR TITLE
:bug: fix[worktrees]: prioritize urgent worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ go install github.com/iamrajjoshi/willow/cmd/willow@latest
 
 - [git](https://git-scm.com/)
 - [tmux](https://github.com/tmux/tmux) — optional, for the `ww tmux` picker popup
-- [gh](https://cli.github.com/) — optional, required for `ww new --pr` and `ww stack status`
+- [gh](https://cli.github.com/) — optional, required for `ww new --pr`, `ww stack status`, and GitHub-aware merged worktree detection
 
 ## Setup
 
@@ -192,7 +192,7 @@ ww new feature/auth                    # auto-cd via shell integration (tmux-awa
 
 ### `ww checkout <branch-or-pr-url>` (alias: `co`)
 
-Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree. Merged worktrees show a `[merged]` indicator in `ww ls` and the tmux picker.
+Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree. Merged worktrees show a `[merged]` indicator in `ww ls` and the tmux picker. When `gh` is installed, willow also marks branches whose latest PR was merged on GitHub via squash/rebase, even if the branch tip is not an ancestor of the base branch.
 
 ```bash
 ww checkout auth-refactor                # switch if exists, create if not
@@ -266,12 +266,12 @@ ww sync --abort            # abort any in-progress rebases
 
 ### `ww sw`
 
-Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by activity.
+Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by urgency: `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline.
 
 ```
-🤖 BUSY   auth-refactor        <willow-base>/worktrees/repo/auth-refactor
-✅ DONE   api-cleanup          <willow-base>/worktrees/repo/api-cleanup
 ⏳ WAIT   payments             <willow-base>/worktrees/repo/payments
+✅ DONE●  api-cleanup          <willow-base>/worktrees/repo/api-cleanup
+🤖 BUSY   auth-refactor        <willow-base>/worktrees/repo/auth-refactor
 🟡 IDLE   main                 <willow-base>/worktrees/repo/main
    --     old-feature          <willow-base>/worktrees/repo/old-feature
 ```
@@ -297,7 +297,7 @@ ww rm auth-refactor --prune      # also run git worktree prune
 
 ### `ww ls [repo]`
 
-List worktrees with status.
+List worktrees with status. Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and merged worktrees at the bottom.
 
 ![ww ls](screenshots/demo-ls.gif)
 

--- a/internal/claude/status_test.go
+++ b/internal/claude/status_test.go
@@ -219,6 +219,24 @@ func TestStatusOrder_Ordering(t *testing.T) {
 	}
 }
 
+func TestWorktreeUrgencyOrder_Ordering(t *testing.T) {
+	if WorktreeUrgencyOrder(StatusWait, false) >= WorktreeUrgencyOrder(StatusDone, true) {
+		t.Error("WAIT should have higher urgency than unread DONE")
+	}
+	if WorktreeUrgencyOrder(StatusDone, true) >= WorktreeUrgencyOrder(StatusBusy, false) {
+		t.Error("unread DONE should have higher urgency than BUSY")
+	}
+	if WorktreeUrgencyOrder(StatusBusy, false) >= WorktreeUrgencyOrder(StatusDone, false) {
+		t.Error("BUSY should have higher urgency than read DONE")
+	}
+	if WorktreeUrgencyOrder(StatusDone, false) >= WorktreeUrgencyOrder(StatusIdle, false) {
+		t.Error("read DONE should have higher urgency than IDLE")
+	}
+	if WorktreeUrgencyOrder(StatusIdle, false) >= WorktreeUrgencyOrder(StatusOffline, false) {
+		t.Error("IDLE should have higher urgency than OFFLINE")
+	}
+}
+
 func TestReadStatus_WaitAggregation(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/claude/worktree_order.go
+++ b/internal/claude/worktree_order.go
@@ -1,0 +1,21 @@
+package claude
+
+// WorktreeUrgencyOrder returns the attention priority for worktree-focused
+// views like pickers and tables.
+// WAIT(0) < DONE unread(1) < BUSY(2) < DONE read(3) < IDLE(4) < everything else(5).
+func WorktreeUrgencyOrder(s Status, unread bool) int {
+	switch {
+	case s == StatusWait:
+		return 0
+	case s == StatusDone && unread:
+		return 1
+	case s == StatusBusy:
+		return 2
+	case s == StatusDone:
+		return 3
+	case s == StatusIdle:
+		return 4
+	default:
+		return 5
+	}
+}

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -77,31 +78,38 @@ func gcCmd() *cli.Command {
 
 				cfg := config.Load(bareDir)
 				repoGit := &git.Git{Dir: bareDir}
-				merged, err := repoGit.MergedBranches(repoGit.ResolveBaseBranch(cfg.BaseBranch))
-				if err != nil {
-					u.Warn(fmt.Sprintf("Skipping repo %s: failed to get merged branches: %v", repoName, err))
-					continue
-				}
-				if len(merged) == 0 {
-					continue
-				}
-
 				wts, err := worktree.List(repoGit)
 				if err != nil {
 					u.Warn(fmt.Sprintf("Skipping repo %s: failed to list worktrees: %v", repoName, err))
 					continue
 				}
 
-				wtBranches := make(map[string]bool)
+				baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
+				branches := make([]string, 0, len(wts))
+				branchHeads := make(map[string]string, len(wts))
+				repoDir := ""
 				for _, wt := range wts {
-					if !wt.IsBare {
-						wtBranches[wt.Branch] = true
+					if wt.IsBare || wt.Branch == "" {
+						continue
 					}
+					if repoDir == "" {
+						repoDir = wt.Path
+					}
+					branches = append(branches, wt.Branch)
+					branchHeads[wt.Branch] = wt.Head
 				}
 
-				for _, branch := range merged {
-					if wtBranches[branch] {
-						candidates = append(candidates, mergedWorktree{repoName: repoName, branch: branch})
+				mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
+				for branch := range gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads) {
+					mergedSet[branch] = true
+				}
+				if len(mergedSet) == 0 {
+					continue
+				}
+
+				for _, wt := range wts {
+					if !wt.IsBare && mergedSet[wt.Branch] {
+						candidates = append(candidates, mergedWorktree{repoName: repoName, branch: wt.Branch})
 					}
 				}
 			}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -3,7 +3,10 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +15,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/tmux"
+	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
 // setupTestEnv creates a fake HOME with an "origin" git repo to clone from.
@@ -100,6 +104,127 @@ func writeActiveSessionFile(t *testing.T, repo, wt, sessionID string, status cla
 	if err := os.WriteFile(filepath.Join(dir, sessionID+".json"), data, 0o644); err != nil {
 		t.Fatalf("write session file: %v", err)
 	}
+}
+
+func configureGitUser(t *testing.T, dir string) {
+	t.Helper()
+
+	g := &git.Git{Dir: dir}
+	if _, err := g.Run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("git config email: %v", err)
+	}
+	if _, err := g.Run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("git config name: %v", err)
+	}
+}
+
+func commitFile(t *testing.T, dir, name, contents, message string) {
+	t.Helper()
+
+	configureGitUser(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+
+	g := &git.Git{Dir: dir}
+	if _, err := g.Run("add", name); err != nil {
+		t.Fatalf("git add %s: %v", name, err)
+	}
+	if _, err := g.Run("commit", "-m", message); err != nil {
+		t.Fatalf("git commit %s: %v", message, err)
+	}
+}
+
+func installTestCLIPath(t *testing.T, ghScript string) (string, string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	for _, binary := range []string{"git", "cat"} {
+		path, err := exec.LookPath(binary)
+		if err != nil {
+			t.Fatalf("find %s: %v", binary, err)
+		}
+		if err := os.Symlink(path, filepath.Join(binDir, binary)); err != nil {
+			t.Fatalf("symlink %s: %v", binary, err)
+		}
+	}
+
+	logPath := filepath.Join(binDir, "gh.log")
+	if ghScript != "" {
+		ghPath := filepath.Join(binDir, "gh")
+		if err := os.WriteFile(ghPath, []byte(ghScript), 0o755); err != nil {
+			t.Fatalf("write gh stub: %v", err)
+		}
+	}
+
+	t.Setenv("PATH", binDir)
+	return binDir, logPath
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	runErr := fn()
+	_ = w.Close()
+	os.Stdout = origStdout
+
+	out, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("read stdout: %v", readErr)
+	}
+	return string(out), runErr
+}
+
+func installMergedStatusGH(t *testing.T, baseBranch, branch, headOID string) string {
+	t.Helper()
+
+	script := fmt.Sprintf(`#!/bin/sh
+set -eu
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  shift 2
+  search=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --search)
+        search="$2"
+        shift 2
+        ;;
+      --state|--json|--limit|-q|--head)
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  case "$search" in
+    *"head:%s"*)
+      printf '[{"number":42,"title":"Merged PR","headRefName":"%s","headRefOid":"%s","baseRefName":"%s","state":"MERGED","mergedAt":"2026-04-21T18:08:47Z","reviewDecision":"","mergeable":"MERGEABLE","additions":0,"deletions":0,"url":"https://github.com/test/repo/pull/42","statusCheckRollup":[]}]\n'
+      ;;
+    *)
+      printf '[]\n'
+      ;;
+  esac
+  exit 0
+fi
+
+printf 'unsupported gh invocation: %%s\n' "$*" >&2
+exit 1
+`, branch, branch, headOID, baseBranch)
+
+	_, logPath := installTestCLIPath(t, script)
+	return logPath
 }
 
 func TestClone_CreatesDirectoryStructure(t *testing.T) {
@@ -1037,6 +1162,70 @@ func TestGc_CleansTrash(t *testing.T) {
 	trashEntries, err := os.ReadDir(trashDir)
 	if err == nil && len(trashEntries) > 0 {
 		t.Errorf("trash dir should be empty after gc, has %d entries", len(trashEntries))
+	}
+}
+
+func TestMergedWorktrees_UsesGitHubMergedPRsAcrossCLI(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "mergedrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "mergedrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	baseBranch := entries[0].Name()
+	mainDir := filepath.Join(worktreeDir, baseBranch)
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-merged", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "feature-merged")
+	commitFile(t, featureDir, "feature.txt", "feature\n", "add feature")
+
+	bareDir := filepath.Join(home, ".willow", "repos", "mergedrepo.git")
+	repoGit := &git.Git{Dir: bareDir}
+	gitMerged := repoGit.MergedBranchSet(baseBranch, []string{"feature-merged"})
+	if gitMerged["feature-merged"] {
+		t.Fatalf("feature-merged should not be git-merged in this regression setup, got %v", gitMerged)
+	}
+
+	headOID, err := (&git.Git{Dir: featureDir}).Run("rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	installMergedStatusGH(t, baseBranch, "feature-merged", strings.TrimSpace(headOID))
+
+	lsOut, err := captureStdout(t, func() error {
+		return runApp("ls", "mergedrepo")
+	})
+	if err != nil {
+		t.Fatalf("ls failed: %v", err)
+	}
+	if !strings.Contains(lsOut, "feature-merged") || !strings.Contains(lsOut, "[merged]") {
+		t.Fatalf("expected ls output to include merged feature worktree, got:\n%s", lsOut)
+	}
+
+	gcOut, err := captureStdout(t, func() error {
+		return runApp("gc")
+	})
+	if err != nil {
+		t.Fatalf("gc failed: %v", err)
+	}
+	if !strings.Contains(gcOut, "feature-merged (repo: mergedrepo)") {
+		t.Fatalf("expected gc output to include merged feature worktree, got:\n%s", gcOut)
+	}
+
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		t.Fatalf("list worktrees: %v", err)
+	}
+	mergedSet := mergedBranchSetForRepo("mergedrepo", bareDir, filterBareWorktrees(wts))
+	if !mergedSet["feature-merged"] {
+		t.Fatalf("expected sw merged helper to include feature-merged, got %v", mergedSet)
 	}
 }
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
@@ -167,10 +169,18 @@ func completeRepos(ctx context.Context, cmd *cli.Command) {
 }
 
 type lsRow struct {
-	branch      string
-	prefix      string // tree-drawing prefix
-	merged      bool
-	wt          worktree.Worktree
+	branch string
+	prefix string // tree-drawing prefix
+	merged bool
+	status claude.Status
+	unread bool
+	wt     worktree.Worktree
+}
+
+type lsRowGroup struct {
+	rows     []lsRow
+	merged   bool
+	priority int
 }
 
 func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree, repoName string, repoGit *git.Git) {
@@ -184,49 +194,41 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 	}
 
 	cfg := config.Load(repoGit.Dir)
+	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
 
 	st := stack.Load(repoGit.Dir)
-	branchSet := make(map[string]bool)
-	wtMap := make(map[string]worktree.Worktree)
 	branches := make([]string, 0, len(worktrees))
+	branchHeads := make(map[string]string, len(worktrees))
+	repoDir := ""
 	for _, wt := range worktrees {
-		branchSet[wt.Branch] = true
-		wtMap[wt.Branch] = wt
+		if repoDir == "" {
+			repoDir = wt.Path
+		}
 		if wt.Branch != "" {
 			branches = append(branches, wt.Branch)
+			branchHeads[wt.Branch] = wt.Head
 		}
 	}
 	done := trace.Span(ctx, "MergedBranchSet")
-	mergedSet := repoGit.MergedBranchSet(repoGit.ResolveBaseBranch(cfg.BaseBranch), branches)
+	mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
+	for branch := range gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads) {
+		mergedSet[branch] = true
+	}
 	done()
 
 	var rows []lsRow
-	stackedBranches := make(map[string]bool)
-
-	if !st.IsEmpty() {
-		treeLines := st.TreeLines(branchSet)
-		for _, tl := range treeLines {
-			if wt, ok := wtMap[tl.Branch]; ok {
-				stackedBranches[tl.Branch] = true
-				rows = append(rows, lsRow{
-					branch: tl.Branch,
-					prefix: tl.Prefix,
-					merged: mergedSet[tl.Branch],
-					wt:     wt,
-				})
-			}
-		}
-	}
-
 	for _, wt := range worktrees {
-		if !stackedBranches[wt.Branch] {
-			rows = append(rows, lsRow{
-				branch: wt.Branch,
-				merged: mergedSet[wt.Branch],
-				wt:     wt,
-			})
-		}
+		wtDir := filepath.Base(wt.Path)
+		ws := claude.ReadStatus(repoName, wtDir)
+		rows = append(rows, lsRow{
+			branch: wt.Branch,
+			merged: mergedSet[wt.Branch],
+			status: ws.Status,
+			unread: ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir),
+			wt:     wt,
+		})
 	}
+	rows = sortLSRows(rows, st)
 
 	branchW := len("BRANCH")
 	statusW := len("STATUS")
@@ -254,10 +256,8 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 
 	for _, row := range rows {
 		age := worktreeAge(row.wt.Path)
-		wtDir := filepath.Base(row.wt.Path)
-		ws := claude.ReadStatus(repoName, wtDir)
-		statusLabel := claude.StatusLabel(ws.Status)
-		if ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir) {
+		statusLabel := claude.StatusLabel(row.status)
+		if row.unread {
 			statusLabel += "\u25CF" // ●
 		}
 		branchPlain := row.prefix + row.branch
@@ -277,6 +277,79 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 		line := fmt.Sprintf("  %s  %-*s  %s  %s", branchCol, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))
 		u.Info(line)
 	}
+}
+
+func sortLSRows(rows []lsRow, st *stack.Stack) []lsRow {
+	rowMap := make(map[string]*lsRow, len(rows))
+	branchSet := make(map[string]bool, len(rows))
+	for i := range rows {
+		rowMap[rows[i].branch] = &rows[i]
+		branchSet[rows[i].branch] = true
+	}
+
+	groupedBranches := make(map[string]bool)
+	var groups []lsRowGroup
+
+	if st != nil && !st.IsEmpty() {
+		treeLines := st.TreeLines(branchSet)
+		prefixByBranch := make(map[string]string, len(treeLines))
+		for _, tl := range treeLines {
+			prefixByBranch[tl.Branch] = tl.Prefix
+		}
+
+		for _, root := range st.Roots() {
+			var groupRows []lsRow
+			for _, branch := range st.SubtreeSort(root) {
+				row, ok := rowMap[branch]
+				if !ok {
+					continue
+				}
+				row.prefix = prefixByBranch[branch]
+				groupedBranches[branch] = true
+				groupRows = append(groupRows, *row)
+			}
+			if len(groupRows) > 0 {
+				groups = append(groups, newLSRowGroup(groupRows))
+			}
+		}
+	}
+
+	for _, row := range rows {
+		if !groupedBranches[row.branch] {
+			groups = append(groups, newLSRowGroup([]lsRow{row}))
+		}
+	}
+
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].merged != groups[j].merged {
+			return !groups[i].merged
+		}
+		return groups[i].priority < groups[j].priority
+	})
+
+	var sorted []lsRow
+	for _, group := range groups {
+		sorted = append(sorted, group.rows...)
+	}
+	return sorted
+}
+
+func newLSRowGroup(rows []lsRow) lsRowGroup {
+	group := lsRowGroup{
+		rows:     rows,
+		merged:   true,
+		priority: claude.WorktreeUrgencyOrder(claude.StatusOffline, false),
+	}
+	for _, row := range rows {
+		if !row.merged {
+			group.merged = false
+		}
+		priority := claude.WorktreeUrgencyOrder(row.status, row.unread)
+		if priority < group.priority {
+			group.priority = priority
+		}
+	}
+	return group
 }
 
 func worktreeAge(path string) string {

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -3,6 +3,10 @@ package cli
 import (
 	"testing"
 	"time"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
 func TestFormatAge(t *testing.T) {
@@ -26,5 +30,64 @@ func TestFormatAge(t *testing.T) {
 				t.Errorf("formatAge(%v) = %q, want %q", tt.d, got, tt.want)
 			}
 		})
+	}
+}
+
+func lsTestStack(pairs ...string) *stack.Stack {
+	st := &stack.Stack{Parents: make(map[string]string)}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		st.Parents[pairs[i]] = pairs[i+1]
+	}
+	return st
+}
+
+func lsBranches(rows []lsRow) []string {
+	branches := make([]string, len(rows))
+	for i, row := range rows {
+		branches[i] = row.branch
+	}
+	return branches
+}
+
+func TestSortLSRows_UrgencyAndMergedOrder(t *testing.T) {
+	rows := []lsRow{
+		{branch: "busy", status: claude.StatusBusy, wt: worktree.Worktree{Branch: "busy"}},
+		{branch: "done-unread", status: claude.StatusDone, unread: true, wt: worktree.Worktree{Branch: "done-unread"}},
+		{branch: "wait", status: claude.StatusWait, wt: worktree.Worktree{Branch: "wait"}},
+		{branch: "done-read", status: claude.StatusDone, wt: worktree.Worktree{Branch: "done-read"}},
+		{branch: "idle", status: claude.StatusIdle, wt: worktree.Worktree{Branch: "idle"}},
+		{branch: "merged-wait", status: claude.StatusWait, merged: true, wt: worktree.Worktree{Branch: "merged-wait"}},
+	}
+
+	got := lsBranches(sortLSRows(rows, nil))
+	want := []string{"wait", "done-unread", "busy", "done-read", "idle", "merged-wait"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("branch[%d] = %q, want %q (full order %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSortLSRows_StackStaysContiguousAndRanksByUrgency(t *testing.T) {
+	rows := []lsRow{
+		{branch: "busy", status: claude.StatusBusy, wt: worktree.Worktree{Branch: "busy"}},
+		{branch: "stack-a", status: claude.StatusIdle, wt: worktree.Worktree{Branch: "stack-a"}},
+		{branch: "stack-b", status: claude.StatusWait, wt: worktree.Worktree{Branch: "stack-b"}},
+		{branch: "done-read", status: claude.StatusDone, wt: worktree.Worktree{Branch: "done-read"}},
+	}
+
+	got := sortLSRows(rows, lsTestStack("stack-a", "main", "stack-b", "stack-a"))
+	want := []string{"stack-a", "stack-b", "busy", "done-read"}
+	branches := lsBranches(got)
+	for i := range want {
+		if branches[i] != want[i] {
+			t.Fatalf("branch[%d] = %q, want %q (full order %v)", i, branches[i], want[i], branches)
+		}
+	}
+	if got[0].prefix != "" {
+		t.Fatalf("root prefix = %q, want empty", got[0].prefix)
+	}
+	if got[1].prefix == "" {
+		t.Fatal("child prefix should be preserved")
 	}
 }

--- a/internal/cli/sw.go
+++ b/internal/cli/sw.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/errors"
 	"github.com/iamrajjoshi/willow/internal/fzf"
+	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -118,20 +120,30 @@ func swCmd() *cli.Command {
 type worktreeWithStatus struct {
 	wt     worktree.Worktree
 	status *claude.WorktreeStatus
+	unread bool
+	merged bool
 }
 
 func buildWorktreeLines(worktrees []worktree.Worktree, repoName string) []string {
+	mergedSet := mergedBranchSetForRepo(repoName, "", worktrees)
 	items := make([]worktreeWithStatus, len(worktrees))
 	for i, wt := range worktrees {
 		wtDir := filepath.Base(wt.Path)
+		ws := claude.ReadStatus(repoName, wtDir)
 		items[i] = worktreeWithStatus{
 			wt:     wt,
-			status: claude.ReadStatus(repoName, wtDir),
+			status: ws,
+			unread: ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir),
+			merged: mergedSet[wt.Branch],
 		}
 	}
 
 	sort.SliceStable(items, func(i, j int) bool {
-		return claude.StatusOrder(items[i].status.Status) < claude.StatusOrder(items[j].status.Status)
+		if items[i].merged != items[j].merged {
+			return !items[i].merged
+		}
+		return claude.WorktreeUrgencyOrder(items[i].status.Status, items[i].unread) <
+			claude.WorktreeUrgencyOrder(items[j].status.Status, items[j].unread)
 	})
 
 	branchW := 0
@@ -146,6 +158,9 @@ func buildWorktreeLines(worktrees []worktree.Worktree, repoName string) []string
 	for _, item := range items {
 		icon := claude.StatusIcon(item.status.Status)
 		label := claude.StatusLabel(item.status.Status)
+		if item.unread {
+			label += "\u25CF"
+		}
 		line := fmt.Sprintf("%s %-*s  %-*s  %s",
 			icon,
 			statusW, label,
@@ -161,18 +176,40 @@ func buildCrossRepoWorktreeLines(rwts []repoWorktree) []string {
 	type item struct {
 		rwt    repoWorktree
 		status *claude.WorktreeStatus
+		unread bool
+		merged bool
 	}
+
+	mergedSets := make(map[string]map[string]bool)
+	grouped := make(map[string][]worktree.Worktree)
+	for _, rwt := range rwts {
+		grouped[rwt.Repo.Name] = append(grouped[rwt.Repo.Name], rwt.Worktree)
+	}
+	for _, rwt := range rwts {
+		if _, ok := mergedSets[rwt.Repo.Name]; ok {
+			continue
+		}
+		mergedSets[rwt.Repo.Name] = mergedBranchSetForRepo(rwt.Repo.Name, rwt.Repo.BareDir, grouped[rwt.Repo.Name])
+	}
+
 	items := make([]item, len(rwts))
 	for i, rwt := range rwts {
 		wtDir := filepath.Base(rwt.Worktree.Path)
+		ws := claude.ReadStatus(rwt.Repo.Name, wtDir)
 		items[i] = item{
 			rwt:    rwt,
-			status: claude.ReadStatus(rwt.Repo.Name, wtDir),
+			status: ws,
+			unread: ws.Status == claude.StatusDone && claude.IsUnread(rwt.Repo.Name, wtDir),
+			merged: mergedSets[rwt.Repo.Name][rwt.Worktree.Branch],
 		}
 	}
 
 	sort.SliceStable(items, func(i, j int) bool {
-		return claude.StatusOrder(items[i].status.Status) < claude.StatusOrder(items[j].status.Status)
+		if items[i].merged != items[j].merged {
+			return !items[i].merged
+		}
+		return claude.WorktreeUrgencyOrder(items[i].status.Status, items[i].unread) <
+			claude.WorktreeUrgencyOrder(items[j].status.Status, items[j].unread)
 	})
 
 	nameW := 0
@@ -188,6 +225,9 @@ func buildCrossRepoWorktreeLines(rwts []repoWorktree) []string {
 	for _, it := range items {
 		icon := claude.StatusIcon(it.status.Status)
 		label := claude.StatusLabel(it.status.Status)
+		if it.unread {
+			label += "\u25CF"
+		}
 		display := it.rwt.Repo.Name + "/" + it.rwt.Worktree.Branch
 		line := fmt.Sprintf("%s %-*s  %-*s  %s",
 			icon,
@@ -198,6 +238,41 @@ func buildCrossRepoWorktreeLines(rwts []repoWorktree) []string {
 		lines = append(lines, line)
 	}
 	return lines
+}
+
+func mergedBranchSetForRepo(repoName, bareDir string, worktrees []worktree.Worktree) map[string]bool {
+	if bareDir == "" {
+		resolved, err := config.ResolveRepo(repoName)
+		if err != nil {
+			return map[string]bool{}
+		}
+		bareDir = resolved
+	}
+
+	branches := make([]string, 0, len(worktrees))
+	branchHeads := make(map[string]string, len(worktrees))
+	repoDir := ""
+	for _, wt := range worktrees {
+		if wt.Branch != "" {
+			if repoDir == "" {
+				repoDir = wt.Path
+			}
+			branches = append(branches, wt.Branch)
+			branchHeads[wt.Branch] = wt.Head
+		}
+	}
+	if len(branches) == 0 {
+		return map[string]bool{}
+	}
+
+	repoGit := &git.Git{Dir: bareDir}
+	cfg := config.Load(bareDir)
+	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
+	mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
+	for branch := range gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads) {
+		mergedSet[branch] = true
+	}
+	return mergedSet
 }
 
 func fzfPickWorktree(worktrees []worktree.Worktree, repoName string) (string, error) {
@@ -247,4 +322,3 @@ func extractPathFromLine(line string) string {
 	}
 	return fields[len(fields)-1]
 }
-

--- a/internal/cli/sw_test.go
+++ b/internal/cli/sw_test.go
@@ -1,9 +1,14 @@
 package cli
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
@@ -28,6 +33,26 @@ func TestExtractPathFromLine(t *testing.T) {
 	}
 }
 
+func writeSessionStatus(t *testing.T, home, repo, wt string, status claude.Status, ts time.Time) {
+	t.Helper()
+	dir := filepath.Join(home, ".willow", "status", repo, wt)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir status dir: %v", err)
+	}
+
+	data, err := json.Marshal(claude.SessionStatus{
+		Status:    status,
+		SessionID: wt + "-session",
+		Timestamp: ts,
+		Worktree:  wt,
+	})
+	if err != nil {
+		t.Fatalf("marshal session: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, wt+"-session.json"), data, 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+}
 
 func TestBuildWorktreeLines(t *testing.T) {
 	// Use a temp HOME so claude.ReadStatus returns offline for all
@@ -48,6 +73,54 @@ func TestBuildWorktreeLines(t *testing.T) {
 		if !strings.Contains(line, "/wt/repo/") {
 			t.Errorf("line should contain path, got %q", line)
 		}
+	}
+}
+
+func TestBuildWorktreeLines_UrgencyOrder(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	now := time.Now().UTC()
+	writeSessionStatus(t, home, "repo", "busy", claude.StatusBusy, now)
+	writeSessionStatus(t, home, "repo", "done-unread", claude.StatusDone, now)
+	writeSessionStatus(t, home, "repo", "wait", claude.StatusWait, now)
+	writeSessionStatus(t, home, "repo", "done-read", claude.StatusDone, now.Add(-2*time.Minute))
+	readPath := filepath.Join(home, ".willow", "status", "repo", "done-read", ".lastread")
+	if err := os.WriteFile(readPath, []byte(now.UTC().Format(time.RFC3339)+"\n"), 0o644); err != nil {
+		t.Fatalf("write lastread: %v", err)
+	}
+
+	wts := []worktree.Worktree{
+		{Branch: "busy", Path: "/wt/repo/busy"},
+		{Branch: "done-unread", Path: "/wt/repo/done-unread"},
+		{Branch: "wait", Path: "/wt/repo/wait"},
+		{Branch: "done-read", Path: "/wt/repo/done-read"},
+	}
+
+	lines := buildWorktreeLines(wts, "repo")
+	if len(lines) != 4 {
+		t.Fatalf("expected 4 lines, got %d", len(lines))
+	}
+
+	got := []string{
+		extractPathFromLine(lines[0]),
+		extractPathFromLine(lines[1]),
+		extractPathFromLine(lines[2]),
+		extractPathFromLine(lines[3]),
+	}
+	want := []string{
+		"/wt/repo/wait",
+		"/wt/repo/done-unread",
+		"/wt/repo/busy",
+		"/wt/repo/done-read",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("path[%d] = %q, want %q (full order %v)", i, got[i], want[i], got)
+		}
+	}
+	if !strings.Contains(lines[1], "DONE●") {
+		t.Fatalf("expected unread DONE marker in line %q", lines[1])
 	}
 }
 
@@ -92,5 +165,47 @@ func TestBuildCrossRepoWorktreeLines(t *testing.T) {
 	}
 	if !foundBeta {
 		t.Error("expected beta/feature in lines")
+	}
+}
+
+func TestBuildCrossRepoWorktreeLines_UrgencyOrder(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	now := time.Now().UTC()
+	writeSessionStatus(t, home, "alpha", "busy", claude.StatusBusy, now)
+	writeSessionStatus(t, home, "beta", "done-unread", claude.StatusDone, now)
+	writeSessionStatus(t, home, "gamma", "wait", claude.StatusWait, now)
+
+	rwts := []repoWorktree{
+		{
+			Repo:     repoInfo{Name: "alpha", BareDir: "/repos/alpha.git"},
+			Worktree: worktree.Worktree{Branch: "busy", Path: "/wt/alpha/busy"},
+		},
+		{
+			Repo:     repoInfo{Name: "beta", BareDir: "/repos/beta.git"},
+			Worktree: worktree.Worktree{Branch: "done-unread", Path: "/wt/beta/done-unread"},
+		},
+		{
+			Repo:     repoInfo{Name: "gamma", BareDir: "/repos/gamma.git"},
+			Worktree: worktree.Worktree{Branch: "wait", Path: "/wt/gamma/wait"},
+		},
+	}
+
+	lines := buildCrossRepoWorktreeLines(rwts)
+	got := []string{
+		extractPathFromLine(lines[0]),
+		extractPathFromLine(lines[1]),
+		extractPathFromLine(lines[2]),
+	}
+	want := []string{
+		"/wt/gamma/wait",
+		"/wt/beta/done-unread",
+		"/wt/alpha/busy",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("path[%d] = %q, want %q (full order %v)", i, got[i], want[i], got)
+		}
 	}
 }

--- a/internal/gh/merged.go
+++ b/internal/gh/merged.go
@@ -1,0 +1,292 @@
+package gh
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+)
+
+const (
+	mergedWorktreeCacheTTL  = 30 * time.Second
+	mergedWorktreeBatchSize = 20
+	mergedWorktreeCacheDir  = "merged-worktrees"
+	mergedWorktreeSearchCap = 100
+	detachedBranchName      = "(detached)"
+)
+
+type mergedWorktreeCacheEntry struct {
+	CheckedAt   time.Time `json:"checked_at"`
+	Found       bool      `json:"found"`
+	Number      int       `json:"number,omitempty"`
+	State       string    `json:"state,omitempty"`
+	BaseRefName string    `json:"base_ref_name,omitempty"`
+	HeadRefOID  string    `json:"head_ref_oid,omitempty"`
+	MergedAt    string    `json:"merged_at,omitempty"`
+}
+
+type mergedWorktreeCache struct {
+	Entries map[string]mergedWorktreeCacheEntry `json:"entries"`
+}
+
+var (
+	mergedWorktreeNow = time.Now
+	mergedWorktreeCLI = func() bool {
+		_, err := exec.LookPath("gh")
+		return err == nil
+	}
+	mergedWorktreeSearchPRs = searchPRsByBranches
+	mergedWorktreeRepoKey   = repoCacheKey
+)
+
+// MergedWorktreeSet returns branches whose worktrees are safe to treat as
+// merged based on GitHub PR state. It is designed to augment git ancestry-
+// based merged detection and silently falls back to an empty set when `gh`
+// is unavailable or GitHub lookup fails.
+func MergedWorktreeSet(dir, base string, branchHeads map[string]string) map[string]bool {
+	set := make(map[string]bool)
+	if dir == "" || len(branchHeads) == 0 || !mergedWorktreeCLI() {
+		return set
+	}
+
+	now := mergedWorktreeNow()
+	cachePath := mergedWorktreeCachePath(dir, base)
+	cache := loadMergedWorktreeCache(cachePath)
+
+	eligibleHeads := make(map[string]string, len(branchHeads))
+	var pending []string
+	for branch, head := range branchHeads {
+		if branch == "" || branch == base || branch == detachedBranchName || head == "" {
+			continue
+		}
+
+		eligibleHeads[branch] = head
+		entry, ok := cache.Entries[branch]
+		if ok && now.Sub(entry.CheckedAt) < mergedWorktreeCacheTTL {
+			if entry.isMerged(base, head) {
+				set[branch] = true
+			}
+			continue
+		}
+
+		pending = append(pending, branch)
+	}
+
+	if len(pending) == 0 {
+		return set
+	}
+
+	sort.Strings(pending)
+	updated, _ := refreshMergedWorktreeCache(cache, dir, pending, now)
+	_ = saveMergedWorktreeCache(cachePath, updated)
+
+	for branch, head := range eligibleHeads {
+		entry, ok := updated.Entries[branch]
+		if !ok || now.Sub(entry.CheckedAt) >= mergedWorktreeCacheTTL {
+			continue
+		}
+		if entry.isMerged(base, head) {
+			set[branch] = true
+		}
+	}
+
+	return set
+}
+
+func (e mergedWorktreeCacheEntry) isMerged(base, head string) bool {
+	return e.Found &&
+		e.State == "MERGED" &&
+		e.BaseRefName == base &&
+		e.HeadRefOID == head
+}
+
+func refreshMergedWorktreeCache(cache mergedWorktreeCache, dir string, branches []string, now time.Time) (mergedWorktreeCache, error) {
+	updated := cache.clone()
+
+	for start := 0; start < len(branches); start += mergedWorktreeBatchSize {
+		end := start + mergedWorktreeBatchSize
+		if end > len(branches) {
+			end = len(branches)
+		}
+
+		batch := branches[start:end]
+		prs, err := mergedWorktreeSearchPRs(dir, batch)
+		if err != nil {
+			return updated, err
+		}
+
+		latest := latestPRsByBranch(batch, prs)
+		for _, branch := range batch {
+			entry := mergedWorktreeCacheEntry{CheckedAt: now}
+			if pr := latest[branch]; pr != nil {
+				entry.Found = true
+				entry.Number = pr.Number
+				entry.State = pr.State
+				entry.BaseRefName = pr.BaseRefName
+				entry.HeadRefOID = pr.HeadRefOID
+				entry.MergedAt = pr.MergedAt
+			}
+			updated.Entries[branch] = entry
+		}
+	}
+
+	return updated, nil
+}
+
+func latestPRsByBranch(branches []string, prs []*PRInfo) map[string]*PRInfo {
+	branchSet := make(map[string]bool, len(branches))
+	for _, branch := range branches {
+		branchSet[branch] = true
+	}
+
+	latest := make(map[string]*PRInfo, len(branches))
+	for _, pr := range prs {
+		if pr == nil || !branchSet[pr.Branch] {
+			continue
+		}
+		if current := latest[pr.Branch]; current == nil || pr.Number > current.Number {
+			latest[pr.Branch] = pr
+		}
+	}
+
+	return latest
+}
+
+func searchPRsByBranches(dir string, branches []string) ([]*PRInfo, error) {
+	if len(branches) == 0 {
+		return nil, nil
+	}
+
+	limit := mergedWorktreeSearchCap
+	if perBatch := len(branches) * 5; perBatch > limit {
+		limit = perBatch
+	}
+
+	args := []string{
+		"pr", "list",
+		"--search", buildMergedWorktreeSearch(branches),
+		"--state", "all",
+		"--json", prJSONFields,
+		"--limit", fmt.Sprintf("%d", limit),
+	}
+
+	cmd := exec.Command("gh", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GH_PROMPT_DISABLED=1",
+		"GH_NO_UPDATE_NOTIFIER=1",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return nil, fmt.Errorf("gh pr list failed: %s", msg)
+		}
+		return nil, fmt.Errorf("gh pr list failed: %w", err)
+	}
+
+	return parsePRListOutput(out)
+}
+
+func buildMergedWorktreeSearch(branches []string) string {
+	terms := make([]string, 0, len(branches))
+	for _, branch := range branches {
+		terms = append(terms, headSearchTerm(branch))
+	}
+	return strings.Join(terms, " OR ")
+}
+
+func headSearchTerm(branch string) string {
+	if strings.ContainsAny(branch, " \t\"") {
+		return fmt.Sprintf(`head:"%s"`, strings.ReplaceAll(branch, `"`, `\"`))
+	}
+	return "head:" + branch
+}
+
+func mergedWorktreeCachePath(dir, base string) string {
+	sum := sha256.Sum256([]byte(mergedWorktreeRepoKey(dir) + "\x00" + base))
+	return filepath.Join(config.WillowHome(), "cache", mergedWorktreeCacheDir, fmt.Sprintf("%x.json", sum[:]))
+}
+
+func repoCacheKey(dir string) string {
+	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return filepath.Clean(dir)
+	}
+
+	key := strings.TrimSpace(string(out))
+	if key == "" {
+		return filepath.Clean(dir)
+	}
+	if !filepath.IsAbs(key) {
+		key = filepath.Join(dir, key)
+	}
+	return filepath.Clean(key)
+}
+
+func loadMergedWorktreeCache(path string) mergedWorktreeCache {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return mergedWorktreeCache{Entries: make(map[string]mergedWorktreeCacheEntry)}
+	}
+
+	var cache mergedWorktreeCache
+	if err := json.Unmarshal(data, &cache); err != nil {
+		return mergedWorktreeCache{Entries: make(map[string]mergedWorktreeCacheEntry)}
+	}
+	if cache.Entries == nil {
+		cache.Entries = make(map[string]mergedWorktreeCacheEntry)
+	}
+	return cache
+}
+
+func saveMergedWorktreeCache(path string, cache mergedWorktreeCache) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(cache)
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+func (c mergedWorktreeCache) clone() mergedWorktreeCache {
+	cloned := mergedWorktreeCache{
+		Entries: make(map[string]mergedWorktreeCacheEntry, len(c.Entries)),
+	}
+	for branch, entry := range c.Entries {
+		cloned.Entries[branch] = entry
+	}
+	return cloned
+}

--- a/internal/gh/merged_test.go
+++ b/internal/gh/merged_test.go
@@ -1,0 +1,275 @@
+package gh
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestMergedWorktreeSet_MergeEligibility(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		base       string
+		branch     string
+		head       string
+		pr         *PRInfo
+		wantMerged bool
+	}{
+		{
+			name:   "merged pr with matching head sha",
+			base:   "master",
+			branch: "feature",
+			head:   "abc123",
+			pr: &PRInfo{
+				Number:      101,
+				Branch:      "feature",
+				HeadRefOID:  "abc123",
+				BaseRefName: "master",
+				State:       "MERGED",
+				MergedAt:    "2026-04-21T18:08:47Z",
+			},
+			wantMerged: true,
+		},
+		{
+			name:   "open pr is not merged",
+			base:   "master",
+			branch: "feature",
+			head:   "abc123",
+			pr: &PRInfo{
+				Number:      101,
+				Branch:      "feature",
+				HeadRefOID:  "abc123",
+				BaseRefName: "master",
+				State:       "OPEN",
+			},
+		},
+		{
+			name:   "merged pr against different base is ignored",
+			base:   "master",
+			branch: "feature",
+			head:   "abc123",
+			pr: &PRInfo{
+				Number:      101,
+				Branch:      "feature",
+				HeadRefOID:  "abc123",
+				BaseRefName: "develop",
+				State:       "MERGED",
+				MergedAt:    "2026-04-21T18:08:47Z",
+			},
+		},
+		{
+			name:   "merged pr with mismatched head sha is ignored",
+			base:   "master",
+			branch: "feature",
+			head:   "abc123",
+			pr: &PRInfo{
+				Number:      101,
+				Branch:      "feature",
+				HeadRefOID:  "def456",
+				BaseRefName: "master",
+				State:       "MERGED",
+				MergedAt:    "2026-04-21T18:08:47Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prepareMergedWorktreeTestEnv(t, now, func(_ string, branches []string) ([]*PRInfo, error) {
+				if len(branches) != 1 || branches[0] != tt.branch {
+					t.Fatalf("search branches = %v, want [%s]", branches, tt.branch)
+				}
+				if tt.pr == nil {
+					return nil, nil
+				}
+				return []*PRInfo{tt.pr}, nil
+			})
+
+			got := MergedWorktreeSet("/fake/repo", tt.base, map[string]string{
+				tt.branch: tt.head,
+			})
+			if got[tt.branch] != tt.wantMerged {
+				t.Fatalf("MergedWorktreeSet()[%q] = %v, want %v", tt.branch, got[tt.branch], tt.wantMerged)
+			}
+		})
+	}
+}
+
+func TestMergedWorktreeSet_NegativeResultsAreCached(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+	calls := 0
+
+	prepareMergedWorktreeTestEnv(t, now, func(_ string, branches []string) ([]*PRInfo, error) {
+		calls++
+		if len(branches) != 1 || branches[0] != "feature" {
+			t.Fatalf("search branches = %v, want [feature]", branches)
+		}
+		return nil, nil
+	})
+
+	heads := map[string]string{"feature": "abc123"}
+	first := MergedWorktreeSet("/fake/repo", "master", heads)
+	second := MergedWorktreeSet("/fake/repo", "master", heads)
+
+	if len(first) != 0 || len(second) != 0 {
+		t.Fatalf("expected no merged branches, got first=%v second=%v", first, second)
+	}
+	if calls != 1 {
+		t.Fatalf("search calls = %d, want 1", calls)
+	}
+}
+
+func TestMergedWorktreeSet_FreshCacheIsReused(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+	calls := 0
+
+	prepareMergedWorktreeTestEnv(t, now, func(_ string, branches []string) ([]*PRInfo, error) {
+		calls++
+		return []*PRInfo{{
+			Number:      101,
+			Branch:      "feature",
+			HeadRefOID:  "abc123",
+			BaseRefName: "master",
+			State:       "MERGED",
+			MergedAt:    "2026-04-21T18:08:47Z",
+		}}, nil
+	})
+
+	heads := map[string]string{"feature": "abc123"}
+	for i := 0; i < 2; i++ {
+		got := MergedWorktreeSet("/fake/repo", "master", heads)
+		if !got["feature"] {
+			t.Fatalf("call %d: expected feature to be merged, got %v", i+1, got)
+		}
+	}
+
+	if calls != 1 {
+		t.Fatalf("search calls = %d, want 1", calls)
+	}
+}
+
+func TestMergedWorktreeSet_StaleCacheRefreshes(t *testing.T) {
+	start := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+	current := start
+	calls := 0
+
+	prepareMergedWorktreeTestEnv(t, current, func(_ string, branches []string) ([]*PRInfo, error) {
+		calls++
+		if calls == 1 {
+			return nil, nil
+		}
+		return []*PRInfo{{
+			Number:      102,
+			Branch:      "feature",
+			HeadRefOID:  "abc123",
+			BaseRefName: "master",
+			State:       "MERGED",
+			MergedAt:    "2026-04-21T18:45:00Z",
+		}}, nil
+	})
+
+	mergedWorktreeNow = func() time.Time { return current }
+	heads := map[string]string{"feature": "abc123"}
+
+	if got := MergedWorktreeSet("/fake/repo", "master", heads); got["feature"] {
+		t.Fatalf("first call unexpectedly marked feature merged: %v", got)
+	}
+
+	current = start.Add(mergedWorktreeCacheTTL + time.Second)
+	got := MergedWorktreeSet("/fake/repo", "master", heads)
+	if !got["feature"] {
+		t.Fatalf("expected stale cache refresh to mark feature merged, got %v", got)
+	}
+	if calls != 2 {
+		t.Fatalf("search calls = %d, want 2", calls)
+	}
+}
+
+func TestMergedWorktreeSet_MissingBranchEntriesRefreshIndividually(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+	calls := 0
+
+	prepareMergedWorktreeTestEnv(t, now, func(_ string, branches []string) ([]*PRInfo, error) {
+		calls++
+		slices.Sort(branches)
+		switch calls {
+		case 1:
+			if !slices.Equal(branches, []string{"feature-a"}) {
+				t.Fatalf("first search branches = %v, want [feature-a]", branches)
+			}
+			return []*PRInfo{{
+				Number:      101,
+				Branch:      "feature-a",
+				HeadRefOID:  "sha-a",
+				BaseRefName: "master",
+				State:       "MERGED",
+				MergedAt:    "2026-04-21T18:08:47Z",
+			}}, nil
+		case 2:
+			if !slices.Equal(branches, []string{"feature-b"}) {
+				t.Fatalf("second search branches = %v, want [feature-b]", branches)
+			}
+			return []*PRInfo{{
+				Number:      102,
+				Branch:      "feature-b",
+				HeadRefOID:  "sha-b",
+				BaseRefName: "master",
+				State:       "MERGED",
+				MergedAt:    "2026-04-21T18:09:47Z",
+			}}, nil
+		default:
+			t.Fatalf("unexpected search call %d for branches %v", calls, branches)
+			return nil, nil
+		}
+	})
+
+	first := MergedWorktreeSet("/fake/repo", "master", map[string]string{
+		"feature-a": "sha-a",
+	})
+	if !first["feature-a"] {
+		t.Fatalf("expected feature-a to be merged, got %v", first)
+	}
+
+	second := MergedWorktreeSet("/fake/repo", "master", map[string]string{
+		"feature-a": "sha-a",
+		"feature-b": "sha-b",
+	})
+	if !second["feature-a"] || !second["feature-b"] {
+		t.Fatalf("expected both branches merged after refresh, got %v", second)
+	}
+	if calls != 2 {
+		t.Fatalf("search calls = %d, want 2", calls)
+	}
+}
+
+func prepareMergedWorktreeTestEnv(t *testing.T, now time.Time, search func(dir string, branches []string) ([]*PRInfo, error)) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origNow := mergedWorktreeNow
+	origCLI := mergedWorktreeCLI
+	origSearch := mergedWorktreeSearchPRs
+	origKey := mergedWorktreeRepoKey
+
+	mergedWorktreeNow = func() time.Time { return now }
+	mergedWorktreeCLI = func() bool { return true }
+	mergedWorktreeSearchPRs = search
+	mergedWorktreeRepoKey = func(string) string { return "test-repo" }
+
+	t.Cleanup(func() {
+		mergedWorktreeNow = origNow
+		mergedWorktreeCLI = origCLI
+		mergedWorktreeSearchPRs = origSearch
+		mergedWorktreeRepoKey = origKey
+	})
+
+	if err := os.MkdirAll(filepath.Join(home, ".willow", "cache"), 0o755); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+}

--- a/internal/gh/pr.go
+++ b/internal/gh/pr.go
@@ -18,7 +18,10 @@ type ghPR struct {
 	Number       int        `json:"number"`
 	Title        string     `json:"title"`
 	Branch       string     `json:"headRefName"`
+	HeadRefOID   string     `json:"headRefOid"`
+	BaseRefName  string     `json:"baseRefName"`
 	State        string     `json:"state"`
+	MergedAt     string     `json:"mergedAt"`
 	ReviewStatus string     `json:"reviewDecision"`
 	Mergeable    string     `json:"mergeable"`
 	Additions    int        `json:"additions"`
@@ -31,7 +34,10 @@ type PRInfo struct {
 	Number       int    `json:"number"`
 	Title        string `json:"title"`
 	Branch       string `json:"headRefName"`
-	State        string `json:"state"`         // OPEN, MERGED, CLOSED
+	HeadRefOID   string `json:"headRefOid"`
+	BaseRefName  string `json:"baseRefName"`
+	State        string `json:"state"` // OPEN, MERGED, CLOSED
+	MergedAt     string `json:"mergedAt"`
 	ReviewStatus string `json:"reviewDecision"` // APPROVED, CHANGES_REQUESTED, REVIEW_REQUIRED, ""
 	Mergeable    string `json:"mergeable"`      // MERGEABLE, CONFLICTING, UNKNOWN
 	Additions    int    `json:"additions"`
@@ -39,6 +45,8 @@ type PRInfo struct {
 	URL          string `json:"url"`
 	Checks       []checkRun
 }
+
+const prJSONFields = "number,title,headRefName,headRefOid,baseRefName,state,mergedAt,reviewDecision,mergeable,additions,deletions,url,statusCheckRollup"
 
 // CIStatus returns the aggregate CI status: "pass", "fail", "pending", or "none".
 func (p *PRInfo) CIStatus() string {
@@ -58,14 +66,51 @@ func (p *PRInfo) CIStatus() string {
 	return "pass"
 }
 
+func EnsureCLI(feature string) error {
+	if _, err := exec.LookPath("gh"); err != nil {
+		if feature != "" {
+			return errors.Userf("gh CLI required for %s (install: https://cli.github.com)", feature)
+		}
+		return errors.Userf("'gh' CLI not found — install it from https://cli.github.com")
+	}
+	return nil
+}
+
+func parsePRListOutput(out []byte) ([]*PRInfo, error) {
+	var prs []ghPR
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("failed to parse gh output: %w", err)
+	}
+
+	infos := make([]*PRInfo, 0, len(prs))
+	for _, pr := range prs {
+		infos = append(infos, &PRInfo{
+			Number:       pr.Number,
+			Title:        pr.Title,
+			Branch:       pr.Branch,
+			HeadRefOID:   pr.HeadRefOID,
+			BaseRefName:  pr.BaseRefName,
+			State:        pr.State,
+			MergedAt:     pr.MergedAt,
+			ReviewStatus: pr.ReviewStatus,
+			Mergeable:    pr.Mergeable,
+			Additions:    pr.Additions,
+			Deletions:    pr.Deletions,
+			URL:          pr.URL,
+			Checks:       pr.Checks,
+		})
+	}
+	return infos, nil
+}
+
 // BatchPRInfo fetches PR info for multiple branches in a single gh call.
 func BatchPRInfo(dir string, branches []string) (map[string]*PRInfo, error) {
-	if _, err := exec.LookPath("gh"); err != nil {
-		return nil, errors.Userf("gh CLI required for stack status (install: https://cli.github.com)")
+	if err := EnsureCLI("stack status"); err != nil {
+		return nil, err
 	}
 
 	cmd := exec.Command("gh", "pr", "list",
-		"--json", "number,title,headRefName,state,reviewDecision,mergeable,additions,deletions,url,statusCheckRollup",
+		"--json", prJSONFields,
 		"--limit", "100",
 		"--state", "all",
 	)
@@ -75,9 +120,9 @@ func BatchPRInfo(dir string, branches []string) (map[string]*PRInfo, error) {
 		return nil, fmt.Errorf("gh pr list failed: %w", err)
 	}
 
-	var prs []ghPR
-	if err := json.Unmarshal(out, &prs); err != nil {
-		return nil, fmt.Errorf("failed to parse gh output: %w", err)
+	prs, err := parsePRListOutput(out)
+	if err != nil {
+		return nil, err
 	}
 
 	branchSet := make(map[string]bool, len(branches))
@@ -88,18 +133,7 @@ func BatchPRInfo(dir string, branches []string) (map[string]*PRInfo, error) {
 	result := make(map[string]*PRInfo)
 	for _, pr := range prs {
 		if branchSet[pr.Branch] {
-			result[pr.Branch] = &PRInfo{
-				Number:       pr.Number,
-				Title:        pr.Title,
-				Branch:       pr.Branch,
-				State:        pr.State,
-				ReviewStatus: pr.ReviewStatus,
-				Mergeable:    pr.Mergeable,
-				Additions:    pr.Additions,
-				Deletions:    pr.Deletions,
-				URL:          pr.URL,
-				Checks:       pr.Checks,
-			}
+			result[pr.Branch] = pr
 		}
 	}
 	return result, nil

--- a/internal/gh/pr_test.go
+++ b/internal/gh/pr_test.go
@@ -148,3 +148,44 @@ func TestGHPRJSONParsing(t *testing.T) {
 		t.Errorf("PR2 Checks count = %d, want 0", len(pr2.Checks))
 	}
 }
+
+func TestParsePRListOutput(t *testing.T) {
+	raw := `[
+		{
+			"number": 42,
+			"title": "Add feature X",
+			"headRefName": "feature-x",
+			"state": "OPEN",
+			"reviewDecision": "APPROVED",
+			"mergeable": "MERGEABLE",
+			"additions": 100,
+			"deletions": 20,
+			"url": "https://github.com/org/repo/pull/42",
+			"statusCheckRollup": [
+				{"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"}
+			]
+		}
+	]`
+
+	prs, err := parsePRListOutput([]byte(raw))
+	if err != nil {
+		t.Fatalf("parsePRListOutput() error = %v", err)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 PR, got %d", len(prs))
+	}
+
+	pr := prs[0]
+	if pr.Number != 42 {
+		t.Errorf("Number = %d, want 42", pr.Number)
+	}
+	if pr.Branch != "feature-x" {
+		t.Errorf("Branch = %q, want feature-x", pr.Branch)
+	}
+	if pr.URL != "https://github.com/org/repo/pull/42" {
+		t.Errorf("URL = %q, want pull URL", pr.URL)
+	}
+	if len(pr.Checks) != 1 || pr.Checks[0].Name != "test" {
+		t.Errorf("Checks = %+v, want one test check", pr.Checks)
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -150,11 +150,15 @@ func (g *Git) MergedBranches(base string) ([]string, error) {
 // `git branch --merged`, which scans every local ref and would take
 // hundreds of ms on repos with thousands of branches. Excludes trivial
 // forks whose tip SHA equals origin/<base> (same filter as MergedBranches).
+// The origin/<base> ref is included in the query so we can reuse its SHA
+// without spawning a second git process.
 func (g *Git) MergedBranchSet(base string, branches []string) map[string]bool {
 	if len(branches) == 0 {
 		return map[string]bool{}
 	}
 	args := []string{"for-each-ref", "--merged=origin/" + base, "--format=%(refname:short) %(objectname)"}
+	baseRef := "refs/remotes/origin/" + base
+	args = append(args, baseRef)
 	for _, b := range branches {
 		args = append(args, "refs/heads/"+b)
 	}
@@ -162,8 +166,14 @@ func (g *Git) MergedBranchSet(base string, branches []string) map[string]bool {
 	if err != nil || out == "" {
 		return map[string]bool{}
 	}
-	baseSHA, _ := g.Run("rev-parse", "origin/"+base)
-	set := make(map[string]bool)
+
+	baseName := "origin/" + base
+	baseSHA := ""
+	type refInfo struct {
+		name string
+		sha  string
+	}
+	refs := make([]refInfo, 0, len(branches))
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -173,13 +183,22 @@ func (g *Git) MergedBranchSet(base string, branches []string) map[string]bool {
 		if !ok {
 			continue
 		}
+		if name == baseName {
+			baseSHA = sha
+			continue
+		}
 		if name == base {
 			continue
 		}
-		if baseSHA != "" && sha == baseSHA {
+		refs = append(refs, refInfo{name: name, sha: sha})
+	}
+
+	set := make(map[string]bool, len(refs))
+	for _, ref := range refs {
+		if baseSHA != "" && ref.sha == baseSHA {
 			continue
 		}
-		set[name] = true
+		set[ref.name] = true
 	}
 	return set
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -210,6 +210,31 @@ func TestMergedBranchSet_FiltersToGivenBranches(t *testing.T) {
 	}
 }
 
+func TestMergedBranchSet_ExcludesTrivialBranchesAtBaseTip(t *testing.T) {
+	work := setupRemoteAndClone(t, "main")
+	g := &Git{Dir: work}
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = work
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	runGit("branch", "wt-trivial", "origin/main")
+
+	set := g.MergedBranchSet("main", []string{"wt-trivial"})
+	if set["wt-trivial"] {
+		t.Errorf("wt-trivial should be excluded as a zero-commit branch, got %v", set)
+	}
+}
+
 func TestMergedBranchSet_EmptyInput(t *testing.T) {
 	work := setupRemoteAndClone(t, "main")
 	g := &Git{Dir: work}

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
@@ -37,6 +38,12 @@ type PickerItem struct {
 	Sessions    []*claude.SessionStatus
 	Merged      bool
 	StackPrefix string // tree-drawing prefix for stacked branches (e.g., "├─ ")
+}
+
+type pickerGroup struct {
+	items    []PickerItem
+	merged   bool
+	priority int
 }
 
 func BuildPickerItems(ctx context.Context, repoFilter string) ([]PickerItem, error) {
@@ -72,14 +79,24 @@ func BuildPickerItems(ctx context.Context, repoFilter string) ([]PickerItem, err
 		}
 
 		cfg := config.Load(bareDir)
+		baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
 		branches := make([]string, 0, len(wts))
+		branchHeads := make(map[string]string, len(wts))
+		repoDir := ""
 		for _, wt := range wts {
 			if !wt.IsBare && wt.Branch != "" {
+				if repoDir == "" {
+					repoDir = wt.Path
+				}
 				branches = append(branches, wt.Branch)
+				branchHeads[wt.Branch] = wt.Head
 			}
 		}
 		done = trace.Span(ctx, "MergedBranchSet/"+repoName)
-		mergedSet := repoGit.MergedBranchSet(repoGit.ResolveBaseBranch(cfg.BaseBranch), branches)
+		mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
+		for branch := range gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads) {
+			mergedSet[branch] = true
+		}
 		done()
 
 		done = trace.Span(ctx, "per-wt-loop/"+repoName)
@@ -106,66 +123,127 @@ func BuildPickerItems(ctx context.Context, repoFilter string) ([]PickerItem, err
 		done()
 	}
 
-	done := trace.Span(ctx, "applyStackOrder")
-	items = applyStackOrder(items, repoNames)
+	done := trace.Span(ctx, "sortPickerItems")
+	items = sortPickerItems(items, repoNames, defaultPickerStackLoader)
 	done()
 
 	return items, nil
 }
 
-func applyStackOrder(items []PickerItem, repoNames []string) []PickerItem {
-	branchSet := make(map[string]bool)
+type pickerStackLoader func(repoName string) *stack.Stack
+
+func defaultPickerStackLoader(repoName string) *stack.Stack {
+	bareDir, err := config.ResolveRepo(repoName)
+	if err != nil {
+		return nil
+	}
+	return stack.Load(bareDir)
+}
+
+func sortPickerItems(items []PickerItem, repoNames []string, loadStack pickerStackLoader) []PickerItem {
+	groups := buildPickerGroups(items, repoNames, loadStack)
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].merged != groups[j].merged {
+			return !groups[i].merged
+		}
+		return groups[i].priority < groups[j].priority
+	})
+
+	var result []PickerItem
+	for _, group := range groups {
+		result = append(result, group.items...)
+	}
+	return result
+}
+
+func buildPickerGroups(items []PickerItem, repoNames []string, loadStack pickerStackLoader) []pickerGroup {
+	if loadStack == nil {
+		loadStack = func(string) *stack.Stack { return nil }
+	}
+
+	repoBranchSets := make(map[string]map[string]bool)
 	for _, item := range items {
+		branchSet := repoBranchSets[item.RepoName]
+		if branchSet == nil {
+			branchSet = make(map[string]bool)
+			repoBranchSets[item.RepoName] = branchSet
+		}
 		branchSet[item.Branch] = true
 	}
 
 	itemMap := make(map[string]*PickerItem)
 	for i := range items {
-		key := items[i].RepoName + "/" + items[i].Branch
+		key := pickerItemKey(items[i].RepoName, items[i].Branch)
 		itemMap[key] = &items[i]
 	}
 
-	stackedKeys := make(map[string]bool)
-	var stackedItems []PickerItem
+	groupedKeys := make(map[string]bool)
+	var groups []pickerGroup
 
 	for _, repoName := range repoNames {
-		bareDir, err := config.ResolveRepo(repoName)
-		if err != nil {
+		branchSet := repoBranchSets[repoName]
+		if len(branchSet) == 0 {
 			continue
 		}
-		st := stack.Load(bareDir)
-		if st.IsEmpty() {
+		st := loadStack(repoName)
+		if st == nil || st.IsEmpty() {
 			continue
 		}
 
 		treeLines := st.TreeLines(branchSet)
+		prefixByBranch := make(map[string]string, len(treeLines))
 		for _, tl := range treeLines {
-			key := repoName + "/" + tl.Branch
-			if item, ok := itemMap[key]; ok {
-				item.StackPrefix = tl.Prefix
-				stackedKeys[key] = true
-				stackedItems = append(stackedItems, *item)
+			prefixByBranch[tl.Branch] = tl.Prefix
+		}
+
+		for _, root := range st.Roots() {
+			var groupItems []PickerItem
+			for _, branch := range st.SubtreeSort(root) {
+				key := pickerItemKey(repoName, branch)
+				item, ok := itemMap[key]
+				if !ok {
+					continue
+				}
+				item.StackPrefix = prefixByBranch[branch]
+				groupedKeys[key] = true
+				groupItems = append(groupItems, *item)
+			}
+			if len(groupItems) > 0 {
+				groups = append(groups, newPickerGroup(groupItems))
 			}
 		}
 	}
 
-	var nonStacked []PickerItem
 	for _, item := range items {
-		key := item.RepoName + "/" + item.Branch
-		if !stackedKeys[key] {
-			nonStacked = append(nonStacked, item)
+		key := pickerItemKey(item.RepoName, item.Branch)
+		if !groupedKeys[key] {
+			groups = append(groups, newPickerGroup([]PickerItem{item}))
 		}
 	}
 
-	sort.SliceStable(nonStacked, func(i, j int) bool {
-		if nonStacked[i].Merged != nonStacked[j].Merged {
-			return !nonStacked[i].Merged
-		}
-		return claude.StatusOrder(nonStacked[i].Status) < claude.StatusOrder(nonStacked[j].Status)
-	})
+	return groups
+}
 
-	result := append(stackedItems, nonStacked...)
-	return result
+func newPickerGroup(items []PickerItem) pickerGroup {
+	group := pickerGroup{
+		items:    items,
+		merged:   true,
+		priority: claude.WorktreeUrgencyOrder(claude.StatusOffline, false),
+	}
+	for _, item := range items {
+		if !item.Merged {
+			group.merged = false
+		}
+		priority := claude.WorktreeUrgencyOrder(item.Status, item.Unread)
+		if priority < group.priority {
+			group.priority = priority
+		}
+	}
+	return group
+}
+
+func pickerItemKey(repoName, branch string) string {
+	return repoName + "/" + branch
 }
 
 // FormatPickerLines produces ANSI-colored lines for the fzf picker.

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/stack"
 )
 
 func TestStripAnsi(t *testing.T) {
@@ -112,7 +113,6 @@ func TestStatusColor(t *testing.T) {
 		})
 	}
 }
-
 
 func TestDisplayName(t *testing.T) {
 	item := PickerItem{RepoName: "myrepo", Branch: "feat-auth"}
@@ -247,5 +247,107 @@ func TestExtractPathFromLine(t *testing.T) {
 				t.Errorf("ExtractPathFromLine() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func pickerStack(pairs ...string) *stack.Stack {
+	st := &stack.Stack{Parents: make(map[string]string)}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		st.Parents[pairs[i]] = pairs[i+1]
+	}
+	return st
+}
+
+func pickerLoader(stacks map[string]*stack.Stack) pickerStackLoader {
+	return func(repoName string) *stack.Stack {
+		return stacks[repoName]
+	}
+}
+
+func pickerBranches(items []PickerItem) []string {
+	branches := make([]string, len(items))
+	for i, item := range items {
+		branches[i] = item.Branch
+	}
+	return branches
+}
+
+func TestSortPickerItems_UrgencyOrder(t *testing.T) {
+	items := []PickerItem{
+		{RepoName: "repo", Branch: "busy", Status: claude.StatusBusy},
+		{RepoName: "repo", Branch: "done-unread", Status: claude.StatusDone, Unread: true},
+		{RepoName: "repo", Branch: "wait", Status: claude.StatusWait},
+		{RepoName: "repo", Branch: "done-read", Status: claude.StatusDone},
+		{RepoName: "repo", Branch: "idle", Status: claude.StatusIdle},
+		{RepoName: "repo", Branch: "offline", Status: claude.StatusOffline},
+	}
+
+	got := pickerBranches(sortPickerItems(items, []string{"repo"}, pickerLoader(nil)))
+	want := []string{"wait", "done-unread", "busy", "done-read", "idle", "offline"}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("branch[%d] = %q, want %q (full order %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSortPickerItems_MergedLast(t *testing.T) {
+	items := []PickerItem{
+		{RepoName: "repo", Branch: "merged-wait", Status: claude.StatusWait, Merged: true},
+		{RepoName: "repo", Branch: "busy", Status: claude.StatusBusy},
+	}
+
+	got := pickerBranches(sortPickerItems(items, []string{"repo"}, pickerLoader(nil)))
+	want := []string{"busy", "merged-wait"}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("branch[%d] = %q, want %q (full order %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSortPickerItems_StackStaysContiguousAndRanksByUrgency(t *testing.T) {
+	items := []PickerItem{
+		{RepoName: "repo", Branch: "busy", Status: claude.StatusBusy},
+		{RepoName: "repo", Branch: "stack-a", Status: claude.StatusIdle},
+		{RepoName: "repo", Branch: "stack-b", Status: claude.StatusWait},
+		{RepoName: "repo", Branch: "done-read", Status: claude.StatusDone},
+	}
+
+	got := sortPickerItems(items, []string{"repo"}, pickerLoader(map[string]*stack.Stack{
+		"repo": pickerStack("stack-a", "main", "stack-b", "stack-a"),
+	}))
+
+	want := []string{"stack-a", "stack-b", "busy", "done-read"}
+	branches := pickerBranches(got)
+	for i := range want {
+		if branches[i] != want[i] {
+			t.Fatalf("branch[%d] = %q, want %q (full order %v)", i, branches[i], want[i], branches)
+		}
+	}
+	if got[0].StackPrefix != "" {
+		t.Fatalf("root stack prefix = %q, want empty", got[0].StackPrefix)
+	}
+	if got[1].StackPrefix == "" {
+		t.Fatal("child stack prefix should be preserved")
+	}
+}
+
+func TestSortPickerItems_EqualPriorityKeepsStableOrder(t *testing.T) {
+	items := []PickerItem{
+		{RepoName: "repo", Branch: "busy-a", Status: claude.StatusBusy},
+		{RepoName: "repo", Branch: "busy-b", Status: claude.StatusBusy},
+		{RepoName: "repo", Branch: "busy-c", Status: claude.StatusBusy},
+	}
+
+	got := pickerBranches(sortPickerItems(items, []string{"repo"}, pickerLoader(nil)))
+	want := []string{"busy-a", "busy-b", "busy-c"}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("branch[%d] = %q, want %q (full order %v)", i, got[i], want[i], got)
+		}
 	}
 }

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -112,17 +112,17 @@ ww checkout auth-refactor                # auto-cd via shell integration (tmux-a
 
 ### `ww sw`
 
-Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by activity.
+Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by urgency: `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline.
 
 ```
-🤖 BUSY   auth-refactor        <willow-base>/worktrees/repo/auth-refactor
-✅ DONE   api-cleanup          <willow-base>/worktrees/repo/api-cleanup
 ⏳ WAIT   payments             <willow-base>/worktrees/repo/payments
+✅ DONE●  api-cleanup          <willow-base>/worktrees/repo/api-cleanup
+🤖 BUSY   auth-refactor        <willow-base>/worktrees/repo/auth-refactor
 🟡 IDLE   main                 <willow-base>/worktrees/repo/main
    --     old-feature          <willow-base>/worktrees/repo/old-feature
 ```
 
-Active agents sorted first, offline sorted last. Pass a name to skip the picker: `ww sw auth-refactor`.
+Pass a name to skip the picker: `ww sw auth-refactor`.
 
 | Flag | Description | Default |
 |------|-------------|---------|
@@ -157,11 +157,13 @@ List worktrees with status.
 
 ```
   BRANCH               STATUS  PATH                                        AGE
-  main                 IDLE    <willow-base>/worktrees/myrepo/main         3d
-  auth-refactor        BUSY    <willow-base>/worktrees/myrepo/auth-refactor 2h
   payments             WAIT    <willow-base>/worktrees/myrepo/payments     1d
+  auth-refactor        BUSY    <willow-base>/worktrees/myrepo/auth-refactor 2h
+  main                 IDLE    <willow-base>/worktrees/myrepo/main         3d
   old-feature          --      <willow-base>/worktrees/myrepo/old-feature  5m
 ```
+
+Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and merged worktrees at the bottom.
 
 When run outside a willow repo, lists all repos and their worktree counts.
 
@@ -344,7 +346,7 @@ ww gc --prune --dry-run  # list what --prune would remove
 | `--prune` | Interactively remove merged worktrees | `false` |
 | `--dry-run` | Show what would be cleaned up without removing anything | `false` |
 
-Without `--prune`, willow only empties the trash directory and prints the commands you'd run to remove each merged worktree. With `--prune`, it reads `branches.json` across all repos, cross-references `git branch --merged`, and prompts before removing each one.
+Without `--prune`, willow only empties the trash directory and prints the commands you'd run to remove each merged worktree. With `--prune`, it checks both Git ancestry and, when `gh` is available, merged GitHub PR state so squash/rebase-merged branches still show up for cleanup. If `gh` is missing or lookup fails, willow falls back to Git-only detection.
 
 ## Agents
 

--- a/website/src/app/(docs)/guide/page.mdx
+++ b/website/src/app/(docs)/guide/page.mdx
@@ -26,7 +26,7 @@ go install github.com/iamrajjoshi/willow/cmd/willow@latest
 
 - [git](https://git-scm.com/)
 - [tmux](https://github.com/tmux/tmux) — optional, for the `ww tmux` picker popup
-- [gh](https://cli.github.com/) — optional, required for `ww new --pr` and `ww stack status`
+- [gh](https://cli.github.com/) — optional, required for `ww new --pr`, `ww stack status`, and GitHub-aware merged worktree detection
 
 fzf is compiled into the willow binary, so no separate install is needed.
 

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -57,15 +57,17 @@ Press `Ctrl-E` to open a secondary picker showing all remote branches that don't
 
 ### Merged worktree indicator
 
-Worktrees whose branches have been merged into the base branch show a dim `[merged]` tag. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session and any merged worktrees with local changes, unpushed commits, or stacked children are skipped), or use `ww gc --prune`.
+Worktrees whose branches have been merged into the base branch show a dim `[merged]` tag. When `gh` is available, this also covers branches whose latest PR was merged on GitHub via squash/rebase. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session and any merged worktrees with local changes, unpushed commits, or stacked children are skipped), or use `ww gc --prune`.
 
 ### Features
 
 - **Auto-refresh** — the list reloads every 2 seconds with fresh agent status
 - **Auto-navigate** — opens with the cursor on your current session
+- **Urgency sort** — current session first, then `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline
 - **Status colors** — BUSY (green), WAIT (red), DONE (blue), IDLE (yellow)
 - **Unread indicator** — `●` marks completed sessions you haven't viewed
-- **Merged indicator** — `[merged]` marks worktrees whose branches are merged
+- **Merged indicator** — `[merged]` marks worktrees whose branches are merged, including GitHub-merged PRs when `gh` is available
+- **Stack-aware ordering** — stacked branches stay grouped together and inherit the most urgent item in the tree
 - **Multi-Claude sub-rows** — when a worktree has multiple active Claude sessions, each is shown as an indented sub-row with its own status and tool info
 - **Embedded fzf** — fzf is compiled into the willow binary, no external `fzf` dependency needed
 


### PR DESCRIPTION
## Description of the change
Closes #138 by changing worktree-focused views to prioritize urgent items first, keeping stack trees contiguous, and using GitHub PR state to recognize squash/rebase-merged worktrees across `ww tmux`, `ww ls`, `ww sw`, and `ww gc`.

**Ticket:**

## Test plan
Ran `go test ./... -count=1`.

## Loom or screenshots

## Considerations
