### PR TITLE
:sparkles: feat[tmux]: bulk prune merged picker worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by
 
 Remove a worktree. Without arguments, opens fzf picker with multi-select (TAB to toggle, Ctrl-A to select all).
 
+From the tmux picker, `Ctrl-D` removes the selected worktree and `Ctrl-X` bulk-removes safe merged worktrees currently shown in the picker, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
+
 ```bash
 ww rm auth-refactor              # direct removal
 ww rm                            # fzf picker

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/tmux"
 )
 
 // setupTestEnv creates a fake HOME with an "origin" git repo to clone from.
@@ -304,6 +305,143 @@ func TestRm_KeepBranch(t *testing.T) {
 	out, _ := repoGit.Run("branch", "--list", "keep-me")
 	if out == "" {
 		t.Error("branch 'keep-me' should still exist with --keep-branch")
+	}
+}
+
+func TestFilterMergedDeleteCandidates_SkipsUnsafeWorktrees(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, err := os.ReadDir(worktreeDir)
+	if err != nil {
+		t.Fatalf("read worktrees dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 initial worktree, got %d", len(entries))
+	}
+
+	mainBranch := entries[0].Name()
+	mainDir := filepath.Join(worktreeDir, mainBranch)
+	os.Chdir(mainDir)
+
+	mainGit := &git.Git{Dir: mainDir}
+	if _, err := mainGit.Run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("git config email: %v", err)
+	}
+	if _, err := mainGit.Run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("git config name: %v", err)
+	}
+
+	createMergedBranch := func(branch string, pushBranch, dirtyAfterMerge, unsetUpstream bool) string {
+		t.Helper()
+
+		if err := runApp("new", branch, "--no-fetch"); err != nil {
+			t.Fatalf("new %s failed: %v", branch, err)
+		}
+
+		wtPath := filepath.Join(worktreeDir, branch)
+		wtGit := &git.Git{Dir: wtPath}
+		file := filepath.Join(wtPath, branch+".txt")
+		if err := os.WriteFile(file, []byte(branch+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", file, err)
+		}
+		if _, err := wtGit.Run("add", "."); err != nil {
+			t.Fatalf("git add %s: %v", branch, err)
+		}
+		if _, err := wtGit.Run("commit", "-m", "add "+branch); err != nil {
+			t.Fatalf("git commit %s: %v", branch, err)
+		}
+		if pushBranch {
+			if _, err := wtGit.Run("push", "-u", "origin", branch); err != nil {
+				t.Fatalf("git push %s: %v", branch, err)
+			}
+		}
+		if _, err := mainGit.Run("merge", "--no-ff", branch, "-m", "merge "+branch); err != nil {
+			t.Fatalf("git merge %s: %v", branch, err)
+		}
+		if _, err := mainGit.Run("push", "origin", mainBranch); err != nil {
+			t.Fatalf("git push %s: %v", mainBranch, err)
+		}
+		if dirtyAfterMerge {
+			if err := os.WriteFile(file, []byte(branch+"\ndirty\n"), 0o644); err != nil {
+				t.Fatalf("dirty write %s: %v", file, err)
+			}
+		}
+		if unsetUpstream {
+			if _, err := wtGit.Run("branch", "--unset-upstream"); err != nil {
+				t.Fatalf("unset upstream %s: %v", branch, err)
+			}
+		}
+		return wtPath
+	}
+
+	safePath := createMergedBranch("safe-merged", true, false, false)
+	dirtyPath := createMergedBranch("dirty-merged", true, true, false)
+	unpushedPath := createMergedBranch("unpushed-merged", false, false, true)
+
+	if err := runApp("new", "stack-parent", "--no-fetch"); err != nil {
+		t.Fatalf("new stack-parent failed: %v", err)
+	}
+	parentPath := filepath.Join(worktreeDir, "stack-parent")
+	parentGit := &git.Git{Dir: parentPath}
+	parentFile := filepath.Join(parentPath, "stack-parent.txt")
+	if err := os.WriteFile(parentFile, []byte("stack parent\n"), 0o644); err != nil {
+		t.Fatalf("write stack-parent: %v", err)
+	}
+	if _, err := parentGit.Run("add", "."); err != nil {
+		t.Fatalf("git add stack-parent: %v", err)
+	}
+	if _, err := parentGit.Run("commit", "-m", "add stack-parent"); err != nil {
+		t.Fatalf("git commit stack-parent: %v", err)
+	}
+	if _, err := parentGit.Run("push", "-u", "origin", "stack-parent"); err != nil {
+		t.Fatalf("git push stack-parent: %v", err)
+	}
+
+	if err := runApp("new", "stack-child", "-b", "stack-parent", "--no-fetch"); err != nil {
+		t.Fatalf("new stack-child failed: %v", err)
+	}
+	if _, err := mainGit.Run("merge", "--no-ff", "stack-parent", "-m", "merge stack-parent"); err != nil {
+		t.Fatalf("git merge stack-parent: %v", err)
+	}
+	if _, err := mainGit.Run("push", "origin", mainBranch); err != nil {
+		t.Fatalf("git push %s: %v", mainBranch, err)
+	}
+
+	items := []tmux.PickerItem{
+		{RepoName: "testrepo", Branch: "safe-merged", WtDirName: "safe-merged", WtPath: safePath},
+		{RepoName: "testrepo", Branch: "dirty-merged", WtDirName: "dirty-merged", WtPath: dirtyPath},
+		{RepoName: "testrepo", Branch: "unpushed-merged", WtDirName: "unpushed-merged", WtPath: unpushedPath},
+		{RepoName: "testrepo", Branch: "stack-parent", WtDirName: "stack-parent", WtPath: parentPath},
+	}
+
+	safe, skipped, err := filterMergedDeleteCandidates(items)
+	if err != nil {
+		t.Fatalf("filterMergedDeleteCandidates failed: %v", err)
+	}
+
+	if got := branches(safe); len(got) != 1 || got[0] != "safe-merged" {
+		t.Fatalf("safe branches = %v, want [safe-merged]", got)
+	}
+
+	reasons := make(map[string]string)
+	for _, skip := range skipped {
+		reasons[skip.Item.Branch] = skip.Reason
+	}
+
+	if !strings.Contains(reasons["dirty-merged"], "uncommitted changes") {
+		t.Fatalf("dirty-merged reason = %q, want uncommitted changes", reasons["dirty-merged"])
+	}
+	if !strings.Contains(reasons["unpushed-merged"], "unpushed commits") {
+		t.Fatalf("unpushed-merged reason = %q, want unpushed commits", reasons["unpushed-merged"])
+	}
+	if !strings.Contains(reasons["stack-parent"], "stacked children: stack-child") {
+		t.Fatalf("stack-parent reason = %q, want stacked child", reasons["stack-parent"])
 	}
 }
 

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -100,8 +101,8 @@ func tmuxPickCmd() *cli.Command {
 					fzf.WithNoSort(),
 					fzf.WithDelimiter("\\|"),
 					fzf.WithNth("1,2"),
-					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-B: Stacked | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-G: Dispatch | Ctrl-S: Sync | Ctrl-D: Delete"),
-					fzf.WithExpectKeys("ctrl-n", "ctrl-b", "ctrl-e", "ctrl-p", "ctrl-g", "ctrl-s", "ctrl-d"),
+					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-B: Stacked | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-G: Dispatch | Ctrl-S: Sync | Ctrl-D: Delete | Ctrl-X: Prune merged"),
+					fzf.WithExpectKeys("ctrl-n", "ctrl-b", "ctrl-e", "ctrl-p", "ctrl-g", "ctrl-s", "ctrl-d", "ctrl-x"),
 					fzf.WithPrintQuery(),
 					fzf.WithBind(startBind),
 				}
@@ -177,6 +178,14 @@ func tmuxPickCmd() *cli.Command {
 					if err := tmuxPickDelete(self, result.Selection, items); err != nil {
 						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 					}
+					continue
+
+				case "ctrl-x":
+					if err := tmuxPickDeleteMerged(self, curSess, items); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+					}
+					fmt.Fprintf(os.Stderr, "\nPress Enter to return to picker...\n")
+					fmt.Fscanln(os.Stdin)
 					continue
 
 				default:
@@ -588,6 +597,189 @@ func tmuxPickDelete(self, selection string, items []tmux.PickerItem) error {
 		return fmt.Errorf("worktree not found: %s", wtPath)
 	}
 
+	return tmuxPickDeleteItem(self, *item)
+}
+
+func tmuxPickDeleteMerged(self, currentSession string, items []tmux.PickerItem) error {
+	candidates, skippedCurrent := mergedDeleteCandidates(items, currentSession)
+	if len(candidates) == 0 {
+		if skippedCurrent {
+			return errors.Userf("no merged worktrees available to delete (current session skipped)")
+		}
+		return errors.Userf("no merged worktrees available to delete")
+	}
+
+	safe, skipped, err := filterMergedDeleteCandidates(candidates)
+	if err != nil {
+		return err
+	}
+
+	multiRepo := mergedDeleteHasMultipleRepos(items)
+	if len(safe) == 0 {
+		if skippedCurrent {
+			fmt.Fprintln(os.Stderr, "Skipping the active tmux session's worktree.")
+		}
+		if len(skipped) > 0 {
+			fmt.Fprintln(os.Stderr, "Skipping unsafe merged worktrees:")
+			for _, skip := range skipped {
+				fmt.Fprintf(os.Stderr, "  %s (%s)\n", mergedDeleteLabel(skip.Item, multiRepo), skip.Reason)
+			}
+		}
+		return errors.Userf("no safe merged worktrees available to delete")
+	}
+
+	fmt.Fprintf(os.Stderr, "Remove %d merged worktree(s)?\n", len(safe))
+	for _, item := range safe {
+		fmt.Fprintf(os.Stderr, "  %s\n", mergedDeleteLabel(item, multiRepo))
+	}
+	if skippedCurrent {
+		fmt.Fprintln(os.Stderr, "\nSkipping the active tmux session's worktree.")
+	}
+	if len(skipped) > 0 {
+		fmt.Fprintln(os.Stderr, "\nSkipping unsafe merged worktrees:")
+		for _, skip := range skipped {
+			fmt.Fprintf(os.Stderr, "  %s (%s)\n", mergedDeleteLabel(skip.Item, multiRepo), skip.Reason)
+		}
+	}
+
+	fmt.Fprint(os.Stderr, "\nProceed? [y/N] ")
+	answer := readTrimmedStdinLine()
+	if answer != "y" && answer != "Y" {
+		fmt.Fprintln(os.Stderr, "Aborted.")
+		return nil
+	}
+
+	failures := 0
+	for _, item := range safe {
+		fmt.Fprintf(os.Stderr, "Removing %s...\n", mergedDeleteLabel(item, multiRepo))
+		if err := tmuxPickDeleteItem(self, item); err != nil {
+			failures++
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", mergedDeleteLabel(item, multiRepo), err)
+		}
+	}
+	if failures > 0 {
+		return fmt.Errorf("failed to remove %d merged worktree(s)", failures)
+	}
+
+	fmt.Fprintf(os.Stderr, "Removed %d merged worktree(s).\n", len(safe))
+	return nil
+}
+
+type mergedDeleteSkip struct {
+	Item   tmux.PickerItem
+	Reason string
+}
+
+func filterMergedDeleteCandidates(items []tmux.PickerItem) ([]tmux.PickerItem, []mergedDeleteSkip, error) {
+	bareDirs := make(map[string]string)
+	stacks := make(map[string]*stack.Stack)
+	var safe []tmux.PickerItem
+	var skipped []mergedDeleteSkip
+
+	for _, item := range items {
+		bareDir, ok := bareDirs[item.RepoName]
+		if !ok {
+			resolved, err := config.ResolveRepo(item.RepoName)
+			if err != nil {
+				return nil, nil, err
+			}
+			bareDir = resolved
+			bareDirs[item.RepoName] = bareDir
+			stacks[item.RepoName] = stack.Load(bareDir)
+		}
+
+		reason, err := mergedDeleteSkipReason(item, stacks[item.RepoName])
+		if err != nil {
+			return nil, nil, err
+		}
+		if reason != "" {
+			skipped = append(skipped, mergedDeleteSkip{Item: item, Reason: reason})
+			continue
+		}
+		safe = append(safe, item)
+	}
+
+	return safe, skipped, nil
+}
+
+func mergedDeleteCandidates(items []tmux.PickerItem, currentSession string) ([]tmux.PickerItem, bool) {
+	var candidates []tmux.PickerItem
+	skippedCurrent := false
+	for _, item := range items {
+		if !item.Merged {
+			continue
+		}
+		if currentSession != "" && tmux.SessionNameForWorktree(item.RepoName, item.WtDirName) == currentSession {
+			skippedCurrent = true
+			continue
+		}
+		candidates = append(candidates, item)
+	}
+	return candidates, skippedCurrent
+}
+
+func mergedDeleteSkipReason(item tmux.PickerItem, st *stack.Stack) (string, error) {
+	var children []string
+	if st != nil {
+		children = st.Children(item.Branch)
+	}
+
+	wtGit := &git.Git{Dir: item.WtPath}
+	dirty, err := wtGit.IsDirty()
+	if err != nil {
+		return "", err
+	}
+
+	unpushed, err := wtGit.HasUnpushedCommits()
+	if err != nil {
+		return "", err
+	}
+
+	return mergedDeleteSkipReasonFromState(children, dirty, unpushed), nil
+}
+
+func mergedDeleteSkipReasonFromState(children []string, dirty, unpushed bool) string {
+	var reasons []string
+	if len(children) > 0 {
+		reasons = append(reasons, "stacked children: "+strings.Join(children, ", "))
+	}
+	if dirty {
+		reasons = append(reasons, "uncommitted changes")
+	}
+	if unpushed {
+		reasons = append(reasons, "unpushed commits")
+	}
+	return strings.Join(reasons, "; ")
+}
+
+func mergedDeleteLabel(item tmux.PickerItem, multiRepo bool) string {
+	if multiRepo {
+		return item.RepoName + "/" + item.Branch
+	}
+	return item.Branch
+}
+
+func mergedDeleteHasMultipleRepos(items []tmux.PickerItem) bool {
+	repos := make(map[string]bool)
+	for _, item := range items {
+		repos[item.RepoName] = true
+		if len(repos) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func readTrimmedStdinLine() string {
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return strings.TrimSpace(line)
+	}
+	return strings.TrimSpace(line)
+}
+
+func tmuxPickDeleteItem(self string, item tmux.PickerItem) error {
 	sessName := tmux.SessionNameForWorktree(item.RepoName, item.WtDirName)
 	if tmux.SessionExists(sessName) {
 		tmux.KillSession(sessName)

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -198,6 +198,80 @@ func TestMoveToFrontWithStack_BranchNotInStack(t *testing.T) {
 	assertBranches(t, got, want)
 }
 
+func TestMergedDeleteCandidates_SkipsCurrentSessionAndKeepsOrder(t *testing.T) {
+	items := []tmux.PickerItem{
+		{RepoName: "repo", Branch: "main", WtDirName: "main"},
+		{RepoName: "repo", Branch: "feature-a", WtDirName: "feature-a", Merged: true},
+		{RepoName: "repo", Branch: "feature-b", WtDirName: "feature-b", Merged: true},
+		{RepoName: "repo", Branch: "feature-c", WtDirName: "feature-c", Merged: true},
+	}
+
+	got, skippedCurrent := mergedDeleteCandidates(items, "repo/feature-b")
+	if !skippedCurrent {
+		t.Fatal("expected current session worktree to be skipped")
+	}
+
+	want := []string{"feature-a", "feature-c"}
+	assertBranches(t, branches(got), want)
+}
+
+func TestMergedDeleteCandidates_NoCurrentSessionDeletesAllMerged(t *testing.T) {
+	items := []tmux.PickerItem{
+		{RepoName: "repo", Branch: "main", WtDirName: "main"},
+		{RepoName: "repo", Branch: "feature-a", WtDirName: "feature-a", Merged: true},
+		{RepoName: "other", Branch: "feature-b", WtDirName: "feature-b", Merged: true},
+	}
+
+	got, skippedCurrent := mergedDeleteCandidates(items, "")
+	if skippedCurrent {
+		t.Fatal("did not expect any current session skip")
+	}
+
+	want := []string{"feature-a", "feature-b"}
+	assertBranches(t, branches(got), want)
+}
+
+func TestMergedDeleteSkipReasonFromState(t *testing.T) {
+	tests := []struct {
+		name     string
+		children []string
+		dirty    bool
+		unpushed bool
+		want     string
+	}{
+		{
+			name: "safe",
+			want: "",
+		},
+		{
+			name:     "stacked children only",
+			children: []string{"child-a", "child-b"},
+			want:     "stacked children: child-a, child-b",
+		},
+		{
+			name:  "dirty only",
+			dirty: true,
+			want:  "uncommitted changes",
+		},
+		{
+			name:     "all reasons",
+			children: []string{"child-a"},
+			dirty:    true,
+			unpushed: true,
+			want:     "stacked children: child-a; uncommitted changes; unpushed commits",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergedDeleteSkipReasonFromState(tt.children, tt.dirty, tt.unpushed)
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func assertBranches(t *testing.T, got, want []string) {
 	t.Helper()
 	if len(got) != len(want) {

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -132,6 +132,8 @@ Active agents sorted first, offline sorted last. Pass a name to skip the picker:
 
 Remove a worktree. Without arguments, opens fzf picker with multi-select (TAB to toggle, Ctrl-A to select all).
 
+From the tmux picker, `Ctrl-D` removes the selected worktree and `Ctrl-X` bulk-removes safe merged worktrees currently shown in the picker, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
+
 ```bash
 ww rm auth-refactor              # direct removal
 ww rm                            # fzf picker
@@ -517,6 +519,7 @@ ww tmux install           # print tmux.conf lines to add
 ```
 
 Setup: `ww tmux install` prints the config to add to `~/.tmux.conf`, including a `prefix + w` keybinding for the picker popup.
+Inside the picker, `Ctrl-D` deletes the selected worktree and `Ctrl-X` bulk-deletes safe merged worktrees currently shown, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
 
 ### Aliases
 

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -38,6 +38,7 @@ The right panel shows a live preview of the tmux pane content (Claude Code outpu
 | `Ctrl-G` | Dispatch: create worktree from query text as prompt, launch Claude Code |
 | `Ctrl-S` | Sync stacked worktrees (selected branch's subtree, or all) |
 | `Ctrl-D` | Delete selected worktree and its tmux session |
+| `Ctrl-X` | Delete merged worktrees currently shown, skipping unsafe ones |
 | `Esc` | Close picker |
 
 ### Dispatch
@@ -56,7 +57,7 @@ Press `Ctrl-E` to open a secondary picker showing all remote branches that don't
 
 ### Merged worktree indicator
 
-Worktrees whose branches have been merged into the base branch show a dim `[merged]` tag. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up with `Ctrl-D` or `ww gc --prune`.
+Worktrees whose branches have been merged into the base branch show a dim `[merged]` tag. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session and any merged worktrees with local changes, unpushed commits, or stacked children are skipped), or use `ww gc --prune`.
 
 ### Features
 


### PR DESCRIPTION
## Description of the change
Adds a bulk prune shortcut to the tmux picker so merged worktrees can be removed from the popup without deleting them one by one.

**Ticket:** Closes https://github.com/iamrajjoshi/willow/issues/137

## Test plan
Ran the Go test suite, including the updated tmux/CLI coverage.

## Loom or screenshots

## Considerations
`Ctrl-X` skips the active tmux session so the picker does not delete the worktree it is currently running from.