### PR TITLE
:sparkles: feat[pr]: add worktree pr creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ go install github.com/iamrajjoshi/willow/cmd/willow@latest
 
 - [git](https://git-scm.com/)
 - [tmux](https://github.com/tmux/tmux) — optional, for the `ww tmux` picker popup
-- [gh](https://cli.github.com/) — optional, required for `ww new --pr`, `ww stack status`, and GitHub-aware merged worktree detection
+- [gh](https://cli.github.com/) — optional, required for `ww new --pr`, `ww stack status`, `ww pr create`, and GitHub-aware merged worktree detection
 
 ## Setup
 
@@ -263,6 +263,23 @@ ww sync --abort            # abort any in-progress rebases
 | `-r, --repo` | Target repo by name |
 | `--no-fetch` | Skip fetching from remote |
 | `--abort` | Abort in-progress rebases |
+
+### `ww pr create`
+
+Create a GitHub PR for the current worktree. Willow derives the PR base from the stack parent when the branch is stacked, or from the repo's default base branch otherwise. It pushes the branch if needed, skips creation if an open PR already exists, and can publish the current branch's ancestor stack in order.
+
+```bash
+ww pr create                  # create PR for the current branch
+ww pr create --draft          # open a draft PR
+ww pr create --stack          # create missing PRs from root → current branch
+```
+
+| Flag | Description |
+|------|-------------|
+| `--draft` | Create draft pull requests |
+| `--stack` | Create missing PRs for the current branch's ancestor stack |
+
+Requires the [GitHub CLI](https://cli.github.com/) (`gh`) and must be run from inside a willow-managed worktree with a clean working tree.
 
 ### `ww sw`
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -84,6 +84,7 @@ func NewApp() *cli.Command {
 			newCmd(),
 			checkoutCmd(),
 			syncCmd(),
+			prCmd(),
 			swCmd(),
 			rmCmd(),
 			lsCmd(),

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -161,6 +161,139 @@ func installTestCLIPath(t *testing.T, ghScript string) (string, string) {
 	return binDir, logPath
 }
 
+func installFakeGH(t *testing.T) (string, string) {
+	t.Helper()
+
+	stateDir := t.TempDir()
+	binDir, logPath := installTestCLIPath(t, "")
+	ghScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+
+STATE_DIR=%q
+LOG_FILE=%q
+COUNTER_FILE="$STATE_DIR/counter"
+
+log() {
+  printf '%%s\n' "$1" >> "$LOG_FILE"
+}
+
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  shift 2
+  head=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --head)
+        head="$2"
+        shift 2
+        ;;
+      --state|--json|--limit|-q)
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  log "list|$PWD|$head"
+  file="$STATE_DIR/$head.json"
+  if [ -f "$file" ]; then
+    cat "$file"
+  else
+    printf '[]\n'
+  fi
+  exit 0
+fi
+
+if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
+  shift 2
+  base=""
+  head=""
+  draft=false
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --base)
+        base="$2"
+        shift 2
+        ;;
+      --head)
+        head="$2"
+        shift 2
+        ;;
+      --draft)
+        draft=true
+        shift
+        ;;
+      --fill)
+        shift
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  log "create|$PWD|$base|$head|$draft"
+  next=1
+  if [ -f "$COUNTER_FILE" ]; then
+    next=$(( $(cat "$COUNTER_FILE") + 1 ))
+  fi
+  printf '%%s' "$next" > "$COUNTER_FILE"
+
+  url="https://github.com/test/repo/pull/$next"
+  head_oid=$(git rev-parse "$head" 2>/dev/null || printf '')
+  cat > "$STATE_DIR/$head.json" <<EOF
+[{"number":$next,"title":"PR for $head","headRefName":"$head","headRefOid":"$head_oid","state":"OPEN","reviewDecision":"","mergeable":"MERGEABLE","additions":0,"deletions":0,"url":"$url","statusCheckRollup":[]}]
+EOF
+  printf '%%s\n' "$url"
+  exit 0
+fi
+
+printf 'unsupported gh invocation: %%s\n' "$*" >&2
+exit 1
+`, stateDir, logPath)
+	if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(ghScript), 0o755); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+	return stateDir, logPath
+}
+
+func writeFakePROutput(t *testing.T, stateDir, branch, data string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(stateDir, branch+".json"), []byte(data), 0o644); err != nil {
+		t.Fatalf("write fake PR: %v", err)
+	}
+}
+
+func writeFakeOpenPR(t *testing.T, stateDir, branch, headOID string, number int) string {
+	t.Helper()
+
+	url := fmt.Sprintf("https://github.com/test/repo/pull/%d", number)
+	data := fmt.Sprintf(`[{"number":%d,"title":"Existing PR for %s","headRefName":"%s","headRefOid":"%s","state":"OPEN","reviewDecision":"","mergeable":"MERGEABLE","additions":0,"deletions":0,"url":"%s","statusCheckRollup":[]}]`,
+		number, branch, branch, headOID, url)
+	writeFakePROutput(t, stateDir, branch, data)
+	return url
+}
+
+func readLogLines(t *testing.T, path string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("read log %s: %v", path, err)
+	}
+
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "\n")
+}
+
 func captureStdout(t *testing.T, fn func() error) (string, error) {
 	t.Helper()
 
@@ -225,6 +358,13 @@ exit 1
 
 	_, logPath := installTestCLIPath(t, script)
 	return logPath
+}
+
+func canonicalPath(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
 }
 
 func TestClone_CreatesDirectoryStructure(t *testing.T) {
@@ -1012,6 +1152,343 @@ func TestNew_StackedBranch(t *testing.T) {
 	content := string(data)
 	if !strings.Contains(content, "feature-a") || !strings.Contains(content, "feature-b") {
 		t.Errorf("branches.json missing expected entries: %s", content)
+	}
+}
+
+func TestPRCreate_UnstackedBranch(t *testing.T) {
+	origin := setupTestEnv(t)
+	_, logPath := installFakeGH(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	baseBranch := entries[0].Name()
+	mainDir := filepath.Join(worktreeDir, baseBranch)
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-pr", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "feature-pr")
+	commitFile(t, featureDir, "feature.txt", "feature\n", "add feature")
+	os.Chdir(featureDir)
+
+	if err := runApp("pr", "create"); err != nil {
+		t.Fatalf("pr create failed: %v", err)
+	}
+
+	lines := readLogLines(t, logPath)
+	featureDir = canonicalPath(featureDir)
+	want := []string{
+		fmt.Sprintf("list|%s|feature-pr", featureDir),
+		fmt.Sprintf("create|%s|%s|feature-pr|false", featureDir, baseBranch),
+	}
+	if strings.Join(lines, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("gh log = %v, want %v", lines, want)
+	}
+}
+
+func TestPRCreate_StackedBranchUsesParentBase(t *testing.T) {
+	origin := setupTestEnv(t)
+	_, logPath := installFakeGH(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-a failed: %v", err)
+	}
+	featureADir := filepath.Join(worktreeDir, "feature-a")
+	commitFile(t, featureADir, "feature-a.txt", "a\n", "add feature a")
+	configureGitUser(t, featureADir)
+	if _, err := (&git.Git{Dir: featureADir}).Run("push", "-u", "origin", "feature-a"); err != nil {
+		t.Fatalf("push feature-a: %v", err)
+	}
+
+	os.Chdir(featureADir)
+	if err := runApp("new", "feature-b", "-b", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-b failed: %v", err)
+	}
+
+	featureBDir := filepath.Join(worktreeDir, "feature-b")
+	commitFile(t, featureBDir, "feature-b.txt", "b\n", "add feature b")
+	os.Chdir(featureBDir)
+
+	if err := runApp("pr", "create"); err != nil {
+		t.Fatalf("pr create failed: %v", err)
+	}
+
+	lines := readLogLines(t, logPath)
+	featureBDir = canonicalPath(featureBDir)
+	want := []string{
+		fmt.Sprintf("list|%s|feature-b", featureBDir),
+		fmt.Sprintf("create|%s|feature-a|feature-b|false", featureBDir),
+	}
+	if strings.Join(lines, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("gh log = %v, want %v", lines, want)
+	}
+}
+
+func TestPRCreate_StackCreatesAncestorsInOrder(t *testing.T) {
+	origin := setupTestEnv(t)
+	_, logPath := installFakeGH(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	baseBranch := entries[0].Name()
+	mainDir := filepath.Join(worktreeDir, baseBranch)
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-a failed: %v", err)
+	}
+	featureADir := filepath.Join(worktreeDir, "feature-a")
+	commitFile(t, featureADir, "feature-a.txt", "a\n", "add feature a")
+
+	os.Chdir(featureADir)
+	if err := runApp("new", "feature-b", "-b", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-b failed: %v", err)
+	}
+
+	featureBDir := filepath.Join(worktreeDir, "feature-b")
+	commitFile(t, featureBDir, "feature-b.txt", "b\n", "add feature b")
+	os.Chdir(featureBDir)
+
+	if err := runApp("pr", "create", "--stack"); err != nil {
+		t.Fatalf("pr create --stack failed: %v", err)
+	}
+
+	lines := readLogLines(t, logPath)
+	featureADir = canonicalPath(featureADir)
+	featureBDir = canonicalPath(featureBDir)
+	want := []string{
+		fmt.Sprintf("list|%s|feature-a", featureADir),
+		fmt.Sprintf("create|%s|%s|feature-a|false", featureBDir, baseBranch),
+		fmt.Sprintf("list|%s|feature-b", featureBDir),
+		fmt.Sprintf("create|%s|feature-a|feature-b|false", featureBDir),
+	}
+	if strings.Join(lines, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("gh log = %v, want %v", lines, want)
+	}
+}
+
+func TestPRCreate_ExistingPROpensNoNewPR(t *testing.T) {
+	origin := setupTestEnv(t)
+	stateDir, logPath := installFakeGH(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-existing", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "feature-existing")
+	commitFile(t, featureDir, "feature.txt", "feature\n", "add feature")
+	configureGitUser(t, featureDir)
+	if _, err := (&git.Git{Dir: featureDir}).Run("push", "-u", "origin", "feature-existing"); err != nil {
+		t.Fatalf("push feature-existing: %v", err)
+	}
+
+	headOID, err := (&git.Git{Dir: featureDir}).Run("rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+
+	writeFakeOpenPR(t, stateDir, "feature-existing", strings.TrimSpace(headOID), 42)
+	os.Chdir(featureDir)
+
+	if err := runApp("pr", "create"); err != nil {
+		t.Fatalf("pr create failed: %v", err)
+	}
+
+	lines := readLogLines(t, logPath)
+	featureDir = canonicalPath(featureDir)
+	want := []string{
+		fmt.Sprintf("list|%s|feature-existing", featureDir),
+	}
+	if strings.Join(lines, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("gh log = %v, want %v", lines, want)
+	}
+}
+
+func TestPRCreate_IgnoresExistingPRWithMismatchedHeadOID(t *testing.T) {
+	origin := setupTestEnv(t)
+	stateDir, logPath := installFakeGH(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-collision", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "feature-collision")
+	commitFile(t, featureDir, "feature.txt", "feature\n", "add feature")
+	configureGitUser(t, featureDir)
+	if _, err := (&git.Git{Dir: featureDir}).Run("push", "-u", "origin", "feature-collision"); err != nil {
+		t.Fatalf("push feature-collision: %v", err)
+	}
+
+	writeFakePROutput(t, stateDir, "feature-collision", `[{"number":41,"title":"Fork PR","headRefName":"feature-collision","headRefOid":"sha-other","state":"OPEN","reviewDecision":"","mergeable":"MERGEABLE","additions":0,"deletions":0,"url":"https://github.com/test/repo/pull/41","statusCheckRollup":[]}]`)
+	os.Chdir(featureDir)
+
+	if err := runApp("pr", "create"); err != nil {
+		t.Fatalf("pr create failed: %v", err)
+	}
+
+	lines := readLogLines(t, logPath)
+	featureDir = canonicalPath(featureDir)
+	if len(lines) != 2 {
+		t.Fatalf("expected list + create log lines, got %v", lines)
+	}
+	if lines[0] != fmt.Sprintf("list|%s|feature-collision", featureDir) {
+		t.Fatalf("first log line = %q, want branch lookup", lines[0])
+	}
+	if lines[1] != fmt.Sprintf("create|%s|%s|feature-collision|false", featureDir, entries[0].Name()) {
+		t.Fatalf("second log line = %q, want PR creation", lines[1])
+	}
+}
+
+func TestPRCreate_DirtyWorktreeFails(t *testing.T) {
+	origin := setupTestEnv(t)
+	_, _ = installFakeGH(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-dirty", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "feature-dirty")
+	if err := os.WriteFile(filepath.Join(featureDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+	os.Chdir(featureDir)
+
+	err := runApp("pr", "create")
+	if err == nil {
+		t.Fatal("expected dirty worktree error")
+	}
+	if !strings.Contains(err.Error(), `worktree "feature-dirty" has uncommitted changes`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPRCreate_RemoteAheadFails(t *testing.T) {
+	origin := setupTestEnv(t)
+	_, logPath := installFakeGH(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-behind", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "feature-behind")
+	commitFile(t, featureDir, "feature.txt", "one\n", "add first commit")
+	configureGitUser(t, featureDir)
+	featureGit := &git.Git{Dir: featureDir}
+	if _, err := featureGit.Run("push", "-u", "origin", "feature-behind"); err != nil {
+		t.Fatalf("initial push: %v", err)
+	}
+
+	commitFile(t, featureDir, "feature.txt", "two\n", "add second commit")
+	if _, err := featureGit.Run("push", "origin", "feature-behind"); err != nil {
+		t.Fatalf("second push: %v", err)
+	}
+	if _, err := featureGit.Run("reset", "--hard", "HEAD~1"); err != nil {
+		t.Fatalf("reset feature-behind: %v", err)
+	}
+	os.Chdir(featureDir)
+
+	err := runApp("pr", "create")
+	if err == nil {
+		t.Fatal("expected remote-ahead error")
+	}
+	if !strings.Contains(err.Error(), `branch "feature-behind" is behind origin/feature-behind`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lines := readLogLines(t, logPath); len(lines) != 0 {
+		t.Fatalf("expected no gh calls when remote is ahead, got %v", lines)
+	}
+}
+
+func TestPRCreate_MissingGHShowsFriendlyError(t *testing.T) {
+	origin := setupTestEnv(t)
+	_, _ = installTestCLIPath(t, "")
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-no-gh", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "feature-no-gh")
+	commitFile(t, featureDir, "feature.txt", "feature\n", "add feature")
+	os.Chdir(featureDir)
+
+	err := runApp("pr", "create")
+	if err == nil {
+		t.Fatal("expected missing gh error")
+	}
+	if !strings.Contains(err.Error(), "gh CLI required for PR creation") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -1,0 +1,303 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errors"
+	"github.com/iamrajjoshi/willow/internal/gh"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/log"
+	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/trace"
+	"github.com/iamrajjoshi/willow/internal/worktree"
+	"github.com/urfave/cli/v3"
+)
+
+func prCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "pr",
+		Usage: "GitHub pull request workflows",
+		Commands: []*cli.Command{
+			prCreateCmd(),
+		},
+	}
+}
+
+func prCreateCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "create",
+		Usage: "Create a GitHub pull request for the current branch or stack",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "draft",
+				Usage: "Create draft pull requests",
+			},
+			&cli.BoolFlag{
+				Name:  "stack",
+				Usage: "Create missing pull requests for the current branch's ancestor stack",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			defer trace.Span(ctx, "cli.pr.create")()
+			flags := parseFlags(cmd)
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			wtPath, bareDir, err := requireWillowWorktree(g)
+			if err != nil {
+				return err
+			}
+			if err := gh.EnsureCLI("PR creation"); err != nil {
+				return err
+			}
+
+			cfg := config.Load(bareDir)
+			repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+			currentGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
+
+			currentBranch, err := currentBranchName(currentGit)
+			if err != nil {
+				return err
+			}
+			if err := ensureCleanWorktree(currentGit, currentBranch); err != nil {
+				return err
+			}
+
+			st := stack.Load(bareDir)
+			branches := prCreateBranches(st, currentBranch, cmd.Bool("stack"))
+			wtPaths, err := worktreePathsByBranch(repoGit)
+			if err != nil {
+				return fmt.Errorf("failed to list worktrees: %w", err)
+			}
+
+			if len(branches) > 1 {
+				u.Info(fmt.Sprintf("Creating PRs for %d branches:\n", len(branches)))
+			}
+
+			created := 0
+			existing := 0
+			draft := cmd.Bool("draft")
+			for _, branch := range branches {
+				base := prBaseBranch(st, repoGit, cfg, branch)
+				u.Info(fmt.Sprintf("  %s → %s", u.Bold(branch), base))
+
+				branchPath := wtPaths[branch]
+				if branchPath != "" {
+					branchGit := &git.Git{Dir: branchPath, Verbose: g.Verbose}
+					if err := ensureCleanWorktree(branchGit, branch); err != nil {
+						return err
+					}
+				}
+
+				pushed, err := pushBranchIfNeeded(repoGit, branchPath, branch)
+				if err != nil {
+					return err
+				}
+				if pushed {
+					u.Info(fmt.Sprintf("    %s Pushed origin/%s", u.Dim("↑"), branch))
+				}
+
+				headOID, err := branchHeadOID(repoGit, branchPath, branch)
+				if err != nil {
+					return err
+				}
+
+				lookupDir := wtPath
+				if branchPath != "" {
+					lookupDir = branchPath
+				}
+				existingPR, err := gh.FindOpenPR(lookupDir, branch, headOID)
+				if err != nil {
+					return err
+				}
+				if existingPR != nil {
+					if existingPR.URL != "" {
+						u.Info(fmt.Sprintf("    %s Existing PR %s", u.Dim("↺"), existingPR.URL))
+					} else {
+						u.Info(fmt.Sprintf("    %s Existing PR #%d", u.Dim("↺"), existingPR.Number))
+					}
+					existing++
+					continue
+				}
+
+				url, err := gh.CreatePR(wtPath, base, branch, draft)
+				if err != nil {
+					return err
+				}
+
+				meta := map[string]string{
+					"base":  base,
+					"draft": fmt.Sprintf("%t", draft),
+				}
+				if url != "" {
+					meta["url"] = url
+				}
+				_ = log.Append(log.Event{
+					Action:   "pr_create",
+					Repo:     repoNameFromDir(bareDir),
+					Branch:   branch,
+					Metadata: meta,
+				})
+
+				if url != "" {
+					u.Success(fmt.Sprintf("Created PR for %s: %s", branch, url))
+				} else {
+					u.Success(fmt.Sprintf("Created PR for %s", branch))
+				}
+				created++
+			}
+
+			if len(branches) > 1 {
+				u.Info("")
+				u.Success(fmt.Sprintf("%d PR(s) created, %d already existed", created, existing))
+			}
+
+			return nil
+		},
+	}
+}
+
+func requireWillowWorktree(g *git.Git) (string, string, error) {
+	wtPath, err := g.WorktreeRoot()
+	if err != nil {
+		return "", "", errors.Userf("not inside a willow-managed worktree\n\nRun this command from a willow-managed worktree.")
+	}
+
+	bareDir, err := g.BareRepoDir()
+	if err != nil || !config.IsWillowRepo(bareDir) {
+		return "", "", errors.Userf("not inside a willow-managed worktree\n\nRun this command from a willow-managed worktree.")
+	}
+
+	return wtPath, bareDir, nil
+}
+
+func currentBranchName(g *git.Git) (string, error) {
+	branch, err := g.Run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve current branch: %w", err)
+	}
+
+	branch = strings.TrimSpace(branch)
+	if branch == "" || branch == "HEAD" || branch == "(detached)" {
+		return "", errors.Userf("current worktree is in detached HEAD state\n\nCheck out a branch before creating a PR.")
+	}
+
+	return branch, nil
+}
+
+func ensureCleanWorktree(g *git.Git, branch string) error {
+	dirty, err := g.IsDirty()
+	if err != nil {
+		return fmt.Errorf("failed to check worktree %q for uncommitted changes: %w", branch, err)
+	}
+	if dirty {
+		return errors.Userf("worktree %q has uncommitted changes\n\nCommit or stash changes before creating a PR.", branch)
+	}
+	return nil
+}
+
+func prCreateBranches(st *stack.Stack, currentBranch string, includeAncestors bool) []string {
+	if !includeAncestors || !st.IsTracked(currentBranch) {
+		return []string{currentBranch}
+	}
+
+	chain := []string{currentBranch}
+	for parent := st.Parent(currentBranch); parent != "" && st.IsTracked(parent); parent = st.Parent(parent) {
+		chain = append(chain, parent)
+	}
+
+	for left, right := 0, len(chain)-1; left < right; left, right = left+1, right-1 {
+		chain[left], chain[right] = chain[right], chain[left]
+	}
+	return chain
+}
+
+func prBaseBranch(st *stack.Stack, repoGit *git.Git, cfg *config.Config, branch string) string {
+	if st.IsTracked(branch) {
+		if parent := st.Parent(branch); parent != "" {
+			return parent
+		}
+	}
+	return repoGit.ResolveBaseBranch(cfg.BaseBranch)
+}
+
+func worktreePathsByBranch(repoGit *git.Git) (map[string]string, error) {
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		return nil, err
+	}
+
+	paths := make(map[string]string, len(wts))
+	for _, wt := range filterBareWorktrees(wts) {
+		paths[wt.Branch] = wt.Path
+	}
+	return paths, nil
+}
+
+func branchHeadOID(repoGit *git.Git, wtPath, branch string) (string, error) {
+	if wtPath != "" {
+		out, err := (&git.Git{Dir: wtPath, Verbose: repoGit.Verbose}).Run("rev-parse", "HEAD")
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve HEAD for branch %q: %w", branch, err)
+		}
+		return strings.TrimSpace(out), nil
+	}
+
+	out, err := repoGit.Run("rev-parse", branch)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve branch %q: %w", branch, err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func pushBranchIfNeeded(repoGit *git.Git, wtPath, branch string) (bool, error) {
+	needsPush, err := branchNeedsPush(repoGit, branch)
+	if err != nil {
+		return false, err
+	}
+	if !needsPush {
+		return false, nil
+	}
+
+	gitRunner := repoGit
+	args := []string{"push", "origin", branch}
+	if wtPath != "" {
+		gitRunner = &git.Git{Dir: wtPath, Verbose: repoGit.Verbose}
+		args = []string{"push", "-u", "origin", branch}
+	}
+
+	if _, err := gitRunner.Run(args...); err != nil {
+		return false, fmt.Errorf("failed to push branch %q: %w", branch, err)
+	}
+	return true, nil
+}
+
+func branchNeedsPush(repoGit *git.Git, branch string) (bool, error) {
+	if !repoGit.RemoteBranchExists(branch) {
+		return true, nil
+	}
+
+	out, err := repoGit.Run("rev-list", "--left-right", "--count", "origin/"+branch+"..."+branch)
+	if err != nil {
+		return false, fmt.Errorf("failed to compare branch %q to origin: %w", branch, err)
+	}
+
+	trimmed := strings.TrimSpace(out)
+	var behind, ahead int
+	if _, err := fmt.Sscanf(trimmed, "%d\t%d", &behind, &ahead); err != nil {
+		if _, err := fmt.Sscanf(trimmed, "%d %d", &behind, &ahead); err != nil {
+			return false, fmt.Errorf("failed to parse ahead/behind count %q for branch %q: %w", out, branch, err)
+		}
+	}
+
+	if behind > 0 {
+		if ahead > 0 {
+			return false, errors.Userf("branch %q has diverged from origin/%s\n\nReconcile the branch before creating a PR.", branch, branch)
+		}
+		return false, errors.Userf("branch %q is behind origin/%s\n\nFast-forward or reset the branch before creating a PR.", branch, branch)
+	}
+	return ahead > 0, nil
+}

--- a/internal/gh/pr.go
+++ b/internal/gh/pr.go
@@ -3,7 +3,9 @@ package gh
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/errors"
 )
@@ -47,6 +49,7 @@ type PRInfo struct {
 }
 
 const prJSONFields = "number,title,headRefName,headRefOid,baseRefName,state,mergedAt,reviewDecision,mergeable,additions,deletions,url,statusCheckRollup"
+const openPRLookupLimit = 20
 
 // CIStatus returns the aggregate CI status: "pass", "fail", "pending", or "none".
 func (p *PRInfo) CIStatus() string {
@@ -76,6 +79,24 @@ func EnsureCLI(feature string) error {
 	return nil
 }
 
+func prLookupArgs(branch string) []string {
+	return []string{
+		"pr", "list",
+		"--head", branch,
+		"--state", "open",
+		"--json", prJSONFields,
+		"--limit", fmt.Sprintf("%d", openPRLookupLimit),
+	}
+}
+
+func prCreateArgs(base, head string, draft bool) []string {
+	args := []string{"pr", "create", "--fill", "--base", base, "--head", head}
+	if draft {
+		args = append(args, "--draft")
+	}
+	return args
+}
+
 func parsePRListOutput(out []byte) ([]*PRInfo, error) {
 	var prs []ghPR
 	if err := json.Unmarshal(out, &prs); err != nil {
@@ -101,6 +122,77 @@ func parsePRListOutput(out []byte) ([]*PRInfo, error) {
 		})
 	}
 	return infos, nil
+}
+
+func selectMatchingPR(prs []*PRInfo, headOID string) *PRInfo {
+	if len(prs) == 0 {
+		return nil
+	}
+	if headOID == "" {
+		if len(prs) == 1 {
+			return prs[0]
+		}
+		return nil
+	}
+
+	for _, pr := range prs {
+		if pr.HeadRefOID == headOID {
+			return pr
+		}
+	}
+	return nil
+}
+
+func FindOpenPR(dir, branch, headOID string) (*PRInfo, error) {
+	if err := EnsureCLI("PR creation"); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.Command("gh", prLookupArgs(branch)...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GH_PROMPT_DISABLED=1",
+		"GH_NO_UPDATE_NOTIFIER=1",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return nil, fmt.Errorf("gh pr list failed: %s", msg)
+		}
+		return nil, fmt.Errorf("gh pr list failed: %w", err)
+	}
+
+	prs, err := parsePRListOutput(out)
+	if err != nil {
+		return nil, err
+	}
+	return selectMatchingPR(prs, headOID), nil
+}
+
+func CreatePR(dir, base, head string, draft bool) (string, error) {
+	if err := EnsureCLI("PR creation"); err != nil {
+		return "", err
+	}
+
+	cmd := exec.Command("gh", prCreateArgs(base, head, draft)...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GH_PROMPT_DISABLED=1",
+		"GH_NO_UPDATE_NOTIFIER=1",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return "", fmt.Errorf("gh pr create failed: %s", msg)
+		}
+		return "", fmt.Errorf("gh pr create failed: %w", err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
 }
 
 // BatchPRInfo fetches PR info for multiple branches in a single gh call.

--- a/internal/gh/pr_test.go
+++ b/internal/gh/pr_test.go
@@ -2,6 +2,7 @@ package gh
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -149,6 +150,49 @@ func TestGHPRJSONParsing(t *testing.T) {
 	}
 }
 
+func TestPRLookupArgs(t *testing.T) {
+	got := prLookupArgs("feature-x")
+	want := []string{
+		"pr", "list",
+		"--head", "feature-x",
+		"--state", "open",
+		"--json", prJSONFields,
+		"--limit", "20",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("prLookupArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestPRCreateArgs(t *testing.T) {
+	tests := []struct {
+		name  string
+		draft bool
+		want  []string
+	}{
+		{
+			name:  "ready for review",
+			draft: false,
+			want:  []string{"pr", "create", "--fill", "--base", "main", "--head", "feature-x"},
+		},
+		{
+			name:  "draft",
+			draft: true,
+			want:  []string{"pr", "create", "--fill", "--base", "main", "--head", "feature-x", "--draft"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prCreateArgs("main", "feature-x", tt.draft)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("prCreateArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParsePRListOutput(t *testing.T) {
 	raw := `[
 		{
@@ -187,5 +231,25 @@ func TestParsePRListOutput(t *testing.T) {
 	}
 	if len(pr.Checks) != 1 || pr.Checks[0].Name != "test" {
 		t.Errorf("Checks = %+v, want one test check", pr.Checks)
+	}
+}
+
+func TestSelectMatchingPR(t *testing.T) {
+	prs := []*PRInfo{
+		{Number: 41, Branch: "feature-x", HeadRefOID: "sha-other"},
+		{Number: 42, Branch: "feature-x", HeadRefOID: "sha-match"},
+	}
+
+	if got := selectMatchingPR(prs, "sha-match"); got == nil || got.Number != 42 {
+		t.Fatalf("selectMatchingPR() = %+v, want PR #42", got)
+	}
+	if got := selectMatchingPR(prs, "sha-missing"); got != nil {
+		t.Fatalf("selectMatchingPR() = %+v, want nil", got)
+	}
+	if got := selectMatchingPR([]*PRInfo{{Number: 99}}, ""); got == nil || got.Number != 99 {
+		t.Fatalf("selectMatchingPR() with single fallback = %+v, want PR #99", got)
+	}
+	if got := selectMatchingPR(prs, ""); got != nil {
+		t.Fatalf("selectMatchingPR() with ambiguous empty head = %+v, want nil", got)
 	}
 }

--- a/skills/willow/SKILL.md
+++ b/skills/willow/SKILL.md
@@ -23,6 +23,7 @@ Use willow (`ww`) commands instead of `git checkout`, `git branch`, or `git work
 | Hand a task to a fresh Claude agent | `ww dispatch "<prompt>"` |
 | Stack a branch on another | `ww new <child> -b <parent>` |
 | Rebase a stack after upstream changes | `ww sync` |
+| Turn the current branch or stack into PRs | `ww pr create [--stack]` |
 | Check CI/review for the whole stack | `ww stack status` |
 | Switch to an existing worktree | `ww sw <name>` |
 | See all worktrees and their status | `ww ls` |
@@ -94,6 +95,20 @@ ww stack status --json
 ```
 
 Requires the GitHub CLI (`gh`).
+
+### `ww pr create`
+
+Create a GitHub PR for the current branch. The base branch is inferred automatically:
+- stacked branch: uses its recorded parent
+- unstacked branch: uses the repo's default base branch
+
+```bash
+ww pr create                 # current branch only
+ww pr create --draft         # open as draft
+ww pr create --stack         # create missing PRs from root → current branch
+```
+
+Use this when the user says "open a PR", "publish this branch", or "create PRs for this stack". It must be run from inside a willow-managed worktree with no uncommitted changes.
 
 ### `ww dispatch <prompt>`
 

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -252,6 +252,30 @@ ww sync --abort            # abort any in-progress rebases
 
 Dirty worktrees and in-progress rebases are skipped with a warning.
 
+### `ww pr create`
+
+Create a GitHub PR for the current worktree. Willow derives the PR base from the stack parent when the branch is stacked, or from the repo's default base branch otherwise. It pushes the branch if needed, skips creation if an open PR already exists, and can publish the current branch's ancestor stack in root-to-current order.
+
+```bash
+ww pr create                  # create PR for the current branch
+ww pr create --draft          # create a draft PR
+ww pr create --stack          # create missing PRs for root → current branch
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--draft` | Create draft pull requests | `false` |
+| `--stack` | Create missing PRs for the current branch's ancestor stack | `false` |
+
+**Behavior:**
+1. Must be run from inside a willow-managed worktree
+2. Refuses to run if the current worktree has uncommitted changes
+3. Uses the stack parent as the PR base when the branch is stacked
+4. Pushes the branch if the remote is missing or behind
+5. Reuses an existing open PR instead of creating a duplicate
+
+Requires the [GitHub CLI](https://cli.github.com/) (`gh`).
+
 ## Inspection
 
 ### `ww status`

--- a/website/src/app/(docs)/guide/page.mdx
+++ b/website/src/app/(docs)/guide/page.mdx
@@ -26,7 +26,7 @@ go install github.com/iamrajjoshi/willow/cmd/willow@latest
 
 - [git](https://git-scm.com/)
 - [tmux](https://github.com/tmux/tmux) — optional, for the `ww tmux` picker popup
-- [gh](https://cli.github.com/) — optional, required for `ww new --pr`, `ww stack status`, and GitHub-aware merged worktree detection
+- [gh](https://cli.github.com/) — optional, required for `ww new --pr`, `ww stack status`, and `ww pr create`
 
 fzf is compiled into the willow binary, so no separate install is needed.
 

--- a/website/src/lib/docs-nav.ts
+++ b/website/src/lib/docs-nav.ts
@@ -58,6 +58,7 @@ export const DOCS_NAV: DocNavGroup[] = [
           { id: "stacked-prs", text: "Stacked PRs", level: 3 },
           { id: "ww-stack-status-alias-ww-stack-s", text: "ww stack status", level: 3 },
           { id: "ww-sync-branch", text: "ww sync", level: 3 },
+          { id: "ww-pr-create", text: "ww pr create", level: 3 },
           { id: "inspection", text: "Inspection", level: 2 },
           { id: "ww-status", text: "ww status", level: 3 },
           { id: "ww-dashboard-alias-dash-d", text: "ww dashboard", level: 3 },


### PR DESCRIPTION
## Description of the change
Builds on #139 by adding `ww pr create`, including stack-aware base selection, duplicate open-PR detection, safer remote-ahead/diverged checks, and documentation for the new workflow.

**Ticket:**

## Test plan
Ran `go test ./... -count=1`.

## Loom or screenshots

## Considerations
This PR is stacked on top of #139.
