### PR TITLE
🐛 fix[claude]: show session ids in status views

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ List worktrees with status.
 
 ### `ww status`
 
-Rich view of Claude Code agent status. Shows per-session rows when multiple agents run in the same worktree, with unread indicators (`●`) for completed sessions you haven't reviewed.
+Rich view of Claude Code agent status. Shows per-session rows when multiple agents run in the same worktree, with a short session ID on each session row and unread indicators (`●`) for completed sessions you haven't reviewed.
 
 ![ww status](screenshots/demo-status.gif)
 
@@ -316,7 +316,7 @@ Rich view of Claude Code agent status. Shows per-session rows when multiple agen
 
 ### `ww dashboard` (alias: `dash`, `d`)
 
-Live-refreshing TUI showing all Claude Code sessions across all repos. Includes diff stats, unread counts, per-session activity, and a timeline sparkline showing agent status transitions over the last 60 minutes.
+Live-refreshing TUI showing active Claude Code sessions across all repos. Includes short session IDs, diff stats, unread counts, per-session activity, and a timeline sparkline showing agent status transitions over the last 60 minutes.
 
 ```bash
 ww dashboard              # default 2s refresh
@@ -440,7 +440,7 @@ After running `ww cc-setup`, Claude Code automatically reports its state:
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. Stale `BUSY`/`DONE` status (>5 min) automatically degrades to `IDLE`. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
+Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
 
 ## Configuration
 

--- a/internal/claude/status.go
+++ b/internal/claude/status.go
@@ -20,7 +20,8 @@ const (
 	StatusIdle    Status = "IDLE"
 	StatusOffline Status = "--"
 
-	staleTimeout = 2 * time.Minute
+	staleTimeout   = 2 * time.Minute
+	shortSessionID = 8
 )
 
 type WorktreeStatus struct {
@@ -44,7 +45,8 @@ func StatusDir() string {
 }
 
 // ReadAllSessions reads all session status files from the directory-based layout:
-// <willow-base>/status/<repo>/<worktree>/*.json
+// <willow-base>/status/<repo>/<worktree>/*.json. Corrupt session files are
+// cleaned up as they're encountered.
 func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 	dir := filepath.Join(StatusDir(), repoName, worktreeDir)
 	entries, err := os.ReadDir(dir)
@@ -57,6 +59,7 @@ func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
+		sessionID := strings.TrimSuffix(e.Name(), ".json")
 		path := filepath.Join(dir, e.Name())
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -64,7 +67,11 @@ func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 		}
 		var ss SessionStatus
 		if err := json.Unmarshal(data, &ss); err != nil {
+			_ = removeSessionArtifacts(repoName, worktreeDir, sessionID)
 			continue
+		}
+		if ss.SessionID == "" {
+			ss.SessionID = sessionID
 		}
 		sessions = append(sessions, &ss)
 	}
@@ -165,6 +172,13 @@ func TimeSince(t time.Time) string {
 	}
 }
 
+func ShortSessionID(sessionID string) string {
+	if len(sessionID) <= shortSessionID {
+		return sessionID
+	}
+	return sessionID[:shortSessionID]
+}
+
 // SessionFileInfo holds a parsed session with its repo/worktree metadata.
 type SessionFileInfo struct {
 	RepoName    string
@@ -172,11 +186,27 @@ type SessionFileInfo struct {
 	Session     SessionStatus
 }
 
-// RemoveSessionFile removes a single session file and its companion timeline.
+// RemoveSessionFile removes a single session file and its companion artifacts.
 func RemoveSessionFile(repoName, worktreeDir, sessionID string) error {
-	path := filepath.Join(StatusDir(), repoName, worktreeDir, sessionID+".json")
-	os.Remove(TimelinePath(repoName, worktreeDir, sessionID))
-	return os.Remove(path)
+	return removeSessionArtifacts(repoName, worktreeDir, sessionID)
+}
+
+func removeSessionArtifacts(repoName, worktreeDir, sessionID string) error {
+	if sessionID == "" {
+		return nil
+	}
+
+	var firstErr error
+	for _, path := range []string{
+		filepath.Join(StatusDir(), repoName, worktreeDir, sessionID+".json"),
+		filepath.Join(StatusDir(), repoName, worktreeDir, sessionID+".files"),
+		TimelinePath(repoName, worktreeDir, sessionID),
+	} {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // ScanAllSessions walks the willow status directory and returns all parsed sessions.

--- a/internal/claude/status_test.go
+++ b/internal/claude/status_test.go
@@ -90,25 +90,34 @@ func TestReadStatus_AggregatesBusyOverDone(t *testing.T) {
 func TestReadAllSessions_PreservesOldFiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("WILLOW_BASE_DIR", filepath.Join(home, ".willow"))
 
 	repoName := "myrepo"
 	wtName := "old-sessions"
-	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	sessDir := filepath.Join(StatusDir(), repoName, wtName)
 	os.MkdirAll(sessDir, 0o755)
 
-	// Write a session file with a timestamp older than 30 minutes
+	// Old session files should still be readable until an explicit liveness
+	// cleanup path removes them.
 	old := SessionStatus{Status: StatusDone, SessionID: "old-sess", Timestamp: time.Now().UTC().Add(-2 * time.Hour)}
 	data, _ := json.Marshal(old)
 	os.WriteFile(filepath.Join(sessDir, old.SessionID+".json"), data, 0o644)
+	os.WriteFile(filepath.Join(sessDir, old.SessionID+".files"), []byte("/tmp/file\n"), 0o644)
+	os.WriteFile(TimelinePath(repoName, wtName, old.SessionID), []byte("{}\n"), 0o644)
 
 	got := ReadAllSessions(repoName, wtName)
 	if len(got) != 1 {
-		t.Fatalf("ReadAllSessions returned %d sessions, want 1 (should preserve old files)", len(got))
+		t.Fatalf("ReadAllSessions returned %d sessions, want 1", len(got))
 	}
 
-	// Verify file still exists on disk
-	if _, err := os.Stat(filepath.Join(sessDir, "old-sess.json")); os.IsNotExist(err) {
-		t.Error("ReadAllSessions deleted old session file, but should only read")
+	if _, err := os.Stat(filepath.Join(sessDir, "old-sess.json")); err != nil {
+		t.Fatalf("old session json should still exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(sessDir, "old-sess.files")); err != nil {
+		t.Fatalf("old session files sidecar should still exist: %v", err)
+	}
+	if _, err := os.Stat(TimelinePath(repoName, wtName, "old-sess")); err != nil {
+		t.Fatalf("old session timeline should still exist: %v", err)
 	}
 }
 
@@ -150,6 +159,15 @@ func TestTimeSince(t *testing.T) {
 
 	if got := TimeSince(time.Now().Add(-48 * time.Hour)); got != "2d ago" {
 		t.Errorf("TimeSince(48h) = %q, want '2d ago'", got)
+	}
+}
+
+func TestShortSessionID(t *testing.T) {
+	if got := ShortSessionID("1234567890"); got != "12345678" {
+		t.Errorf("ShortSessionID(long) = %q, want %q", got, "12345678")
+	}
+	if got := ShortSessionID("short"); got != "short" {
+		t.Errorf("ShortSessionID(short) = %q, want %q", got, "short")
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -85,6 +85,13 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 	return rs
 }
 
+func statusBranchLabel(branch, sessionID string) string {
+	if sessionID == "" {
+		return branch
+	}
+	return fmt.Sprintf("%s [%s]", branch, claude.ShortSessionID(sessionID))
+}
+
 func statusCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "status",
@@ -147,8 +154,9 @@ func statusCmd() *cli.Command {
 
 				branchW := 0
 				for _, e := range rs.Entries {
-					if len(e.Branch) > branchW {
-						branchW = len(e.Branch)
+					label := statusBranchLabel(e.Branch, e.SessionID)
+					if len(label) > branchW {
+						branchW = len(label)
 					}
 				}
 
@@ -158,13 +166,14 @@ func statusCmd() *cli.Command {
 					if e.Unread {
 						label += "\u25CF" // bullet
 					}
+					branchLabel := statusBranchLabel(e.Branch, e.SessionID)
 					var line string
 					if e.Timestamp != "" {
 						line = fmt.Sprintf("  %s %-*s  %-6s  %s",
-							icon, branchW, e.Branch, label, u.Dim(e.Timestamp))
+							icon, branchW, branchLabel, label, u.Dim(e.Timestamp))
 					} else {
 						line = fmt.Sprintf("  %s %-*s  %s",
-							icon, branchW, e.Branch, label)
+							icon, branchW, branchLabel, label)
 					}
 					u.Info(line)
 				}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -100,6 +100,15 @@ func TestCollectRepoStatus_RepoNameSet(t *testing.T) {
 	}
 }
 
+func TestStatusBranchLabel(t *testing.T) {
+	if got := statusBranchLabel("feature", "1234567890"); got != "feature [12345678]" {
+		t.Errorf("statusBranchLabel with session = %q, want %q", got, "feature [12345678]")
+	}
+	if got := statusBranchLabel("main", ""); got != "main" {
+		t.Errorf("statusBranchLabel without session = %q, want %q", got, "main")
+	}
+}
+
 func TestCollectRepoStatus_UnreadMarking(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -40,9 +40,9 @@ type session struct {
 }
 
 type summary struct {
-	Repos   int
-	Agents  int
-	Unread  int
+	Repos  int
+	Agents int
+	Unread int
 }
 
 type cachedDiff struct {
@@ -51,8 +51,8 @@ type cachedDiff struct {
 }
 
 var (
-	diffCache   = map[string]cachedDiff{}
-	diffCacheMu sync.Mutex
+	diffCache    = map[string]cachedDiff{}
+	diffCacheMu  sync.Mutex
 	diffCacheTTL = 10 * time.Second
 )
 
@@ -274,6 +274,9 @@ func collectData() ([]session, summary) {
 			if len(allSessions) > 0 {
 				for _, ss := range allSessions {
 					effective := claude.EffectiveStatus(ss.Status, ss.Timestamp)
+					if effective == claude.StatusIdle || effective == claude.StatusOffline {
+						continue
+					}
 					timeline, _ := claude.ReadTimeline(repoName, wtDir, ss.SessionID, timelineSince)
 					s := session{
 						Repo:      repoName,
@@ -340,24 +343,27 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	}
 
 	type rowLabel struct {
-		text string
+		status  string
+		session string
 	}
 	labels := make([]rowLabel, len(sessions))
 	statusW := len("STATUS")
 	repoW := len("REPO")
 	branchW := len("BRANCH")
+	sessionW := len("SESSION")
 	diffW := len("DIFF")
 	for i, s := range sessions {
-		text := string(s.Status)
+		statusText := string(s.Status)
 		if s.Unread {
-			text += "\u25CF"
+			statusText += "\u25CF"
 		}
 		if s.Status == claude.StatusBusy && s.Tool != "" {
-			text += " (" + s.Tool + ")"
+			statusText += " (" + s.Tool + ")"
 		}
-		labels[i] = rowLabel{text: text}
-		if len(text) > statusW {
-			statusW = len(text)
+		sessionText := claude.ShortSessionID(s.SessionID)
+		labels[i] = rowLabel{status: statusText, session: sessionText}
+		if len(statusText) > statusW {
+			statusW = len(statusText)
 		}
 		if len(s.Repo) > repoW {
 			repoW = len(s.Repo)
@@ -365,13 +371,16 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 		if len(s.Branch) > branchW {
 			branchW = len(s.Branch)
 		}
+		if len(sessionText) > sessionW {
+			sessionW = len(sessionText)
+		}
 		if len(s.DiffStats) > diffW {
 			diffW = len(s.DiffStats)
 		}
 	}
 
 	timelineW := 30
-	tableW := 2 + 2 + 1 + statusW + 2 + repoW + 2 + branchW + 2 + diffW + 2 + 8
+	tableW := 2 + 2 + 1 + statusW + 2 + repoW + 2 + branchW + 2 + sessionW + 2 + diffW + 2 + 8
 	if showTimeline {
 		tableW += 2 + timelineW // 2 for gap + column width
 	}
@@ -387,8 +396,8 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	b.WriteString(u.Bold(headerText))
 	b.WriteString("\n\n")
 
-	headerLine := fmt.Sprintf("  %-2s %-*s  %-*s  %-*s  %-*s",
-		"", statusW, "STATUS", repoW, "REPO", branchW, "BRANCH", diffW, "DIFF")
+	headerLine := fmt.Sprintf("  %-2s %-*s  %-*s  %-*s  %-*s  %-*s",
+		"", statusW, "STATUS", repoW, "REPO", branchW, "BRANCH", sessionW, "SESSION", diffW, "DIFF")
 	headerLine += "  AGE"
 	if showTimeline {
 		headerLine += fmt.Sprintf("  %-*s", timelineW, "TIMELINE")
@@ -410,10 +419,11 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 		if s.Status == claude.StatusBusy {
 			icon = u.Cyan(u.SpinnerFrame(frame))
 		}
-		line := fmt.Sprintf("  %s %-*s  %-*s  %-*s  %-*s",
-			icon, statusW, labels[i].text,
+		line := fmt.Sprintf("  %s %-*s  %-*s  %-*s  %-*s  %-*s",
+			icon, statusW, labels[i].status,
 			repoW, s.Repo,
 			branchW, s.Branch,
+			sessionW, labels[i].session,
 			diffW, s.DiffStats)
 		line += "  " + u.Dim(s.Age)
 		if showTimeline {
@@ -469,7 +479,6 @@ func getDiffStats(wtPath, baseBranch string) string {
 
 	return stats
 }
-
 
 func termWidth() int {
 	cmd := exec.Command("stty", "size")

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -66,7 +66,7 @@ func TestRenderSingleSession(t *testing.T) {
 		{
 			Repo:      "myrepo",
 			Branch:    "feat--thing",
-			SessionID: "abc123",
+			SessionID: "abc12345rest",
 			Status:    claude.StatusBusy,
 			Tool:      "",
 			DiffStats: "2f +10 -3",
@@ -85,6 +85,12 @@ func TestRenderSingleSession(t *testing.T) {
 	}
 	if !strings.Contains(out, "2f +10 -3") {
 		t.Errorf("expected diff stats in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "SESSION") {
+		t.Errorf("expected SESSION column header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "abc12345") {
+		t.Errorf("expected shortened session id in output, got:\n%s", out)
 	}
 }
 

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -252,16 +252,16 @@ Dirty worktrees and in-progress rebases are skipped with a warning.
 
 ### `ww status`
 
-Rich view of Claude Code agent status across all worktrees. Shows per-session rows when multiple Claude sessions run in the same worktree.
+Rich view of Claude Code agent status across all worktrees. Shows per-session rows when multiple Claude sessions run in the same worktree, with a short session ID on each session row.
 
 ```
 myrepo (4 worktrees, 3 sessions active, 1 unread)
 
-  🤖 auth-refactor          BUSY    2m ago
-  🤖 auth-refactor          BUSY    5m ago
-  ✅ payments               DONE●   12m ago
-  🟡 main                   IDLE    1h ago
-     old-feature            --
+  🤖 auth-refactor [4f2c9a1b]  BUSY    2m ago
+  🤖 auth-refactor [9b7d2e44]  BUSY    5m ago
+  ✅ payments      [3ac18f02]  DONE●   12m ago
+  🟡 main                     IDLE    1h ago
+     old-feature              --
 ```
 
 The `●` indicator marks completed sessions you haven't reviewed yet. Switching to a worktree via `ww sw` marks it as read.
@@ -272,7 +272,7 @@ The `●` indicator marks completed sessions you haven't reviewed yet. Switching
 
 ### `ww dashboard` (alias: `dash`, `d`)
 
-Live-refreshing TUI showing all Claude Code sessions across all repos. Renders in an alternate screen buffer with no flicker. Includes a timeline sparkline showing BUSY/WAIT/DONE transitions over the last 60 minutes.
+Live-refreshing TUI showing active Claude Code sessions across all repos. Renders in an alternate screen buffer with no flicker. Includes short session IDs and a timeline sparkline showing BUSY/WAIT/DONE transitions over the last 60 minutes.
 
 ```bash
 ww dashboard              # default 2s refresh
@@ -408,7 +408,7 @@ After running `ww cc-setup`, Claude Code automatically reports its state:
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Stale `BUSY`/`DONE` status (>5 min) automatically degrades to `IDLE`. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
+Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
 
 ## Configuration
 


### PR DESCRIPTION
## Description of the change
Show short session IDs in `ww status` and `ww dashboard` so concurrent sessions in the same worktree are easy to distinguish.

This also keeps valid session state from being deleted solely because it is old, while preserving the existing liveness-based cleanup paths.

Codex-assisted change.

**Ticket:** 

## Test plan
Repo test suite via `go test ./... -count=1`

## Loom or screenshots

## Considerations
