### PR TITLE
:bug: fix[tmux]: avoid slow picker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ From the tmux picker, `Ctrl-E` opens the same existing-branch flow from cached r
 
 ### `ww checkout <branch-or-pr-url>` (alias: `co`)
 
-Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree. Merged worktrees show a `[merged]` indicator in `ww ls` and the tmux picker. When `gh` is installed, willow also marks branches whose latest PR was merged on GitHub via squash/rebase, even if the branch tip is not an ancestor of the base branch.
+Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree. Merged worktrees show a `[merged]` indicator in `ww ls` and the tmux picker. When `gh` is installed, willow also marks branches whose latest PR was merged on GitHub via squash/rebase, even if the branch tip is not an ancestor of the base branch. The tmux picker uses cached GitHub merge results on open so slow PR lookups don't block rendering.
 
 ```bash
 ww checkout auth-refactor                # switch if exists, create if not

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -65,7 +65,7 @@ func tmuxPickCmd() *cli.Command {
 			}
 
 			for {
-				items, err := tmux.BuildPickerItems(ctx, repoFilter)
+				items, err := tmux.BuildPickerItemsWithOptions(ctx, repoFilter, tmux.PickerBuildOptions{})
 				if err != nil {
 					return err
 				}
@@ -85,17 +85,7 @@ func tmuxPickCmd() *cli.Command {
 					lines = tmux.FormatPickerLines(items)
 				}
 
-				previewCmd := fmt.Sprintf("%s tmux preview -- {}", self)
-				reloadCmd := fmt.Sprintf("%s tmux list", self)
-				if repoFilter != "" {
-					reloadCmd += fmt.Sprintf(" --repo %s", repoFilter)
-				}
-				if curSess != "" {
-					reloadCmd += fmt.Sprintf(" --session %s", curSess)
-				}
-
-				startBind := fmt.Sprintf("start:reload-sync(%s)", reloadCmd)
-
+				previewCmd := fmt.Sprintf("%s tmux preview -- {}", shellQuote(self))
 				opts := []fzf.Option{
 					fzf.WithAnsi(),
 					fzf.WithReverse(),
@@ -105,7 +95,6 @@ func tmuxPickCmd() *cli.Command {
 					fzf.WithHeader("Enter: Switch | Ctrl-N: New | Ctrl-B: Stacked | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-G: Dispatch | Ctrl-S: Sync | Ctrl-D: Delete | Ctrl-X: Prune merged"),
 					fzf.WithExpectKeys("ctrl-n", "ctrl-b", "ctrl-e", "ctrl-p", "ctrl-g", "ctrl-s", "ctrl-d", "ctrl-x"),
 					fzf.WithPrintQuery(),
-					fzf.WithBind(startBind),
 				}
 
 				cfg := config.Load("")
@@ -1177,10 +1166,17 @@ func tmuxListCmd() *cli.Command {
 				Aliases: []string{"s"},
 				Usage:   "Current tmux session (moves matching worktree to top)",
 			},
+			&cli.BoolFlag{
+				Name:   "refresh-github-merged",
+				Usage:  "Refresh GitHub-backed merged status instead of using cached results",
+				Hidden: true,
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			defer trace.Span(ctx, "tmux.list")()
-			items, err := tmux.BuildPickerItems(ctx, cmd.String("repo"))
+			items, err := tmux.BuildPickerItemsWithOptions(ctx, cmd.String("repo"), tmux.PickerBuildOptions{
+				RefreshGitHubMerged: cmd.Bool("refresh-github-merged"),
+			})
 			if err != nil {
 				return err
 			}

--- a/internal/gh/merged.go
+++ b/internal/gh/merged.go
@@ -100,6 +100,28 @@ func MergedWorktreeSet(dir, base string, branchHeads map[string]string) map[stri
 	return set
 }
 
+// CachedMergedWorktreeSet returns merged branches from the on-disk GitHub
+// lookup cache only. It never shells out to gh, so interactive pickers can use
+// it without putting network-backed PR lookups on their initial render path.
+func CachedMergedWorktreeSet(dir, base string, branchHeads map[string]string) map[string]bool {
+	set := make(map[string]bool)
+	if dir == "" || len(branchHeads) == 0 {
+		return set
+	}
+
+	cache := loadMergedWorktreeCache(mergedWorktreeCachePath(dir, base))
+	for branch, head := range branchHeads {
+		if branch == "" || branch == base || branch == detachedBranchName || head == "" {
+			continue
+		}
+		entry, ok := cache.Entries[branch]
+		if ok && entry.isMerged(base, head) {
+			set[branch] = true
+		}
+	}
+	return set
+}
+
 func (e mergedWorktreeCacheEntry) isMerged(base, head string) bool {
 	return e.Found &&
 		e.State == "MERGED" &&

--- a/internal/gh/merged_test.go
+++ b/internal/gh/merged_test.go
@@ -246,6 +246,41 @@ func TestMergedWorktreeSet_MissingBranchEntriesRefreshIndividually(t *testing.T)
 	}
 }
 
+func TestCachedMergedWorktreeSet_UsesStalePositiveCacheWithoutRefreshing(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+	calls := 0
+
+	prepareMergedWorktreeTestEnv(t, now, func(_ string, branches []string) ([]*PRInfo, error) {
+		calls++
+		t.Fatalf("cached lookup unexpectedly refreshed branches %v", branches)
+		return nil, nil
+	})
+
+	cachePath := mergedWorktreeCachePath("/fake/repo", "master")
+	err := saveMergedWorktreeCache(cachePath, mergedWorktreeCache{Entries: map[string]mergedWorktreeCacheEntry{
+		"feature": {
+			CheckedAt:   now.Add(-2 * mergedWorktreeCacheTTL),
+			Found:       true,
+			Number:      101,
+			State:       "MERGED",
+			BaseRefName: "master",
+			HeadRefOID:  "abc123",
+			MergedAt:    "2026-04-21T18:08:47Z",
+		},
+	}})
+	if err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+
+	got := CachedMergedWorktreeSet("/fake/repo", "master", map[string]string{"feature": "abc123"})
+	if !got["feature"] {
+		t.Fatalf("expected cached merged branch, got %v", got)
+	}
+	if calls != 0 {
+		t.Fatalf("search calls = %d, want 0", calls)
+	}
+}
+
 func prepareMergedWorktreeTestEnv(t *testing.T, now time.Time, search func(dir string, branches []string) ([]*PRInfo, error)) {
 	t.Helper()
 

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -46,7 +46,15 @@ type pickerGroup struct {
 	priority int
 }
 
+type PickerBuildOptions struct {
+	RefreshGitHubMerged bool
+}
+
 func BuildPickerItems(ctx context.Context, repoFilter string) ([]PickerItem, error) {
+	return BuildPickerItemsWithOptions(ctx, repoFilter, PickerBuildOptions{RefreshGitHubMerged: true})
+}
+
+func BuildPickerItemsWithOptions(ctx context.Context, repoFilter string, opts PickerBuildOptions) ([]PickerItem, error) {
 	defer trace.Span(ctx, "BuildPickerItems")()
 
 	var repoNames []string
@@ -92,9 +100,18 @@ func BuildPickerItems(ctx context.Context, repoFilter string) ([]PickerItem, err
 				branchHeads[wt.Branch] = wt.Head
 			}
 		}
-		done = trace.Span(ctx, "MergedBranchSet/"+repoName)
+		done = trace.Span(ctx, "git.MergedBranchSet/"+repoName)
 		mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
-		for branch := range gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads) {
+		done()
+
+		done = trace.Span(ctx, "gh.MergedWorktreeSet/"+repoName)
+		var githubMerged map[string]bool
+		if opts.RefreshGitHubMerged {
+			githubMerged = gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads)
+		} else {
+			githubMerged = gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads)
+		}
+		for branch := range githubMerged {
 			mergedSet[branch] = true
 		}
 		done()

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -541,7 +541,7 @@ Tmux integration for worktree management. See the [Tmux Integration](/tmux/) pag
 
 ```bash
 ww tmux pick              # interactive worktree picker (for tmux popup)
-ww tmux list              # formatted picker lines (for fzf reload)
+ww tmux list              # formatted picker lines (for diagnostics)
 ww tmux status-bar        # tmux status-right widget
 ww tmux install           # print tmux.conf lines to add
 ```

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -57,16 +57,16 @@ Press `Ctrl-E` to open a secondary picker showing all remote branches that don't
 
 ### Merged worktree indicator
 
-Worktrees whose branches have been merged into the base branch show a dim `[merged]` tag. When `gh` is available, this also covers branches whose latest PR was merged on GitHub via squash/rebase. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session and any merged worktrees with local changes, unpushed commits, or stacked children are skipped), or use `ww gc --prune`.
+Worktrees whose branches have been merged into the base branch show a dim `[merged]` tag. When `gh` is available, this also covers branches whose latest PR was merged on GitHub via squash/rebase. The picker uses cached GitHub merge results on open so slow PR lookups don't block rendering. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session and any merged worktrees with local changes, unpushed commits, or stacked children are skipped), or use `ww gc --prune`.
 
 ### Features
 
-- **Auto-refresh** — the list reloads every 2 seconds with fresh agent status
+- **Fast startup** — opens from local git/status files and cached GitHub merge results
 - **Auto-navigate** — opens with the cursor on your current session
 - **Urgency sort** — current session first, then `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline
 - **Status colors** — BUSY (green), WAIT (red), DONE (blue), IDLE (yellow)
 - **Unread indicator** — `●` marks completed sessions you haven't viewed
-- **Merged indicator** — `[merged]` marks worktrees whose branches are merged, including GitHub-merged PRs when `gh` is available
+- **Merged indicator** — `[merged]` marks worktrees whose branches are merged, including cached GitHub-merged PRs when `gh` is available
 - **Stack-aware ordering** — stacked branches stay grouped together and inherit the most urgent item in the tree
 - **Multi-Claude sub-rows** — when a worktree has multiple active Claude sessions, each is shown as an indented sub-row with its own status and tool info
 - **Embedded fzf** — fzf is compiled into the willow binary, no external `fzf` dependency needed
@@ -172,7 +172,7 @@ ww tmux pick -r myrepo    # filter to one repo
 
 ### `ww tmux list`
 
-Print formatted picker lines. Used by fzf's reload binding for auto-refresh.
+Print formatted picker lines for diagnostics and picker integrations.
 
 ### `ww tmux status-bar`
 


### PR DESCRIPTION
## Description of the change
Fixes the tmux picker startup regression by removing live GitHub PR lookups and synchronous fzf reloads from the initial render path. The picker now opens from local git/status data plus cached GitHub merge results, so slow `gh pr list` calls no longer block the UI.

## Test plan
Ran the full Go test suite and traced `ww tmux list` before/after to confirm startup time drops from ~11s to sub-second locally.
