### PR TITLE
:test_tube: test[coverage]: improve command coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,3 +24,7 @@ jobs:
 
       - name: Test
         run: go test ./... -count=1 -v
+
+      - name: Coverage
+        continue-on-error: true
+        run: go test ./... -coverpkg=./... -coverprofile=coverage.out -covermode=count

--- a/cmd/willow/main_test.go
+++ b/cmd/willow/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestTraceStderrRequested(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		args []string
+		want bool
+	}{
+		{name: "env one", env: "1", args: []string{"willow"}, want: true},
+		{name: "env true", env: "true", args: []string{"willow"}, want: true},
+		{name: "env on", env: "on", args: []string{"willow"}, want: true},
+		{name: "trace flag", args: []string{"willow", "--trace", "ls"}, want: true},
+		{name: "single dash trace flag", args: []string{"willow", "-trace", "ls"}, want: true},
+		{name: "disabled", env: "0", args: []string{"willow", "ls"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("WILLOW_TRACE", tt.env)
+			if got := traceStderrRequested(tt.args); got != tt.want {
+				t.Fatalf("traceStderrRequested(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/iamrajjoshi/willow/internal/config"
@@ -26,6 +29,91 @@ func TestConfigCmd_Structure(t *testing.T) {
 		if !names[want] {
 			t.Errorf("missing subcommand %q", want)
 		}
+	}
+}
+
+func TestConfigShowJSONUsesGlobalConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgPath := config.GlobalConfigPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{"branchPrefix":"raj","defaults":{"fetch":false}}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("config", "show", "--json")
+	})
+	if err != nil {
+		t.Fatalf("config show --json failed: %v", err)
+	}
+
+	var got config.Config
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("config show output is not JSON: %v\n%s", err, out)
+	}
+	if got.BranchPrefix != "raj" {
+		t.Fatalf("BranchPrefix = %q, want raj", got.BranchPrefix)
+	}
+	if got.Defaults.Fetch == nil || *got.Defaults.Fetch {
+		t.Fatalf("Defaults.Fetch = %v, want false", got.Defaults.Fetch)
+	}
+	if got.BaseDir != filepath.Join(home, ".willow") {
+		t.Fatalf("BaseDir = %q, want default willow home", got.BaseDir)
+	}
+}
+
+func TestConfigShowPrintsSourceAnnotationsAndWarnings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgPath := config.GlobalConfigPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{"tmux":{"panes":[{"command":"echo hi"}]}}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("config", "show")
+	})
+	if err != nil {
+		t.Fatalf("config show failed: %v", err)
+	}
+	for _, want := range []string{"baseDir:", "# default", "tmux.panes:", "# global", "tmux.panes configured"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("config show output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestConfigEditCreatesFileAndRunsEditor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logPath := filepath.Join(home, "editor.log")
+	editorPath := filepath.Join(home, "editor")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$1\" >> " + logPath + "\n"
+	if err := os.WriteFile(editorPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write editor: %v", err)
+	}
+	t.Setenv("VISUAL", editorPath)
+
+	if err := runApp("config", "edit"); err != nil {
+		t.Fatalf("config edit failed: %v", err)
+	}
+
+	cfgPath := config.GlobalConfigPath()
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("expected config file to be created: %v", err)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read editor log: %v", err)
+	}
+	if strings.TrimSpace(string(logData)) != cfgPath {
+		t.Fatalf("editor invoked with %q, want %q", strings.TrimSpace(string(logData)), cfgPath)
 	}
 }
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
@@ -97,6 +98,7 @@ func writeActiveSessionFile(t *testing.T, repo, wt, sessionID string, status cla
 	data, err := json.Marshal(claude.SessionStatus{
 		Status:    status,
 		SessionID: sessionID,
+		Timestamp: time.Now(),
 	})
 	if err != nil {
 		t.Fatalf("marshal session status: %v", err)

--- a/internal/cli/log_cmd_test.go
+++ b/internal/cli/log_cmd_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	activitylog "github.com/iamrajjoshi/willow/internal/log"
+)
+
+func TestParseDurationSupportsDaysAndReportsBadInput(t *testing.T) {
+	got, err := parseDuration("7d")
+	if err != nil {
+		t.Fatalf("parseDuration(7d) error = %v", err)
+	}
+	if got != 7*24*time.Hour {
+		t.Fatalf("parseDuration(7d) = %s, want 168h", got)
+	}
+
+	got, err = parseDuration("30m")
+	if err != nil {
+		t.Fatalf("parseDuration(30m) error = %v", err)
+	}
+	if got != 30*time.Minute {
+		t.Fatalf("parseDuration(30m) = %s, want 30m", got)
+	}
+
+	if _, err := parseDuration("soon"); err == nil || !strings.Contains(err.Error(), "invalid duration") {
+		t.Fatalf("parseDuration(soon) error = %v, want invalid duration", err)
+	}
+}
+
+func TestFormatMetadataSkipsEmptyAndTruncatesLongValues(t *testing.T) {
+	got := formatMetadata(map[string]string{
+		"empty": "",
+		"short": "ok",
+		"long":  strings.Repeat("x", 70),
+	})
+	if strings.Contains(got, "empty=") {
+		t.Fatalf("formatMetadata should skip empty values, got %q", got)
+	}
+	if !strings.Contains(got, "short=ok") {
+		t.Fatalf("formatMetadata missing short value: %q", got)
+	}
+	if !strings.Contains(got, "long="+strings.Repeat("x", 57)+"...") {
+		t.Fatalf("formatMetadata missing truncated long value: %q", got)
+	}
+}
+
+func TestLogCommandJSONAppliesRepoBranchSinceAndLimitFilters(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	now := time.Now().UTC()
+	events := []activitylog.Event{
+		{Action: "create", Repo: "repo", Branch: "feature", Timestamp: now.Add(-10 * time.Minute), Metadata: map[string]string{"base": "main"}},
+		{Action: "remove", Repo: "repo", Branch: "other", Timestamp: now.Add(-9 * time.Minute)},
+		{Action: "create", Repo: "other", Branch: "feature", Timestamp: now.Add(-8 * time.Minute)},
+		{Action: "old", Repo: "repo", Branch: "feature", Timestamp: now.Add(-48 * time.Hour)},
+	}
+	for _, e := range events {
+		if err := activitylog.Append(e); err != nil {
+			t.Fatalf("append log event: %v", err)
+		}
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("log", "--repo", "repo", "--branch", "feature", "--since", "24h", "--limit", "5", "--json")
+	})
+	if err != nil {
+		t.Fatalf("log command failed: %v", err)
+	}
+
+	var got []activitylog.Event
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("log JSON output failed to parse: %v\n%s", err, out)
+	}
+	if len(got) != 1 {
+		t.Fatalf("log command returned %d events, want 1: %+v", len(got), got)
+	}
+	if got[0].Action != "create" || got[0].Repo != "repo" || got[0].Branch != "feature" {
+		t.Fatalf("unexpected filtered log event: %+v", got[0])
+	}
+}
+
+func TestLogCommandHumanOutputIncludesMetadata(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := activitylog.Append(activitylog.Event{
+		Action:   "sync",
+		Repo:     "repo",
+		Branch:   "feature",
+		Metadata: map[string]string{"parent": "main"},
+	}); err != nil {
+		t.Fatalf("append log event: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("log", "--repo", "repo")
+	})
+	if err != nil {
+		t.Fatalf("log command failed: %v", err)
+	}
+	for _, want := range []string{"sync", "repo", "feature", "parent=main"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("log output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/refresh_status_test.go
+++ b/internal/cli/refresh_status_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+)
+
+func TestRefreshStatusDryRunAndRemoval(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeActiveSessionFile(t, "repo", "feature", "s1", claude.StatusBusy)
+	sessionPath := filepath.Join(claude.StatusDir(), "repo", "feature", "s1.json")
+
+	dryRunOut, err := captureStdout(t, func() error {
+		return runApp("refresh-status", "--dry-run")
+	})
+	if err != nil {
+		t.Fatalf("refresh-status --dry-run failed: %v", err)
+	}
+	if !strings.Contains(dryRunOut, "Would remove repo/feature session s1") {
+		t.Fatalf("dry-run output missing orphaned session:\n%s", dryRunOut)
+	}
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("dry-run should leave session file in place: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("refresh-status")
+	})
+	if err != nil {
+		t.Fatalf("refresh-status failed: %v", err)
+	}
+	if !strings.Contains(out, "Removed 1 orphaned session") {
+		t.Fatalf("remove output missing summary:\n%s", out)
+	}
+	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
+		t.Fatalf("session file should be removed, stat err = %v", err)
+	}
+}

--- a/internal/cli/stack_cmd_test.go
+++ b/internal/cli/stack_cmd_test.go
@@ -1,6 +1,15 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/gh"
+	"github.com/iamrajjoshi/willow/internal/ui"
+)
 
 func TestStackCmd(t *testing.T) {
 	cmd := stackCmd()
@@ -23,5 +32,95 @@ func TestStackCmd(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected 'status' subcommand")
+	}
+}
+
+func TestFormatPRAnnotation(t *testing.T) {
+	u := &ui.UI{}
+	pr := &gh.PRInfo{
+		Number:       42,
+		ReviewStatus: "APPROVED",
+		Mergeable:    "MERGEABLE",
+		Additions:    3,
+		Deletions:    1,
+	}
+
+	got := formatPRAnnotation(u, pr)
+	for _, want := range []string{"#42", "CI", "Review", "MERGEABLE", "+3", "-1"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatPRAnnotation() missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestFindGHDir(t *testing.T) {
+	root := t.TempDir()
+	if _, err := findGHDir(root); err == nil {
+		t.Fatal("expected empty worktree dir to fail")
+	}
+
+	want := filepath.Join(root, "main")
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	got, err := findGHDir(root)
+	if err != nil {
+		t.Fatalf("findGHDir() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("findGHDir() = %q, want %q", got, want)
+	}
+}
+
+func TestStackStatusJSON(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, "stackstatus"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "stackstatus")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatalf("chdir main: %v", err)
+	}
+	if err := runApp("new", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-a failed: %v", err)
+	}
+	if err := runApp("new", "feature-b", "--base", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-b failed: %v", err)
+	}
+
+	ghScript := `#!/bin/sh
+set -eu
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  cat <<'JSON'
+[
+  {"number":10,"title":"Feature A","headRefName":"feature-a","headRefOid":"sha-a","baseRefName":"main","state":"OPEN","reviewDecision":"APPROVED","mergeable":"MERGEABLE","additions":5,"deletions":1,"url":"https://github.com/test/repo/pull/10","statusCheckRollup":[{"name":"test","status":"COMPLETED","conclusion":"SUCCESS"}]},
+  {"number":11,"title":"Feature B","headRefName":"feature-b","headRefOid":"sha-b","baseRefName":"feature-a","state":"OPEN","reviewDecision":"REVIEW_REQUIRED","mergeable":"UNKNOWN","additions":7,"deletions":2,"url":"https://github.com/test/repo/pull/11","statusCheckRollup":[]}
+]
+JSON
+  exit 0
+fi
+exit 1
+`
+	installTestCLIPath(t, ghScript)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("stack", "status", "--repo", "stackstatus", "--json")
+	})
+	if err != nil {
+		t.Fatalf("stack status --json failed: %v", err)
+	}
+
+	var got map[string]gh.PRInfo
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("stack status JSON failed to parse: %v\n%s", err, out)
+	}
+	if got["feature-a"].Number != 10 {
+		t.Fatalf("feature-a PR = %+v, want #10", got["feature-a"])
+	}
+	if got["feature-b"].BaseRefName != "feature-a" {
+		t.Fatalf("feature-b PR = %+v, want base feature-a", got["feature-b"])
 	}
 }

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/errors"
@@ -82,6 +85,19 @@ func syncCmd() *cli.Command {
 			for _, wt := range wts {
 				if !wt.IsBare {
 					wtPaths[wt.Branch] = wt.Path
+				}
+			}
+			if cmd.Bool("abort") {
+				repoName := repoNameFromDir(bareDir)
+				for _, branch := range st.TopoSort() {
+					if _, ok := wtPaths[branch]; ok {
+						continue
+					}
+					dirName := strings.ReplaceAll(branch, "/", "-")
+					candidate := filepath.Join(config.WorktreesDir(), repoName, dirName)
+					if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+						wtPaths[branch] = candidate
+					}
 				}
 			}
 			done()
@@ -188,9 +204,9 @@ func syncCmd() *cli.Command {
 					meta["ahead"] = fmt.Sprintf("%d", ahead)
 				}
 				_ = log.Append(log.Event{
-					Action: "sync",
-					Repo:   repoNameFromDir(bareDir),
-					Branch: branch,
+					Action:   "sync",
+					Repo:     repoNameFromDir(bareDir),
+					Branch:   branch,
 					Metadata: meta,
 				})
 				synced++

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1,0 +1,238 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/git"
+)
+
+type syncStackFixture struct {
+	Home        string
+	BareDir     string
+	WorktreeDir string
+	BaseBranch  string
+	MainDir     string
+	FeatureADir string
+	FeatureBDir string
+}
+
+func setupSyncStack(t *testing.T, repoName string) syncStackFixture {
+	t.Helper()
+
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, repoName); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", repoName)
+	entries, err := os.ReadDir(worktreeDir)
+	if err != nil {
+		t.Fatalf("read worktrees dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one initial worktree, got %d", len(entries))
+	}
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatalf("chdir main: %v", err)
+	}
+
+	if err := runApp("new", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-a failed: %v", err)
+	}
+	featureADir := filepath.Join(worktreeDir, "feature-a")
+	commitFile(t, featureADir, "feature-a.txt", "feature a\n", "feature a")
+
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatalf("chdir main: %v", err)
+	}
+	if err := runApp("new", "feature-b", "--base", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-b failed: %v", err)
+	}
+	featureBDir := filepath.Join(worktreeDir, "feature-b")
+	commitFile(t, featureBDir, "feature-b.txt", "feature b\n", "feature b")
+
+	return syncStackFixture{
+		Home:        home,
+		BareDir:     filepath.Join(home, ".willow", "repos", repoName+".git"),
+		WorktreeDir: worktreeDir,
+		BaseBranch:  entries[0].Name(),
+		MainDir:     mainDir,
+		FeatureADir: featureADir,
+		FeatureBDir: featureBDir,
+	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := (&git.Git{Dir: dir}).Run(args...)
+	if err != nil {
+		t.Fatalf("git %v in %s: %v", args, dir, err)
+	}
+	return strings.TrimSpace(out)
+}
+
+func TestSync_NoStack(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, "nostack"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "nostack")
+	entries, err := os.ReadDir(worktreeDir)
+	if err != nil {
+		t.Fatalf("read worktrees dir: %v", err)
+	}
+	if err := os.Chdir(filepath.Join(worktreeDir, entries[0].Name())); err != nil {
+		t.Fatalf("chdir worktree: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sync", "--no-fetch")
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if !strings.Contains(out, "No stacked branches found") {
+		t.Fatalf("expected no-stack message, got:\n%s", out)
+	}
+}
+
+func TestSync_RebasesChildOntoUpdatedParent(t *testing.T) {
+	f := setupSyncStack(t, "syncfull")
+	commitFile(t, f.FeatureADir, "feature-a-2.txt", "feature a update\n", "feature a update")
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sync", "--no-fetch")
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if !strings.Contains(out, "All 2 worktree(s) synced") {
+		t.Fatalf("expected successful sync summary, got:\n%s", out)
+	}
+
+	if _, err := (&git.Git{Dir: f.FeatureBDir}).Run("merge-base", "--is-ancestor", "feature-a", "HEAD"); err != nil {
+		t.Fatalf("feature-b should be rebased onto feature-a: %v", err)
+	}
+}
+
+func TestSync_TargetBranchOnlySyncsSubtree(t *testing.T) {
+	f := setupSyncStack(t, "syncsubtree")
+	if err := os.Chdir(f.MainDir); err != nil {
+		t.Fatalf("chdir main: %v", err)
+	}
+	if err := runApp("new", "feature-c", "--base", "feature-b", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-c failed: %v", err)
+	}
+	featureCDir := filepath.Join(f.WorktreeDir, "feature-c")
+	commitFile(t, featureCDir, "feature-c.txt", "feature c\n", "feature c")
+	commitFile(t, f.FeatureBDir, "feature-b-2.txt", "feature b update\n", "feature b update")
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sync", "feature-b", "--no-fetch")
+	})
+	if err != nil {
+		t.Fatalf("sync feature-b failed: %v", err)
+	}
+	if !strings.Contains(out, "Syncing 2 stacked worktree(s)") {
+		t.Fatalf("expected subtree sync count, got:\n%s", out)
+	}
+	if _, err := (&git.Git{Dir: featureCDir}).Run("merge-base", "--is-ancestor", "feature-b", "HEAD"); err != nil {
+		t.Fatalf("feature-c should be rebased onto updated feature-b: %v", err)
+	}
+}
+
+func TestSync_SkipsTrackedBranchWithoutWorktree(t *testing.T) {
+	f := setupSyncStack(t, "syncmissing")
+	if _, err := (&git.Git{Dir: f.BareDir}).Run("worktree", "remove", "--force", f.FeatureBDir); err != nil {
+		t.Fatalf("remove feature-b worktree: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sync", "--no-fetch")
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if !strings.Contains(out, "Skipped (no worktree)") {
+		t.Fatalf("expected missing-worktree skip, got:\n%s", out)
+	}
+}
+
+func TestSync_SkipsDirtyWorktree(t *testing.T) {
+	f := setupSyncStack(t, "syncdirty")
+	oldHead := gitOutput(t, f.FeatureBDir, "rev-parse", "HEAD")
+	if err := os.WriteFile(filepath.Join(f.FeatureBDir, "dirty.txt"), []byte("dirty\n"), 0o644); err != nil {
+		t.Fatalf("write dirty file: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sync", "--no-fetch")
+	})
+	if err != nil {
+		t.Fatalf("sync failed: %v", err)
+	}
+	if !strings.Contains(out, "Skipped (uncommitted changes)") {
+		t.Fatalf("expected dirty-worktree skip, got:\n%s", out)
+	}
+	if got := gitOutput(t, f.FeatureBDir, "rev-parse", "HEAD"); got != oldHead {
+		t.Fatalf("dirty worktree head changed: got %s, want %s", got, oldHead)
+	}
+}
+
+func TestSync_ConflictSkipsDescendantsAndAbortClearsRebase(t *testing.T) {
+	f := setupSyncStack(t, "syncconflict")
+
+	commitFile(t, f.FeatureADir, "conflict.txt", "base\n", "add conflict base")
+	if err := os.Chdir(f.MainDir); err != nil {
+		t.Fatalf("chdir main: %v", err)
+	}
+	if err := runApp("new", "conflict-child", "--base", "feature-a", "--no-fetch"); err != nil {
+		t.Fatalf("new conflict-child failed: %v", err)
+	}
+	childDir := filepath.Join(f.WorktreeDir, "conflict-child")
+	commitFile(t, childDir, "conflict.txt", "child\n", "child conflict edit")
+	if err := os.Chdir(f.MainDir); err != nil {
+		t.Fatalf("chdir main: %v", err)
+	}
+	if err := runApp("new", "conflict-grandchild", "--base", "conflict-child", "--no-fetch"); err != nil {
+		t.Fatalf("new conflict-grandchild failed: %v", err)
+	}
+	grandchildDir := filepath.Join(f.WorktreeDir, "conflict-grandchild")
+	commitFile(t, grandchildDir, "grandchild.txt", "grandchild\n", "grandchild work")
+	commitFile(t, f.FeatureADir, "conflict.txt", "parent\n", "parent conflict edit")
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sync", "--no-fetch")
+	})
+	if err != nil {
+		t.Fatalf("sync should report conflicts without returning an error: %v", err)
+	}
+	if !strings.Contains(out, "Conflict") {
+		t.Fatalf("expected conflict output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Skipped (ancestor has conflict)") {
+		t.Fatalf("expected descendant skip after conflict, got:\n%s", out)
+	}
+	if !(&git.Git{Dir: childDir}).IsRebaseInProgress() {
+		t.Fatal("expected conflict-child to have an in-progress rebase")
+	}
+
+	abortOut, err := captureStdout(t, func() error {
+		return runApp("sync", "--abort", "--no-fetch")
+	})
+	if err != nil {
+		t.Fatalf("sync --abort failed: %v", err)
+	}
+	if !strings.Contains(abortOut, "Aborted 1 rebase") {
+		t.Fatalf("expected abort summary, got:\n%s", abortOut)
+	}
+	if (&git.Git{Dir: childDir}).IsRebaseInProgress() {
+		t.Fatal("expected sync --abort to clear the in-progress rebase")
+	}
+}

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -1,8 +1,13 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/tmux"
 )
@@ -299,6 +304,215 @@ func TestExistingBranchCacheRoundTrip(t *testing.T) {
 		t.Fatalf("loadExistingBranchCache() error = %v", err)
 	}
 	assertBranches(t, got, want)
+}
+
+func TestExtractBranchFromPRLine(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "normal PR line",
+			line: "#42  Add picker action  (raj)  [feature/tmux-picker]",
+			want: "feature/tmux-picker",
+		},
+		{
+			name: "branch with brackets earlier in title",
+			line: "#43  Fix [docs] rendering  (raj)  [fix/docs-rendering]",
+			want: "fix/docs-rendering",
+		},
+		{
+			name: "missing brackets",
+			line: "#44  No branch here",
+			want: "",
+		},
+		{
+			name: "empty branch",
+			line: "#45  Bad line []",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractBranchFromPRLine(tt.line); got != tt.want {
+				t.Fatalf("extractBranchFromPRLine(%q) = %q, want %q", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergedDeleteLabel(t *testing.T) {
+	item := tmux.PickerItem{RepoName: "repo-a", Branch: "feature-a"}
+	if got := mergedDeleteLabel(item, false); got != "feature-a" {
+		t.Fatalf("single-repo label = %q, want feature-a", got)
+	}
+	if got := mergedDeleteLabel(item, true); got != "repo-a/feature-a" {
+		t.Fatalf("multi-repo label = %q, want repo-a/feature-a", got)
+	}
+}
+
+func TestMergedDeleteHasMultipleRepos(t *testing.T) {
+	if mergedDeleteHasMultipleRepos(nil) {
+		t.Fatal("empty item set should not count as multiple repos")
+	}
+	if mergedDeleteHasMultipleRepos([]tmux.PickerItem{item("repo-a", "main"), item("repo-a", "feature")}) {
+		t.Fatal("same repo items should not count as multiple repos")
+	}
+	if !mergedDeleteHasMultipleRepos([]tmux.PickerItem{item("repo-a", "main"), item("repo-b", "feature")}) {
+		t.Fatal("different repo items should count as multiple repos")
+	}
+}
+
+func TestFindItemByPath(t *testing.T) {
+	items := []tmux.PickerItem{
+		item("repo", "main"),
+		item("repo", "feature"),
+	}
+
+	got := findItemByPath(items, "/fake/repo/feature")
+	if got == nil || got.Branch != "feature" {
+		t.Fatalf("findItemByPath() = %+v, want feature item", got)
+	}
+	if got := findItemByPath(items, "/fake/repo/missing"); got != nil {
+		t.Fatalf("findItemByPath() = %+v, want nil for missing path", got)
+	}
+}
+
+func TestBuildStackChain(t *testing.T) {
+	st := makeStack(
+		"feature-a", "main",
+		"feature-b", "feature-a",
+		"feature-c", "feature-b",
+		"feature-d", "feature-b",
+	)
+
+	got := buildStackChain(st, "feature-b")
+	for _, want := range []string{"main", "feature-a", "[feature-b]", "feature-c", "feature-d"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("buildStackChain() = %q, missing %q", got, want)
+		}
+	}
+	if !strings.Contains(got, "→") {
+		t.Fatalf("buildStackChain() = %q, want arrow separators", got)
+	}
+}
+
+func TestTmuxInstallCommand_PrintsConfig(t *testing.T) {
+	out, err := captureStdout(t, func() error {
+		return runApp("tmux", "install")
+	})
+	if err != nil {
+		t.Fatalf("tmux install failed: %v", err)
+	}
+	for _, want := range []string{"bind w run-shell", "tmux pick", "status-right", "status-interval 3"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("tmux install output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestTmuxExistingBranchesCommand_ListsAvailableRemoteBranches(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "tmuxbranches"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "tmuxbranches")
+	entries, err := os.ReadDir(worktreeDir)
+	if err != nil {
+		t.Fatalf("read worktrees dir: %v", err)
+	}
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	wg := &git.Git{Dir: mainDir}
+	if _, err := wg.Run("checkout", "-b", "remote-only"); err != nil {
+		t.Fatalf("create remote-only branch: %v", err)
+	}
+	if _, err := wg.Run("push", "origin", "remote-only"); err != nil {
+		t.Fatalf("push remote-only branch: %v", err)
+	}
+	if _, err := wg.Run("checkout", "-"); err != nil {
+		t.Fatalf("checkout previous branch: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("tmux", "existing-branches", "--repo", "tmuxbranches", "--refresh")
+	})
+	if err != nil {
+		t.Fatalf("tmux existing-branches failed: %v", err)
+	}
+	if !strings.Contains(out, "remote-only") {
+		t.Fatalf("expected available remote branch in output, got:\n%s", out)
+	}
+	if strings.Contains(out, entries[0].Name()) {
+		t.Fatalf("current worktree branch should be filtered out, got:\n%s", out)
+	}
+}
+
+func TestTmuxListCommand_PrintsPickerLines(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "tmuxlist"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "tmuxlist")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	if err := runApp("new", "feature-picker", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("tmux", "list", "--repo", "tmuxlist")
+	})
+	if err != nil {
+		t.Fatalf("tmux list failed: %v", err)
+	}
+	if !strings.Contains(out, "feature-picker") {
+		t.Fatalf("expected picker output to include feature branch, got:\n%s", out)
+	}
+	if !strings.Contains(out, filepath.Join(".willow", "worktrees", "tmuxlist", "feature-picker")) {
+		t.Fatalf("expected picker output to include shortened worktree path, got:\n%s", out)
+	}
+}
+
+func TestTmuxStatusBarCommand_CountsWorktreesAndAgents(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "tmuxstatus"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "tmuxstatus")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	if err := runApp("new", "feature-agent", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+	writeActiveSessionFile(t, "tmuxstatus", "feature-agent", "s1", claude.StatusDone)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("tmux", "status-bar")
+	})
+	if err != nil {
+		t.Fatalf("tmux status-bar failed: %v", err)
+	}
+	if !strings.Contains(out, " 2 ") {
+		t.Fatalf("expected two worktrees in status bar, got %q", out)
+	}
+	if !strings.Contains(out, " 1") {
+		t.Fatalf("expected one active agent in status bar, got %q", out)
+	}
 }
 
 func assertBranches(t *testing.T, got, want []string) {

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -1,10 +1,16 @@
 package dashboard
 
 import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 )
 
@@ -223,5 +229,189 @@ func TestRenderTimelineKeybindingHint(t *testing.T) {
 	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, true, 0, nil)
 	if !strings.Contains(out, "t: timeline") {
 		t.Errorf("expected 't: timeline' in keybinding hint, got:\n%s", out)
+	}
+}
+
+func runDashboardGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func setupDashboardRepo(t *testing.T) string {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	src := filepath.Join(home, "src")
+	bareDir := filepath.Join(config.ReposDir(), "dashrepo.git")
+	wtPath := filepath.Join(config.WorktreesDir(), "dashrepo", "main")
+
+	if err := os.MkdirAll(filepath.Dir(bareDir), 0o755); err != nil {
+		t.Fatalf("mkdir repos dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
+		t.Fatalf("mkdir worktrees dir: %v", err)
+	}
+
+	runDashboardGit(t, home, "init", "--initial-branch=main", src)
+	runDashboardGit(t, src, "config", "user.email", "test@test")
+	runDashboardGit(t, src, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("# dash\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runDashboardGit(t, src, "add", ".")
+	runDashboardGit(t, src, "commit", "-m", "initial")
+	runDashboardGit(t, home, "clone", "--bare", src, bareDir)
+	runDashboardGit(t, bareDir, "update-ref", "refs/remotes/origin/main", "main")
+	runDashboardGit(t, bareDir, "worktree", "add", wtPath, "main")
+	runDashboardGit(t, wtPath, "config", "user.email", "test@test")
+	runDashboardGit(t, wtPath, "config", "user.name", "Test")
+	return wtPath
+}
+
+func writeDashboardSession(t *testing.T, repo, wtDir, sessionID string, status claude.Status, tool string, ts time.Time) {
+	t.Helper()
+
+	dir := filepath.Join(claude.StatusDir(), repo, wtDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir status dir: %v", err)
+	}
+	data, err := json.Marshal(claude.SessionStatus{
+		Status:    status,
+		SessionID: sessionID,
+		Tool:      tool,
+		Timestamp: ts,
+	})
+	if err != nil {
+		t.Fatalf("marshal session: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, sessionID+".json"), data, 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+}
+
+func resetDiffCache() {
+	diffCacheMu.Lock()
+	defer diffCacheMu.Unlock()
+	diffCache = map[string]cachedDiff{}
+}
+
+func TestCollectDataIncludesActiveSessionsUnreadAndDiffStats(t *testing.T) {
+	resetDiffCache()
+	wtPath := setupDashboardRepo(t)
+	if err := os.WriteFile(filepath.Join(wtPath, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+	runDashboardGit(t, wtPath, "add", "feature.txt")
+	runDashboardGit(t, wtPath, "commit", "-m", "feature")
+
+	now := time.Now()
+	writeDashboardSession(t, "dashrepo", "main", "busy-session", claude.StatusBusy, "Edit", now)
+	writeDashboardSession(t, "dashrepo", "main", "done-session", claude.StatusDone, "", now)
+
+	sessions, sum := collectData()
+	if sum.Repos != 1 {
+		t.Fatalf("Repos = %d, want 1", sum.Repos)
+	}
+	if sum.Agents != 2 {
+		t.Fatalf("Agents = %d, want 2 active busy/done sessions", sum.Agents)
+	}
+	if sum.Unread != 1 {
+		t.Fatalf("Unread = %d, want 1 done unread session", sum.Unread)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("len(sessions) = %d, want 2", len(sessions))
+	}
+
+	var sawBusy, sawDone bool
+	for _, s := range sessions {
+		if s.Repo != "dashrepo" || s.Branch != "main" || s.WtDirName != "main" {
+			t.Fatalf("unexpected session row: %+v", s)
+		}
+		if s.DiffStats != "1f +1" {
+			t.Fatalf("DiffStats = %q, want 1f +1", s.DiffStats)
+		}
+		if s.Status == claude.StatusBusy && s.Tool == "Edit" {
+			sawBusy = true
+		}
+		if s.Status == claude.StatusDone && s.Unread {
+			sawDone = true
+		}
+	}
+	if !sawBusy || !sawDone {
+		t.Fatalf("expected busy and unread done rows, got %+v", sessions)
+	}
+}
+
+func TestGetDiffStatsCachesByWorktreePath(t *testing.T) {
+	resetDiffCache()
+	wtPath := setupDashboardRepo(t)
+	if err := os.WriteFile(filepath.Join(wtPath, "first.txt"), []byte("first\n"), 0o644); err != nil {
+		t.Fatalf("write first: %v", err)
+	}
+	runDashboardGit(t, wtPath, "add", "first.txt")
+	runDashboardGit(t, wtPath, "commit", "-m", "first")
+
+	first := getDiffStats(wtPath, "main")
+	if first != "1f +1" {
+		t.Fatalf("first diff stats = %q, want 1f +1", first)
+	}
+
+	if err := os.WriteFile(filepath.Join(wtPath, "second.txt"), []byte("second\n"), 0o644); err != nil {
+		t.Fatalf("write second: %v", err)
+	}
+	runDashboardGit(t, wtPath, "add", "second.txt")
+	runDashboardGit(t, wtPath, "commit", "-m", "second")
+
+	second := getDiffStats(wtPath, "main")
+	if second != first {
+		t.Fatalf("cached diff stats changed before TTL expiry: got %q, want %q", second, first)
+	}
+}
+
+func TestUpdateFlashesRecordsBusyToDoneAndPrunesMissingSessions(t *testing.T) {
+	doneSession := session{
+		Repo:      "repo",
+		Branch:    "feature",
+		SessionID: "s1",
+		Status:    claude.StatusDone,
+		WtDirName: "feature",
+	}
+	key := sessionKey(doneSession)
+	prev := map[string]claude.Status{key: claude.StatusBusy}
+	flashUntil := map[string]time.Time{}
+
+	updateFlashes([]session{doneSession}, prev, flashUntil)
+	if prev[key] != claude.StatusDone {
+		t.Fatalf("prev[%q] = %s, want DONE", key, prev[key])
+	}
+	if until, ok := flashUntil[key]; !ok || time.Now().After(until) {
+		t.Fatalf("expected fresh flash entry, got %v ok=%v", until, ok)
+	}
+
+	updateFlashes(nil, prev, flashUntil)
+	if _, ok := prev[key]; ok {
+		t.Fatalf("expected missing session to be pruned from prev: %v", prev)
+	}
+	if _, ok := flashUntil[key]; ok {
+		t.Fatalf("expected missing session to be pruned from flashUntil: %v", flashUntil)
+	}
+}
+
+func TestTermWidthReturnsPositiveFallback(t *testing.T) {
+	if got := termWidth(); got <= 0 {
+		t.Fatalf("termWidth() = %d, want positive width", got)
 	}
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,39 @@
+package errors
+
+import (
+	stderrors "errors"
+	"fmt"
+	"testing"
+)
+
+func TestUserErrorWrappingAndDetection(t *testing.T) {
+	cause := fmt.Errorf("root cause")
+	err := User(cause)
+
+	if err.Error() != "root cause" {
+		t.Fatalf("Error() = %q, want root cause", err.Error())
+	}
+	if !stderrors.Is(err, cause) {
+		t.Fatalf("User error should unwrap to cause")
+	}
+	if !IsUser(err) {
+		t.Fatalf("IsUser() should identify User(cause)")
+	}
+	ue, ok := err.(interface{ IsUserError() bool })
+	if !ok || !ue.IsUserError() {
+		t.Fatalf("wrapped error should expose IsUserError")
+	}
+}
+
+func TestUserf(t *testing.T) {
+	err := Userf("hello %s", "willow")
+	if err.Error() != "hello willow" {
+		t.Fatalf("Userf() = %q, want formatted message", err.Error())
+	}
+	if !IsUser(err) {
+		t.Fatalf("IsUser() should identify Userf error")
+	}
+	if IsUser(fmt.Errorf("plain")) {
+		t.Fatalf("IsUser() should not identify plain errors")
+	}
+}

--- a/internal/fzf/fzf_pos_test.go
+++ b/internal/fzf/fzf_pos_test.go
@@ -1,6 +1,7 @@
 package fzf
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -58,5 +59,41 @@ func TestQueryEmpty(t *testing.T) {
 		if arg == "--query" {
 			t.Errorf("expected no --query in args when empty, got: %v", args)
 		}
+	}
+}
+
+func TestBuildArgsIncludesAllOptionsInOrder(t *testing.T) {
+	cfg := defaults()
+	WithAnsi()(cfg)
+	WithReverse()(cfg)
+	WithNoSort()(cfg)
+	WithHeader("Pick one")(cfg)
+	WithPreview("willow tmux preview -- {}", "right:50%:wrap")(cfg)
+	WithExpectKeys("ctrl-n", "ctrl-p")(cfg)
+	WithPrintQuery()(cfg)
+	WithQuery("feature")(cfg)
+	WithBind("start:reload(echo hi)", "ctrl-r:reload-sync(echo refresh)")(cfg)
+	WithDelimiter("\\|")(cfg)
+	WithNth("1,2")(cfg)
+
+	got := buildArgs(cfg)
+	want := []string{
+		"--ansi",
+		"--reverse",
+		"--no-sort",
+		"--cycle",
+		"--header", "Pick one",
+		"--preview", "willow tmux preview -- {}",
+		"--preview-window", "right:50%:wrap",
+		"--expect", "ctrl-n,ctrl-p",
+		"--print-query",
+		"--query", "feature",
+		"--bind", "start:reload(echo hi)",
+		"--bind", "ctrl-r:reload-sync(echo refresh)",
+		"--delimiter", "\\|",
+		"--nth", "1,2",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildArgs() = %#v, want %#v", got, want)
 	}
 }

--- a/internal/gh/pr_test.go
+++ b/internal/gh/pr_test.go
@@ -2,6 +2,8 @@ package gh
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -251,5 +253,77 @@ func TestSelectMatchingPR(t *testing.T) {
 	}
 	if got := selectMatchingPR(prs, ""); got != nil {
 		t.Fatalf("selectMatchingPR() with ambiguous empty head = %+v, want nil", got)
+	}
+}
+
+func TestBatchPRInfoUsesSingleGHCallAndFiltersBranches(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "gh.log")
+	ghPath := filepath.Join(binDir, "gh")
+	script := `#!/bin/sh
+set -eu
+printf '%s\n' "$*" >> "` + logPath + `"
+/bin/cat <<'JSON'
+[
+  {
+    "number": 1,
+    "title": "Feature A",
+    "headRefName": "feature-a",
+    "headRefOid": "sha-a",
+    "baseRefName": "main",
+    "state": "OPEN",
+    "reviewDecision": "APPROVED",
+    "mergeable": "MERGEABLE",
+    "additions": 10,
+    "deletions": 2,
+    "url": "https://github.com/org/repo/pull/1",
+    "statusCheckRollup": [{"name":"test","status":"COMPLETED","conclusion":"SUCCESS"}]
+  },
+  {
+    "number": 2,
+    "title": "Other",
+    "headRefName": "other",
+    "headRefOid": "sha-other",
+    "baseRefName": "main",
+    "state": "OPEN",
+    "reviewDecision": "REVIEW_REQUIRED",
+    "mergeable": "UNKNOWN",
+    "additions": 3,
+    "deletions": 4,
+    "url": "https://github.com/org/repo/pull/2",
+    "statusCheckRollup": []
+  }
+]
+JSON
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	got, err := BatchPRInfo(t.TempDir(), []string{"feature-a", "missing"})
+	if err != nil {
+		t.Fatalf("BatchPRInfo() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("BatchPRInfo() returned %d entries, want 1: %#v", len(got), got)
+	}
+	pr := got["feature-a"]
+	if pr == nil {
+		t.Fatalf("feature-a PR missing from result: %#v", got)
+	}
+	if pr.Number != 1 || pr.Title != "Feature A" || pr.CIStatus() != "pass" {
+		t.Fatalf("unexpected feature-a PR: %+v", pr)
+	}
+	if got["other"] != nil {
+		t.Fatalf("unrequested branch should be filtered out: %#v", got)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read gh log: %v", err)
+	}
+	if string(logData) != "pr list --json number,title,headRefName,headRefOid,baseRefName,state,mergedAt,reviewDecision,mergeable,additions,deletions,url,statusCheckRollup --limit 100 --state all\n" {
+		t.Fatalf("unexpected gh invocation:\n%s", logData)
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -254,6 +254,15 @@ func (g *Git) IsRebaseInProgress() bool {
 	if err != nil {
 		return false
 	}
+	if !filepath.IsAbs(gitDir) {
+		base := g.Dir
+		if base == "" {
+			if cwd, err := os.Getwd(); err == nil {
+				base = cwd
+			}
+		}
+		gitDir = filepath.Join(base, gitDir)
+	}
 	for _, dir := range []string{"rebase-merge", "rebase-apply"} {
 		if _, err := os.Stat(filepath.Join(gitDir, dir)); err == nil {
 			return true

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -241,5 +242,145 @@ func TestMergedBranchSet_EmptyInput(t *testing.T) {
 	set := g.MergedBranchSet("main", nil)
 	if len(set) != 0 {
 		t.Errorf("empty input should return empty set, got %v", set)
+	}
+}
+
+func TestRemoteBranchesFiltersOriginHead(t *testing.T) {
+	work := setupRemoteAndClone(t, "main")
+	g := &Git{Dir: work}
+
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = work
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	runGit("checkout", "-b", "remote-feature", "origin/main")
+	if err := os.WriteFile(filepath.Join(work, "remote-feature.txt"), []byte("remote feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit("add", "remote-feature.txt")
+	runGit("commit", "-m", "remote feature")
+	runGit("push", "origin", "remote-feature")
+	runGit("fetch", "origin")
+	runGit("remote", "set-head", "origin", "main")
+
+	branches, err := g.RemoteBranches()
+	if err != nil {
+		t.Fatalf("RemoteBranches() error = %v", err)
+	}
+	set := make(map[string]bool, len(branches))
+	for _, branch := range branches {
+		set[branch] = true
+		if branch == "HEAD" || branch == "origin/HEAD" {
+			t.Fatalf("RemoteBranches() should filter HEAD pointers, got %v", branches)
+		}
+		if strings.HasPrefix(branch, "origin/") {
+			t.Fatalf("RemoteBranches() should trim origin/ prefix, got %v", branches)
+		}
+	}
+	for _, want := range []string{"main", "remote-feature"} {
+		if !set[want] {
+			t.Fatalf("RemoteBranches() = %v, missing %q", branches, want)
+		}
+	}
+}
+
+func TestDirtyAheadUnpushedAndRebaseHelpers(t *testing.T) {
+	work := setupRemoteAndClone(t, "main")
+	g := &Git{Dir: work}
+
+	dirty, err := g.IsDirty()
+	if err != nil {
+		t.Fatalf("IsDirty() error = %v", err)
+	}
+	if dirty {
+		t.Fatal("fresh checkout should be clean")
+	}
+
+	if err := os.WriteFile(filepath.Join(work, "change.txt"), []byte("change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dirty, err = g.IsDirty()
+	if err != nil {
+		t.Fatalf("IsDirty() after write error = %v", err)
+	}
+	if !dirty {
+		t.Fatal("untracked file should mark worktree dirty")
+	}
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = work
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("add", "change.txt")
+	run("commit", "-m", "change")
+
+	dirty, err = g.IsDirty()
+	if err != nil {
+		t.Fatalf("IsDirty() after commit error = %v", err)
+	}
+	if dirty {
+		t.Fatal("committed worktree should be clean")
+	}
+
+	ahead, err := g.CommitsAhead("origin/main")
+	if err != nil {
+		t.Fatalf("CommitsAhead() error = %v", err)
+	}
+	if ahead != 1 {
+		t.Fatalf("CommitsAhead(origin/main) = %d, want 1", ahead)
+	}
+
+	unpushed, err := g.HasUnpushedCommits()
+	if err != nil {
+		t.Fatalf("HasUnpushedCommits() error = %v", err)
+	}
+	if !unpushed {
+		t.Fatal("local commit should be unpushed")
+	}
+	run("push", "origin", "main")
+	unpushed, err = g.HasUnpushedCommits()
+	if err != nil {
+		t.Fatalf("HasUnpushedCommits() after push error = %v", err)
+	}
+	if unpushed {
+		t.Fatal("pushed branch should not have unpushed commits")
+	}
+
+	gitDir, err := g.Run("rev-parse", "--git-dir")
+	if err != nil {
+		t.Fatalf("rev-parse --git-dir: %v", err)
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(work, gitDir)
+	}
+	rebaseDir := filepath.Join(gitDir, "rebase-merge")
+	if err := os.MkdirAll(rebaseDir, 0o755); err != nil {
+		t.Fatalf("mkdir rebase dir: %v", err)
+	}
+	if !g.IsRebaseInProgress() {
+		t.Fatal("synthetic rebase-merge dir should be detected")
+	}
+	if err := os.RemoveAll(rebaseDir); err != nil {
+		t.Fatalf("remove rebase dir: %v", err)
+	}
+	if g.IsRebaseInProgress() {
+		t.Fatal("removed rebase dir should not be detected")
 	}
 }

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -168,3 +168,39 @@ func TestRemoveReparentsChildren(t *testing.T) {
 		t.Error("a should be removed")
 	}
 }
+
+func TestIsEmpty(t *testing.T) {
+	if !(&Stack{Parents: map[string]string{}}).IsEmpty() {
+		t.Fatal("empty stack should report IsEmpty")
+	}
+	if (&Stack{Parents: map[string]string{"a": "main"}}).IsEmpty() {
+		t.Fatal("non-empty stack should not report IsEmpty")
+	}
+}
+
+func TestTreeLinesFiltersToVisibleBranches(t *testing.T) {
+	s := &Stack{Parents: map[string]string{
+		"a": "main",
+		"b": "a",
+		"c": "b",
+		"x": "main",
+	}}
+
+	lines := s.TreeLines(map[string]bool{"b": true, "c": true})
+	if len(lines) != 2 {
+		t.Fatalf("TreeLines() returned %d lines, want 2: %+v", len(lines), lines)
+	}
+	if lines[0].Branch != "b" || lines[0].Prefix != "└─ " || lines[0].Depth != 1 {
+		t.Fatalf("first tree line = %+v, want b with skipped-root prefix", lines[0])
+	}
+	if lines[1].Branch != "c" || lines[1].Depth != 2 {
+		t.Fatalf("second tree line = %+v, want c descendant", lines[1])
+	}
+}
+
+func TestTreeLinesEmptyStack(t *testing.T) {
+	s := &Stack{Parents: map[string]string{}}
+	if got := s.TreeLines(map[string]bool{"a": true}); got != nil {
+		t.Fatalf("empty TreeLines() = %+v, want nil", got)
+	}
+}

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -247,6 +248,56 @@ func TestExtractPathFromLine(t *testing.T) {
 				t.Errorf("ExtractPathFromLine() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatPickerLinesMultiRepoMergedUnreadAndSubSessions(t *testing.T) {
+	t.Setenv("HOME", "/fakehome")
+	now := time.Now()
+
+	items := []PickerItem{
+		{
+			RepoName:  "repo-a",
+			Branch:    "done-branch",
+			WtPath:    "/fakehome/worktrees/repo-a/done-branch",
+			Status:    claude.StatusDone,
+			Unread:    true,
+			Merged:    true,
+			WtDirName: "done-branch",
+		},
+		{
+			RepoName:    "repo-b",
+			Branch:      "stack-child",
+			WtPath:      "/fakehome/worktrees/repo-b/stack-child",
+			Status:      claude.StatusBusy,
+			StackPrefix: "└─ ",
+			Sessions: []*claude.SessionStatus{
+				{SessionID: "busy-session-123", Status: claude.StatusBusy, Tool: "Edit", Timestamp: now},
+				{SessionID: "done-session-456", Status: claude.StatusDone, Timestamp: now},
+			},
+			WtDirName: "stack-child",
+		},
+	}
+
+	lines := FormatPickerLines(items)
+	if len(lines) != 4 {
+		t.Fatalf("FormatPickerLines() returned %d lines, want 4: %#v", len(lines), lines)
+	}
+
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{
+		"repo-a/done-branch",
+		"[merged]",
+		"●",
+		"~/worktrees/repo-a/done-branch",
+		"└─ repo-b/stack-child",
+		"busy-se",
+		"(Edit)",
+		"done-se",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("formatted picker lines missing %q:\n%s", want, joined)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description of the change
Adds focused coverage for the highest-risk Willow paths: tmux command helpers, stacked sync integration behavior, dashboard data collection and diff caching, config/log/stack/refresh command actions, and git/gh/fzf wrappers.

Also adds a non-blocking CI coverage report step and fixes two bugs uncovered by the new tests: relative git-dir rebase detection and sync abort worktree discovery for detached rebases.

## Test plan
go test ./... -count=1
go test ./... -coverpkg=./... -coverprofile=/tmp/willow_all.cover -covermode=count

## Loom or screenshots
N/A