### PR TITLE
:sparkles: feat[worktree]: support detached worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ This gives you:
 | `ww <cmd>` | Alias for `willow` |
 | `ww sw` | fzf worktree switcher (cd's into selection) |
 | `ww new <branch>` | Create worktree + cd into it (tmux-aware) |
+| `ww new <name> --detach` | Create a named detached worktree |
+| `ww promote [name] <branch>` | Promote a detached worktree to a branch |
 | `ww checkout <branch>` | Smart checkout + cd (switch or create, tmux-aware) |
 | `wwn <branch>` | Shorthand for `ww new` |
 | `wwc <branch>` | Shorthand for `ww checkout` |
@@ -168,29 +170,48 @@ ww clone git@github.com:org/repo.git --force    # re-clone from scratch
 
 ### `ww new <branch> [flags]`
 
-Create a new worktree with a new branch, an existing branch, or a GitHub PR.
+Create a new worktree with a new branch, an existing branch, a named detached HEAD, or a GitHub PR.
 
 ```bash
 ww new feature/auth                    # create worktree
 ww new feature/auth -b develop         # fork from specific branch
 ww new -e existing-branch              # use existing branch
 ww new -e                              # pick from remote branches (fzf)
+ww new scratch-repro --detach          # named detached worktree at default base
+ww new v1-debug --detach --ref v1.2.3  # named detached worktree at a tag/commit
 ww new --pr 123                        # checkout PR #123
 ww new https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww new feature/auth -r myrepo          # target a specific repo
 ww new feature/auth                    # auto-cd via shell integration (tmux-aware)
 ```
 
-From the tmux picker, `Ctrl-E` opens the same existing-branch flow from cached refs first, then refreshes remote branches in the background so large repos feel instant to open.
+From the tmux picker, `Ctrl-T` creates a named detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree to a branch, and `Ctrl-E` opens the existing-branch flow from cached refs first, then refreshes remote branches in the background so large repos feel instant to open.
 
 | Flag | Description |
 |------|-------------|
 | `-b, --base` | Base branch to fork from |
 | `-r, --repo` | Target repo by name |
 | `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) |
+| `--detach` | Create a named detached HEAD worktree |
+| `--ref` | Commit, tag, or branch to check out in detached mode |
 | `--pr` | GitHub PR number or URL |
 | `--no-fetch` | Skip fetching from remote |
 | `--cd` | Print only the path (for scripting) |
+
+### `ww promote [worktree] <branch>`
+
+Promote a named detached worktree to a normal branch-backed worktree in place. The directory and tmux session name stay the same, so active panes and agent status do not move.
+
+```bash
+ww promote feature/auth                 # from inside a detached worktree
+ww promote scratch-repro feature/auth   # promote by worktree name
+ww promote scratch-repro                # promote to branch scratch-repro
+```
+
+| Flag | Description |
+|------|-------------|
+| `-r, --repo` | Target repo by name |
+| `-b, --base` | Record a stack parent for the promoted branch |
 
 ### `ww checkout <branch-or-pr-url>` (alias: `co`)
 

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -82,6 +82,7 @@ func NewApp() *cli.Command {
 		Commands: []*cli.Command{
 			cloneCmd(),
 			newCmd(),
+			promoteCmd(),
 			checkoutCmd(),
 			syncCmd(),
 			prCmd(),

--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -156,7 +156,7 @@ func checkoutCmd() *cli.Command {
 			}
 
 			if repoGit.RemoteBranchExists(branch) {
-				dirName := strings.ReplaceAll(branch, "/", "-")
+				dirName := worktreeDirName(branch)
 				wtPath := filepath.Join(config.WorktreesDir(), repo.Name, dirName)
 
 				done = tr.StartCtx(ctx, "git worktree add (existing)")
@@ -199,7 +199,7 @@ func checkoutCmd() *cli.Command {
 				gitRef = baseBranch
 			}
 
-			dirName := strings.ReplaceAll(branch, "/", "-")
+			dirName := worktreeDirName(branch)
 			wtPath := filepath.Join(config.WorktreesDir(), repo.Name, dirName)
 
 			done = tr.StartCtx(ctx, "git worktree add (new)")

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -89,7 +89,7 @@ func gcCmd() *cli.Command {
 				branchHeads := make(map[string]string, len(wts))
 				repoDir := ""
 				for _, wt := range wts {
-					if wt.IsBare || wt.Branch == "" {
+					if wt.IsBare || wt.Detached || wt.Branch == "" {
 						continue
 					}
 					if repoDir == "" {
@@ -108,7 +108,7 @@ func gcCmd() *cli.Command {
 				}
 
 				for _, wt := range wts {
-					if !wt.IsBare && mergedSet[wt.Branch] {
+					if !wt.IsBare && !wt.Detached && mergedSet[wt.Branch] {
 						candidates = append(candidates, mergedWorktree{repoName: repoName, branch: wt.Branch})
 					}
 				}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -447,6 +447,258 @@ func TestNew_CreatesWorktree(t *testing.T) {
 	}
 }
 
+func TestNew_DetachedCreatesNamedWorktree(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "scratch-repro", "--detach", "--ref", "HEAD", "--no-fetch"); err != nil {
+		t.Fatalf("new --detach failed: %v", err)
+	}
+
+	detachedDir := filepath.Join(worktreeDir, "scratch-repro")
+	if _, err := os.Stat(detachedDir); os.IsNotExist(err) {
+		t.Fatalf("detached worktree not created at %s", detachedDir)
+	}
+
+	wtGit := &git.Git{Dir: detachedDir}
+	branch, err := wtGit.Run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	if branch != "HEAD" {
+		t.Fatalf("detached worktree branch = %q, want HEAD", branch)
+	}
+
+	bareDir := filepath.Join(home, ".willow", "repos", "testrepo.git")
+	repoGit := &git.Git{Dir: bareDir}
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		t.Fatalf("list worktrees: %v", err)
+	}
+	var found *worktree.Worktree
+	for i := range wts {
+		if comparablePath(wts[i].Path) == comparablePath(detachedDir) {
+			found = &wts[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("detached worktree missing from git worktree list")
+	}
+	if !found.Detached {
+		t.Fatalf("Detached = false, want true")
+	}
+	if got := found.MatchName(); got != "scratch-repro" {
+		t.Fatalf("MatchName() = %q, want scratch-repro", got)
+	}
+}
+
+func TestPromote_DetachedWorktreeInPlace(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "scratch-repro", "--detach", "--ref", "HEAD", "--no-fetch"); err != nil {
+		t.Fatalf("new --detach failed: %v", err)
+	}
+
+	detachedDir := filepath.Join(worktreeDir, "scratch-repro")
+	os.Chdir(detachedDir)
+	if err := runApp("promote", "feature-from-scratch"); err != nil {
+		t.Fatalf("promote failed: %v", err)
+	}
+
+	wtGit := &git.Git{Dir: detachedDir}
+	branch, err := wtGit.Run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	if branch != "feature-from-scratch" {
+		t.Fatalf("branch = %q, want feature-from-scratch", branch)
+	}
+
+	bareDir := filepath.Join(home, ".willow", "repos", "testrepo.git")
+	repoGit := &git.Git{Dir: bareDir}
+	out, err := repoGit.Run("branch", "--list", "feature-from-scratch")
+	if err != nil {
+		t.Fatalf("git branch --list: %v", err)
+	}
+	if out == "" {
+		t.Fatal("branch 'feature-from-scratch' not found")
+	}
+
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		t.Fatalf("list worktrees: %v", err)
+	}
+	for _, wt := range wts {
+		if comparablePath(wt.Path) == comparablePath(detachedDir) {
+			if wt.Detached {
+				t.Fatal("promoted worktree still marked detached")
+			}
+			if wt.Branch != "feature-from-scratch" {
+				t.Fatalf("worktree branch = %q, want feature-from-scratch", wt.Branch)
+			}
+			return
+		}
+	}
+	t.Fatalf("promoted worktree missing from git worktree list")
+}
+
+func TestPromote_DetachedByNameFromAnotherWorktree(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	bareDir := filepath.Join(home, ".willow", "repos", "testrepo.git")
+	configPath := filepath.Join(bareDir, "willow.json")
+	if err := os.WriteFile(configPath, []byte(`{"branchPrefix": "alice"}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	if err := runApp("new", "scratch-repro", "--detach", "--ref", "HEAD", "--no-fetch"); err != nil {
+		t.Fatalf("new --detach failed: %v", err)
+	}
+	if err := runApp("promote", "scratch-repro", "feature-by-name"); err != nil {
+		t.Fatalf("promote by name failed: %v", err)
+	}
+
+	detachedDir := filepath.Join(worktreeDir, "scratch-repro")
+	wtGit := &git.Git{Dir: detachedDir}
+	branch, err := wtGit.Run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	if branch != "alice/feature-by-name" {
+		t.Fatalf("branch = %q, want alice/feature-by-name", branch)
+	}
+
+	if err := runApp("new", "scratch-onearg", "--detach", "--ref", "HEAD", "--no-fetch"); err != nil {
+		t.Fatalf("second new --detach failed: %v", err)
+	}
+	if err := runApp("promote", "scratch-onearg"); err != nil {
+		t.Fatalf("promote one arg from another worktree failed: %v", err)
+	}
+
+	oneArgGit := &git.Git{Dir: filepath.Join(worktreeDir, "scratch-onearg")}
+	oneArgBranch, err := oneArgGit.Run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse one-arg HEAD: %v", err)
+	}
+	if oneArgBranch != "alice/scratch-onearg" {
+		t.Fatalf("branch = %q, want alice/scratch-onearg", oneArgBranch)
+	}
+}
+
+func TestNew_DetachedRejectsConflictingModes(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "ref requires detach",
+			args: []string{"new", "scratch-ref", "--ref", "HEAD"},
+			want: "--ref can only be used with --detach",
+		},
+		{
+			name: "detach excludes existing",
+			args: []string{"new", "scratch-existing", "--detach", "--existing", "--no-fetch"},
+			want: "--detach cannot be used with --existing",
+		},
+		{
+			name: "detach excludes pr",
+			args: []string{"new", "scratch-pr", "--detach", "--pr", "1", "--no-fetch"},
+			want: "--detach cannot be used with --pr",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runApp(tt.args...)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestRm_DetachedWithUnanchoredCommitRequiresForce(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "scratch-repro", "--detach", "--ref", "HEAD", "--no-fetch"); err != nil {
+		t.Fatalf("new --detach failed: %v", err)
+	}
+
+	detachedDir := filepath.Join(worktreeDir, "scratch-repro")
+	commitFile(t, detachedDir, "detached.txt", "detached\n", "detached commit")
+
+	err := runApp("rm", "--repo", "testrepo", "scratch-repro")
+	if err == nil {
+		t.Fatal("expected rm to reject unanchored detached commit")
+	}
+	if !strings.Contains(err.Error(), "detached HEAD has unanchored commits") {
+		t.Fatalf("error = %q, want unanchored detached warning", err.Error())
+	}
+
+	if err := runApp("rm", "--repo", "testrepo", "--force", "scratch-repro"); err != nil {
+		t.Fatalf("rm --force failed: %v", err)
+	}
+	if _, err := os.Stat(detachedDir); !os.IsNotExist(err) {
+		t.Fatal("detached worktree should be removed after --force")
+	}
+}
+
 func TestNew_BranchPrefixFromConfig(t *testing.T) {
 	origin := setupTestEnv(t)
 	home, _ := os.UserHomeDir()

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -204,7 +204,7 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 		if repoDir == "" {
 			repoDir = wt.Path
 		}
-		if wt.Branch != "" {
+		if wt.Branch != "" && !wt.Detached {
 			branches = append(branches, wt.Branch)
 			branchHeads[wt.Branch] = wt.Head
 		}
@@ -222,7 +222,7 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 		ws := claude.ReadStatus(repoName, wtDir)
 		rows = append(rows, lsRow{
 			branch: wt.Branch,
-			merged: mergedSet[wt.Branch],
+			merged: !wt.Detached && mergedSet[wt.Branch],
 			status: ws.Status,
 			unread: ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir),
 			wt:     wt,
@@ -235,7 +235,7 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 	pathW := len("PATH")
 	ageW := len("AGE")
 	for _, row := range rows {
-		display := row.prefix + row.branch
+		display := row.prefix + row.wt.DisplayName()
 		if row.merged {
 			display += " [merged]"
 		}
@@ -260,7 +260,7 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 		if row.unread {
 			statusLabel += "\u25CF" // ●
 		}
-		branchPlain := row.prefix + row.branch
+		branchPlain := row.prefix + row.wt.DisplayName()
 		branchDisplay := branchPlain
 		if row.merged {
 			branchPlain += " [merged]"
@@ -283,6 +283,9 @@ func sortLSRows(rows []lsRow, st *stack.Stack) []lsRow {
 	rowMap := make(map[string]*lsRow, len(rows))
 	branchSet := make(map[string]bool, len(rows))
 	for i := range rows {
+		if rows[i].wt.Detached {
+			continue
+		}
 		rowMap[rows[i].branch] = &rows[i]
 		branchSet[rows[i].branch] = true
 	}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -25,6 +25,14 @@ func repoNameFromDir(bareDir string) string {
 	return strings.TrimSuffix(filepath.Base(bareDir), ".git")
 }
 
+func detachedWorktreeDirName(name string) (string, error) {
+	dirName := worktreeDirName(name)
+	if dirName == "" || dirName == "." || dirName == ".." {
+		return "", errors.Userf("invalid detached worktree name %q", name)
+	}
+	return dirName, nil
+}
+
 func runHooks(commands []string, dir string, u *ui.UI, stdout *os.File) error {
 	for _, c := range commands {
 		u.Info(fmt.Sprintf("  → %s", c))
@@ -76,6 +84,57 @@ func runPostCheckoutHook(hookPath, wtPath string, u *ui.UI, cdOnly bool) {
 	}
 }
 
+func resolveDetachedRef(ctx context.Context, tr *trace.Tracer, cmd *cli.Command, cfg *config.Config, repoGit *git.Git, u *ui.UI, cdOnly bool) (string, string, error) {
+	if ref := cmd.String("ref"); ref != "" {
+		return ref, ref, nil
+	}
+
+	done := tr.StartCtx(ctx, "resolve detached ref")
+	baseBranch := cmd.String("base")
+	explicitBase := baseBranch != ""
+	var err error
+	if baseBranch == "" {
+		baseBranch = cfg.BaseBranch
+	}
+	if baseBranch == "" {
+		baseBranch, err = repoGit.DefaultBranch()
+		if err != nil {
+			done()
+			return "", "", fmt.Errorf("failed to detect default branch (use --ref to specify): %w", err)
+		}
+	}
+	done()
+
+	localBase := explicitBase && repoGit.LocalBranchExists(baseBranch)
+	gitRef := "origin/" + baseBranch
+	if localBase {
+		gitRef = baseBranch
+	}
+
+	shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch") && !localBase
+	if shouldFetch {
+		done = tr.StartCtx(ctx, "git fetch detached ref")
+		if cdOnly {
+			fmt.Fprintf(os.Stderr, "Fetching %s from origin...\n", baseBranch)
+			if _, err := repoGit.RunStream(os.Stderr, "fetch", "--progress", "origin", baseBranch); err != nil {
+				done()
+				return "", "", fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
+			}
+		} else {
+			if err := u.Spin(fmt.Sprintf("Fetching %s from origin", u.Bold(baseBranch)), func() error {
+				_, err := repoGit.Run("fetch", "origin", baseBranch)
+				return err
+			}); err != nil {
+				done()
+				return "", "", fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
+			}
+		}
+		done()
+	}
+
+	return gitRef, gitRef, nil
+}
+
 func newCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "new",
@@ -102,6 +161,15 @@ func newCmd() *cli.Command {
 				Name:    "existing",
 				Aliases: []string{"e"},
 				Usage:   "Use an existing local/remote branch",
+			},
+			&cli.BoolFlag{
+				Name:    "detach",
+				Aliases: []string{"detached"},
+				Usage:   "Create a detached HEAD worktree named <branch>",
+			},
+			&cli.StringFlag{
+				Name:  "ref",
+				Usage: "Commit, tag, or branch to check out in detached mode",
 			},
 			&cli.BoolFlag{
 				Name:  "no-fetch",
@@ -152,6 +220,50 @@ func newCmd() *cli.Command {
 			repoName := repoNameFromDir(bareDir)
 
 			branch := cmd.StringArg("branch")
+			detached := cmd.Bool("detach")
+			if !detached && cmd.String("ref") != "" {
+				return errors.Userf("--ref can only be used with --detach")
+			}
+
+			if detached {
+				if existing {
+					return errors.Userf("--detach cannot be used with --existing")
+				}
+				if cmd.String("pr") != "" {
+					return errors.Userf("--detach cannot be used with --pr")
+				}
+				if branch == "" {
+					return errors.Userf("worktree name is required\n\nUsage: ww new <name> --detach [--ref <commit-ish>]")
+				}
+
+				name := branch
+				dirName, err := detachedWorktreeDirName(name)
+				if err != nil {
+					return err
+				}
+				ref, refLabel, err := resolveDetachedRef(ctx, tr, cmd, cfg, repoGit, u, cdOnly)
+				if err != nil {
+					return err
+				}
+
+				wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
+
+				done = tr.StartCtx(ctx, "git worktree add detached")
+				if cdOnly {
+					fmt.Fprintf(os.Stderr, "Creating detached worktree %s at %s...\n", name, refLabel)
+					if _, err := repoGit.RunStream(os.Stderr, "worktree", "add", "--detach", wtPath, ref); err != nil {
+						return fmt.Errorf("failed to create detached worktree: %w", err)
+					}
+				} else {
+					u.Info(fmt.Sprintf("Creating detached worktree %s at %s...", u.Bold(name), u.Bold(refLabel)))
+					if _, err := repoGit.Run("worktree", "add", "--detach", wtPath, ref); err != nil {
+						return fmt.Errorf("failed to create detached worktree: %w", err)
+					}
+				}
+				done()
+
+				return finishDetachedWorktree(ctx, tr, cfg, g, u, wtPath, repoName, name, refLabel, cdOnly)
+			}
 
 			if prRef := cmd.String("pr"); prRef != "" {
 				done = tr.StartCtx(ctx, "resolve PR")
@@ -230,7 +342,7 @@ func newCmd() *cli.Command {
 					done()
 				}
 
-				dirName := strings.ReplaceAll(branch, "/", "-")
+				dirName := worktreeDirName(branch)
 				wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
 
 				done = tr.StartCtx(ctx, "git worktree add")
@@ -297,7 +409,7 @@ func newCmd() *cli.Command {
 				done()
 			}
 
-			dirName := strings.ReplaceAll(branch, "/", "-")
+			dirName := worktreeDirName(branch)
 			wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
 
 			done = tr.StartCtx(ctx, "git worktree add")
@@ -327,13 +439,27 @@ func newCmd() *cli.Command {
 	}
 }
 
+type finishWorktreeOptions struct {
+	BaseBranch string
+	Detached   bool
+	Ref        string
+}
+
 func finishWorktree(ctx context.Context, tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, wtPath, repoName, branch, baseBranch string, cdOnly bool) error {
+	return finishWorktreeWithOptions(ctx, tr, cfg, g, u, wtPath, repoName, branch, finishWorktreeOptions{BaseBranch: baseBranch}, cdOnly)
+}
+
+func finishDetachedWorktree(ctx context.Context, tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, wtPath, repoName, name, ref string, cdOnly bool) error {
+	return finishWorktreeWithOptions(ctx, tr, cfg, g, u, wtPath, repoName, name, finishWorktreeOptions{Detached: true, Ref: ref}, cdOnly)
+}
+
+func finishWorktreeWithOptions(ctx context.Context, tr *trace.Tracer, cfg *config.Config, g *git.Git, u *ui.UI, wtPath, repoName, label string, opts finishWorktreeOptions, cdOnly bool) error {
 	done := tr.StartCtx(ctx, "post-checkout hook")
 	runPostCheckoutHook(cfg.PostCheckoutHook, wtPath, u, cdOnly)
 	done()
 
 	done = tr.StartCtx(ctx, "auto setup remote")
-	if *cfg.Defaults.AutoSetupRemote {
+	if *cfg.Defaults.AutoSetupRemote && !opts.Detached {
 		wtGit := &git.Git{Dir: wtPath, Verbose: g.Verbose}
 		if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
 			u.Warn("Failed to set push.autoSetupRemote: " + err.Error())
@@ -373,20 +499,33 @@ func finishWorktree(ctx context.Context, tr *trace.Tracer, cfg *config.Config, g
 	done()
 
 	meta := map[string]string{}
-	if baseBranch != "" {
-		meta["base"] = baseBranch
+	if opts.BaseBranch != "" {
+		meta["base"] = opts.BaseBranch
 	}
-	_ = log.Append(log.Event{Action: "create", Repo: repoName, Branch: branch, Metadata: meta})
+	if opts.Detached {
+		meta["detached"] = "true"
+		if opts.Ref != "" {
+			meta["ref"] = opts.Ref
+		}
+	}
+	_ = log.Append(log.Event{Action: "create", Repo: repoName, Branch: label, Metadata: meta})
 
 	if cdOnly {
 		fmt.Println(wtPath)
 		return nil
 	}
 
-	u.Success(fmt.Sprintf("Created worktree %s", u.Bold(branch)))
+	if opts.Detached {
+		u.Success(fmt.Sprintf("Created detached worktree %s", u.Bold(label)))
+	} else {
+		u.Success(fmt.Sprintf("Created worktree %s", u.Bold(label)))
+	}
 	u.Info(fmt.Sprintf("  path:   %s", u.Dim(wtPath)))
-	if baseBranch != "" {
-		u.Info(fmt.Sprintf("  base:   %s", u.Dim("origin/"+baseBranch)))
+	if opts.BaseBranch != "" {
+		u.Info(fmt.Sprintf("  base:   %s", u.Dim("origin/"+opts.BaseBranch)))
+	}
+	if opts.Ref != "" {
+		u.Info(fmt.Sprintf("  ref:    %s", u.Dim(opts.Ref)))
 	}
 	return nil
 }
@@ -442,7 +581,7 @@ func pickExistingBranchWithQuery(repoGit *git.Git, query string) (string, error)
 	}
 	wtBranches := make(map[string]bool)
 	for _, wt := range wts {
-		if !wt.IsBare {
+		if !wt.IsBare && !wt.Detached {
 			wtBranches[wt.Branch] = true
 		}
 	}

--- a/internal/cli/pr.go
+++ b/internal/cli/pr.go
@@ -232,6 +232,9 @@ func worktreePathsByBranch(repoGit *git.Git) (map[string]string, error) {
 
 	paths := make(map[string]string, len(wts))
 	for _, wt := range filterBareWorktrees(wts) {
+		if wt.Detached {
+			continue
+		}
 		paths[wt.Branch] = wt.Path
 	}
 	return paths, nil

--- a/internal/cli/promote.go
+++ b/internal/cli/promote.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/errors"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/log"
+	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/trace"
+	"github.com/iamrajjoshi/willow/internal/worktree"
+	"github.com/urfave/cli/v3"
+)
+
+func promoteCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "promote",
+		Usage: "Promote a detached worktree to a branch",
+		Arguments: []cli.Argument{
+			&cli.StringArg{
+				Name:      "target",
+				UsageText: "[worktree]",
+			},
+			&cli.StringArg{
+				Name:      "branch",
+				UsageText: "<branch>",
+			},
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target a willow-managed repo by name",
+			},
+			&cli.StringFlag{
+				Name:    "base",
+				Aliases: []string{"b"},
+				Usage:   "Record a stack parent for the promoted branch",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			flags := parseFlags(cmd)
+			tr := trace.FromContext(ctx)
+			defer tr.Total()
+			g := flags.NewGit()
+			u := flags.NewUI()
+
+			target, branch := promotionArgs(g, cmd.StringArg("target"), cmd.StringArg("branch"))
+			if branch == "" {
+				return errors.Userf("branch name is required\n\nUsage: ww promote [worktree] <branch>")
+			}
+
+			done := tr.StartCtx(ctx, "resolve promotion target")
+			rwt, err := resolvePromotionTarget(g, cmd.String("repo"), target)
+			if err != nil {
+				return err
+			}
+			done()
+
+			if !rwt.Worktree.Detached {
+				return errors.Userf("worktree %q is already on branch %q", rwt.Worktree.MatchName(), rwt.Worktree.Branch)
+			}
+
+			done = tr.StartCtx(ctx, "load config")
+			cfg := config.Load(rwt.Repo.BareDir)
+			done()
+
+			if cfg.BranchPrefix != "" && !strings.HasPrefix(branch, cfg.BranchPrefix+"/") {
+				branch = cfg.BranchPrefix + "/" + branch
+			}
+
+			repoGit := &git.Git{Dir: rwt.Repo.BareDir, Verbose: g.Verbose}
+			if repoGit.LocalBranchExists(branch) {
+				return errors.Userf("branch %q already exists", branch)
+			}
+
+			done = tr.StartCtx(ctx, "git checkout branch")
+			wtGit := &git.Git{Dir: rwt.Worktree.Path, Verbose: g.Verbose}
+			if _, err := wtGit.Run("checkout", "-b", branch); err != nil {
+				return fmt.Errorf("failed to promote detached worktree: %w", err)
+			}
+			done()
+
+			done = tr.StartCtx(ctx, "auto setup remote")
+			if *cfg.Defaults.AutoSetupRemote {
+				if _, err := wtGit.Run("config", "--local", "push.autoSetupRemote", "true"); err != nil {
+					u.Warn("Failed to set push.autoSetupRemote: " + err.Error())
+				}
+			}
+			done()
+
+			baseBranch := cmd.String("base")
+			if baseBranch != "" {
+				done = tr.StartCtx(ctx, "record stack parent")
+				if err := stack.Update(rwt.Repo.BareDir, func(s *stack.Stack) {
+					s.SetParent(branch, baseBranch)
+				}); err != nil {
+					u.Warn(fmt.Sprintf("Failed to save stack: %v", err))
+				}
+				done()
+			}
+
+			meta := map[string]string{
+				"from": rwt.Worktree.MatchName(),
+				"path": rwt.Worktree.Path,
+			}
+			if baseBranch != "" {
+				meta["base"] = baseBranch
+			}
+			_ = log.Append(log.Event{Action: "promote", Repo: rwt.Repo.Name, Branch: branch, Metadata: meta})
+
+			u.Success(fmt.Sprintf("Promoted %s to branch %s", u.Bold(rwt.Worktree.MatchName()), u.Bold(branch)))
+			u.Info(fmt.Sprintf("  path:   %s", u.Dim(rwt.Worktree.Path)))
+			if baseBranch != "" {
+				u.Info(fmt.Sprintf("  base:   %s", u.Dim(baseBranch)))
+			}
+			return nil
+		},
+	}
+}
+
+func promotionArgs(g *git.Git, first, second string) (target, branch string) {
+	if second != "" {
+		return first, second
+	}
+	if first == "" {
+		return "", ""
+	}
+	if current, err := currentManagedWorktree(g); err == nil && current.Worktree.Detached {
+		return "", first
+	}
+	return first, first
+}
+
+func resolvePromotionTarget(g *git.Git, repoFlag, target string) (*repoWorktree, error) {
+	if target == "" {
+		return currentManagedWorktree(g)
+	}
+
+	repos, err := resolveRepos(g, repoFlag)
+	if err != nil {
+		return nil, err
+	}
+	allWts := collectAllWorktrees(repos, g.Verbose)
+	return findCrossRepoWorktree(allWts, target)
+}
+
+func currentManagedWorktree(g *git.Git) (*repoWorktree, error) {
+	bareDir, err := requireWillowRepo(g)
+	if err != nil {
+		return nil, err
+	}
+	root, err := g.WorktreeRoot()
+	if err != nil {
+		return nil, errors.Userf("not inside a willow-managed worktree\n\nRun this from a detached worktree, or pass a worktree name.")
+	}
+
+	repo := repoInfo{Name: repoNameFromDir(bareDir), BareDir: bareDir}
+	repoGit := &git.Git{Dir: bareDir, Verbose: g.Verbose}
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+
+	cleanRoot := comparablePath(filepath.Clean(root))
+	for _, wt := range filterBareWorktrees(wts) {
+		if comparablePath(filepath.Clean(wt.Path)) == cleanRoot {
+			return &repoWorktree{Repo: repo, Worktree: wt}, nil
+		}
+	}
+	return nil, errors.Userf("current directory is not a willow-managed worktree")
+}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -199,39 +199,56 @@ func rmCmd() *cli.Command {
 
 func removeWorktree(ctx context.Context, tr *trace.Tracer, u *ui.UI, repoGit *git.Git, wt *worktree.Worktree, bareDir string, cfg *config.Config, force, keepBranch, verbose bool) error {
 	wtGit := &git.Git{Dir: wt.Path, Verbose: verbose}
+	label := wt.DisplayName()
 
 	st := stack.Load(bareDir)
-	if children := st.Children(wt.Branch); len(children) > 0 && !force {
-		u.Warn(fmt.Sprintf("Branch %s has stacked children: %s", u.Bold(wt.Branch), strings.Join(children, ", ")))
-		u.Warn("Children will be re-parented. Use --force to proceed.")
-		return errors.Userf("branch has stacked children (use --force)")
+	if !wt.Detached {
+		if children := st.Children(wt.Branch); len(children) > 0 && !force {
+			u.Warn(fmt.Sprintf("Branch %s has stacked children: %s", u.Bold(wt.Branch), strings.Join(children, ", ")))
+			u.Warn("Children will be re-parented. Use --force to proceed.")
+			return errors.Userf("branch has stacked children (use --force)")
+		}
 	}
 
 	if !force {
-		done := tr.StartCtx(ctx, "check dirty " + wt.Branch)
+		done := tr.StartCtx(ctx, "check dirty "+label)
 		dirty, err := wtGit.IsDirty()
 		if err != nil {
 			return err
 		}
 		if dirty {
-			u.Warn(fmt.Sprintf("Worktree %s has uncommitted changes", u.Bold(wt.Branch)))
+			u.Warn(fmt.Sprintf("Worktree %s has uncommitted changes", u.Bold(label)))
 		}
 		done()
 
-		done = tr.StartCtx(ctx, "check unpushed " + wt.Branch)
-		unpushed, err := wtGit.HasUnpushedCommits()
-		if err != nil {
-			return err
+		if wt.Detached {
+			done = tr.StartCtx(ctx, "check detached reachability "+label)
+			reachable, err := detachedHeadReachable(wtGit)
+			if err != nil {
+				return err
+			}
+			if !reachable {
+				u.Warn(fmt.Sprintf("Detached worktree %s has commits not reachable from any branch", u.Bold(label)))
+				done()
+				return errors.Userf("detached HEAD has unanchored commits (use --force)")
+			}
+			done()
+		} else {
+			done = tr.StartCtx(ctx, "check unpushed "+wt.Branch)
+			unpushed, err := wtGit.HasUnpushedCommits()
+			if err != nil {
+				return err
+			}
+			if unpushed {
+				u.Warn(fmt.Sprintf("Worktree %s has unpushed commits", u.Bold(wt.Branch)))
+			}
+			done()
 		}
-		if unpushed {
-			u.Warn(fmt.Sprintf("Worktree %s has unpushed commits", u.Bold(wt.Branch)))
-		}
-		done()
 	}
 
 	if len(cfg.Teardown) > 0 {
-		done := tr.StartCtx(ctx, "teardown hooks " + wt.Branch)
-		u.Info(fmt.Sprintf("Running teardown hooks for %s...", u.Bold(wt.Branch)))
+		done := tr.StartCtx(ctx, "teardown hooks "+label)
+		u.Info(fmt.Sprintf("Running teardown hooks for %s...", u.Bold(label)))
 		if err := runHooks(cfg.Teardown, wt.Path, u, os.Stdout); err != nil {
 			return err
 		}
@@ -241,7 +258,7 @@ func removeWorktree(ctx context.Context, tr *trace.Tracer, u *ui.UI, repoGit *gi
 	// Read the actual admin dir from the worktree's .git file before moving
 	// anything. The computed path (bareDir/worktrees/<basename>) can be wrong
 	// when git appended a numeric suffix to avoid collisions.
-	done := tr.StartCtx(ctx, "remove worktree " + wt.Branch)
+	done := tr.StartCtx(ctx, "remove worktree "+label)
 	adminDir, err := readGitAdminDir(wt.Path)
 	if err != nil {
 		adminDir = filepath.Join(bareDir, "worktrees", filepath.Base(wt.Path))
@@ -272,21 +289,21 @@ func removeWorktree(ctx context.Context, tr *trace.Tracer, u *ui.UI, repoGit *gi
 	}
 	done()
 
-	done = tr.StartCtx(ctx, "git branch -D " + wt.Branch)
-	if !keepBranch {
+	done = tr.StartCtx(ctx, "git branch -D "+wt.Branch)
+	if !keepBranch && !wt.Detached {
 		if _, err := repoGit.Run("branch", "-D", wt.Branch); err != nil {
 			u.Warn(fmt.Sprintf("Failed to delete branch %s: %v", wt.Branch, err))
 		}
 	}
 	done()
 
-	done = tr.StartCtx(ctx, "cleanup status " + wt.Branch)
+	done = tr.StartCtx(ctx, "cleanup status "+label)
 	repoName := repoNameFromDir(bareDir)
 	wtDir := filepath.Base(wt.Path)
 	claude.RemoveStatusDir(repoName, wtDir)
 	done()
 
-	if st.IsTracked(wt.Branch) {
+	if !wt.Detached && st.IsTracked(wt.Branch) {
 		if err := stack.Update(bareDir, func(s *stack.Stack) {
 			s.Remove(wt.Branch)
 		}); err != nil {
@@ -294,10 +311,25 @@ func removeWorktree(ctx context.Context, tr *trace.Tracer, u *ui.UI, repoGit *gi
 		}
 	}
 
-	_ = log.Append(log.Event{Action: "remove", Repo: repoNameFromDir(bareDir), Branch: wt.Branch})
+	_ = log.Append(log.Event{Action: "remove", Repo: repoNameFromDir(bareDir), Branch: wt.MatchName()})
 
-	u.Success(fmt.Sprintf("Removed worktree %s", u.Bold(wt.Branch)))
+	u.Success(fmt.Sprintf("Removed worktree %s", u.Bold(label)))
 	return nil
+}
+
+func detachedHeadReachable(g *git.Git) (bool, error) {
+	out, err := g.Run("branch", "-a", "--contains", "HEAD", "--format=%(refname:short)")
+	if err != nil {
+		return false, err
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "(") {
+			continue
+		}
+		return true, nil
+	}
+	return false, nil
 }
 
 // readGitAdminDir reads the worktree's .git file to find the actual admin

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -47,7 +47,7 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 				effective := claude.EffectiveStatus(ss.Status, ss.Timestamp)
 				entry := sessionEntry{
 					Repo:      repoName,
-					Branch:    wt.Branch,
+					Branch:    wt.DisplayName(),
 					SessionID: ss.SessionID,
 					Status:    string(effective),
 					Path:      wt.Path,
@@ -68,7 +68,7 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 			ws := claude.ReadStatus(repoName, wtDir)
 			entry := sessionEntry{
 				Repo:   repoName,
-				Branch: wt.Branch,
+				Branch: wt.DisplayName(),
 				Status: string(ws.Status),
 				Path:   wt.Path,
 			}

--- a/internal/cli/sw.go
+++ b/internal/cli/sw.go
@@ -134,7 +134,7 @@ func buildWorktreeLines(worktrees []worktree.Worktree, repoName string) []string
 			wt:     wt,
 			status: ws,
 			unread: ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir),
-			merged: mergedSet[wt.Branch],
+			merged: !wt.Detached && mergedSet[wt.Branch],
 		}
 	}
 
@@ -149,8 +149,9 @@ func buildWorktreeLines(worktrees []worktree.Worktree, repoName string) []string
 	branchW := 0
 	statusW := 4 // len("BUSY")
 	for _, item := range items {
-		if len(item.wt.Branch) > branchW {
-			branchW = len(item.wt.Branch)
+		display := item.wt.DisplayName()
+		if len(display) > branchW {
+			branchW = len(display)
 		}
 	}
 
@@ -164,7 +165,7 @@ func buildWorktreeLines(worktrees []worktree.Worktree, repoName string) []string
 		line := fmt.Sprintf("%s %-*s  %-*s  %s",
 			icon,
 			statusW, label,
-			branchW, item.wt.Branch,
+			branchW, item.wt.DisplayName(),
 			item.wt.Path,
 		)
 		lines = append(lines, line)
@@ -200,7 +201,7 @@ func buildCrossRepoWorktreeLines(rwts []repoWorktree) []string {
 			rwt:    rwt,
 			status: ws,
 			unread: ws.Status == claude.StatusDone && claude.IsUnread(rwt.Repo.Name, wtDir),
-			merged: mergedSets[rwt.Repo.Name][rwt.Worktree.Branch],
+			merged: !rwt.Worktree.Detached && mergedSets[rwt.Repo.Name][rwt.Worktree.Branch],
 		}
 	}
 
@@ -215,7 +216,7 @@ func buildCrossRepoWorktreeLines(rwts []repoWorktree) []string {
 	nameW := 0
 	statusW := 4
 	for _, it := range items {
-		display := it.rwt.Repo.Name + "/" + it.rwt.Worktree.Branch
+		display := it.rwt.Repo.Name + "/" + it.rwt.Worktree.DisplayName()
 		if len(display) > nameW {
 			nameW = len(display)
 		}
@@ -228,7 +229,7 @@ func buildCrossRepoWorktreeLines(rwts []repoWorktree) []string {
 		if it.unread {
 			label += "\u25CF"
 		}
-		display := it.rwt.Repo.Name + "/" + it.rwt.Worktree.Branch
+		display := it.rwt.Repo.Name + "/" + it.rwt.Worktree.DisplayName()
 		line := fmt.Sprintf("%s %-*s  %-*s  %s",
 			icon,
 			statusW, label,
@@ -253,7 +254,7 @@ func mergedBranchSetForRepo(repoName, bareDir string, worktrees []worktree.Workt
 	branchHeads := make(map[string]string, len(worktrees))
 	repoDir := ""
 	for _, wt := range worktrees {
-		if wt.Branch != "" {
+		if wt.Branch != "" && !wt.Detached {
 			if repoDir == "" {
 				repoDir = wt.Path
 			}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -83,7 +83,7 @@ func syncCmd() *cli.Command {
 			}
 			wtPaths := make(map[string]string) // branch → worktree path
 			for _, wt := range wts {
-				if !wt.IsBare {
+				if !wt.IsBare && !wt.Detached {
 					wtPaths[wt.Branch] = wt.Path
 				}
 			}

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -23,6 +23,8 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
+const tmuxPickerHeader = "Enter | ^N new ^T det ^U prom ^B base ^E ex ^P PR ^G run ^S sync ^D rm ^X prune"
+
 func tmuxCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "tmux",
@@ -92,8 +94,8 @@ func tmuxPickCmd() *cli.Command {
 					fzf.WithNoSort(),
 					fzf.WithDelimiter("\\|"),
 					fzf.WithNth("1,2"),
-					fzf.WithHeader("Ctrl-N: New | Ctrl-B: Stacked | Ctrl-E: Existing | Ctrl-P: PR | Ctrl-G: Dispatch | Ctrl-S: Sync | Ctrl-D: Delete | Ctrl-X: Prune merged"),
-					fzf.WithExpectKeys("ctrl-n", "ctrl-b", "ctrl-e", "ctrl-p", "ctrl-g", "ctrl-s", "ctrl-d", "ctrl-x"),
+					fzf.WithHeader(tmuxPickerHeader),
+					fzf.WithExpectKeys("ctrl-n", "ctrl-t", "ctrl-u", "ctrl-b", "ctrl-e", "ctrl-p", "ctrl-g", "ctrl-s", "ctrl-d", "ctrl-x"),
 					fzf.WithPrintQuery(),
 				}
 
@@ -113,6 +115,26 @@ func tmuxPickCmd() *cli.Command {
 				switch result.Key {
 				case "ctrl-n":
 					if err := tmuxPickNew(self, result.Query, repoFilter, sessionName, items); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						continue
+					}
+					return nil
+
+				case "ctrl-t":
+					if result.Selection == "" {
+						continue
+					}
+					if err := tmuxPickDetached(self, result.Query, result.Selection, repoFilter, sessionName, items); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						continue
+					}
+					return nil
+
+				case "ctrl-u":
+					if result.Selection == "" {
+						continue
+					}
+					if err := tmuxPickPromote(self, result.Query, result.Selection, items); err != nil {
 						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 						continue
 					}
@@ -151,7 +173,9 @@ func tmuxPickCmd() *cli.Command {
 					if result.Selection != "" {
 						wtPath := tmux.ExtractPathFromLine(result.Selection)
 						if item := findItemByPath(items, wtPath); item != nil {
-							branch = item.Branch
+							if !item.Detached {
+								branch = item.Branch
+							}
 						}
 					}
 					if err := tmuxPickSync(self, repoFilter, sessionName, items, branch); err != nil {
@@ -289,6 +313,80 @@ func tmuxPickNew(self, query, repoFilter, sessionName string, items []tmux.Picke
 	return ensureTmuxSessionFromPath(wtPath)
 }
 
+func tmuxPickDetached(self, query, selection, repoFilter, sessionName string, items []tmux.PickerItem) error {
+	name := strings.TrimSpace(query)
+	if name == "" {
+		return errors.Userf("enter a detached worktree name first")
+	}
+
+	repo := ""
+	ref := ""
+	if selection != "" {
+		wtPath := tmux.ExtractPathFromLine(selection)
+		if item := findItemByPath(items, wtPath); item != nil {
+			repo = item.RepoName
+			ref = item.Head
+		}
+	}
+	if repo == "" {
+		var err error
+		repo, err = resolveRepo(repoFilter, sessionName, items)
+		if err != nil {
+			return err
+		}
+	}
+	cmd := exec.Command(self, tmuxPickDetachedArgs(name, repo, ref)...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to create detached worktree: %w", err)
+	}
+
+	wtPath := strings.TrimSpace(string(out))
+	if wtPath == "" {
+		return fmt.Errorf("no path returned from willow new")
+	}
+
+	return ensureTmuxSessionFromPath(wtPath)
+}
+
+func tmuxPickDetachedArgs(name, repo, ref string) []string {
+	args := []string{"new", "--detach", "--cd", "--repo", repo}
+	if ref != "" {
+		args = append(args, "--ref", ref)
+	}
+	return append(args, "--", name)
+}
+
+func tmuxPickPromote(self, query, selection string, items []tmux.PickerItem) error {
+	wtPath := tmux.ExtractPathFromLine(selection)
+	item := findItemByPath(items, wtPath)
+	if item == nil {
+		return fmt.Errorf("worktree not found: %s", wtPath)
+	}
+	if !item.Detached {
+		return errors.Userf("worktree %s is already on branch %s", item.WtDirName, item.Branch)
+	}
+
+	branch := strings.TrimSpace(query)
+	if branch == "" {
+		branch = item.WtDirName
+	}
+
+	cmd := exec.Command(self, tmuxPickPromoteArgs(*item, branch)...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to promote detached worktree: %w", err)
+	}
+
+	return ensureTmuxSession(item.RepoName, item.WtDirName, item.WtPath)
+}
+
+func tmuxPickPromoteArgs(item tmux.PickerItem, branch string) []string {
+	return []string{"promote", "--repo", item.RepoName, item.WtDirName, branch}
+}
+
 func tmuxPickNewWithBase(self, query, repoFilter, sessionName string, items []tmux.PickerItem) error {
 	if query == "" {
 		return errors.Userf("enter a branch name first")
@@ -313,7 +411,9 @@ func tmuxPickNewWithBase(self, query, repoFilter, sessionName string, items []tm
 	var branches []string
 	for _, wt := range wts {
 		if !wt.IsBare {
-			branches = append(branches, wt.Branch)
+			if !wt.Detached {
+				branches = append(branches, wt.Branch)
+			}
 		}
 	}
 	if len(branches) == 0 {
@@ -462,6 +562,9 @@ func availableExistingBranches(remoteBranches []string, repo string, items []tmu
 		if item.RepoName != repo {
 			continue
 		}
+		if item.Detached {
+			continue
+		}
 		wtBranches[item.Branch] = true
 	}
 	return filterAvailableBranches(remoteBranches, wtBranches)
@@ -475,7 +578,7 @@ func currentWorktreeBranchSet(repoGit *git.Git) (map[string]bool, error) {
 
 	wtBranches := make(map[string]bool)
 	for _, wt := range wts {
-		if wt.IsBare {
+		if wt.IsBare || wt.Detached {
 			continue
 		}
 		wtBranches[wt.Branch] = true
@@ -916,10 +1019,18 @@ func tmuxPickDeleteItem(self string, item tmux.PickerItem) error {
 		tmux.KillSession(sessName)
 	}
 
-	cmd := exec.Command(self, "rm", item.Branch, "--force", "--repo", item.RepoName)
+	cmd := exec.Command(self, tmuxPickDeleteArgs(item)...)
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func tmuxPickDeleteArgs(item tmux.PickerItem) []string {
+	target := item.Branch
+	if item.Detached {
+		target = item.WtDirName
+	}
+	return []string{"rm", target, "--force", "--repo", item.RepoName}
 }
 
 func loadRepoConfig(repoName string) *config.Config {
@@ -981,6 +1092,9 @@ func moveToFrontWithStack(items []tmux.PickerItem, sessName string, loadStack st
 	matched := items[matchIdx]
 
 	st := loadStack(matched.RepoName)
+	if matched.Detached {
+		return moveItemToFront(items, matchIdx)
+	}
 	if st == nil || !st.IsTracked(matched.Branch) {
 		return moveItemToFront(items, matchIdx)
 	}
@@ -1002,7 +1116,7 @@ func moveToFrontWithStack(items []tmux.PickerItem, sessName string, loadStack st
 
 	var treeItems, rest []tmux.PickerItem
 	for _, item := range items {
-		if item.RepoName == matched.RepoName && treeBranches[item.Branch] {
+		if !item.Detached && item.RepoName == matched.RepoName && treeBranches[item.Branch] {
 			treeItems = append(treeItems, item)
 		} else {
 			rest = append(rest, item)
@@ -1081,12 +1195,20 @@ func printPreviewMetadata(wtPath, repoName string) {
 	branch := ""
 	if b, err := g.Run("rev-parse", "--abbrev-ref", "HEAD"); err == nil {
 		branch = b
-		fmt.Printf("  \033[1mBranch:\033[0m  %s\n", branch)
+		if branch == "HEAD" {
+			if head, err := g.Run("rev-parse", "HEAD"); err == nil {
+				fmt.Printf("  \033[1mHead:\033[0m    detached %s\n", worktree.ShortHead(head))
+			} else {
+				fmt.Printf("  \033[1mHead:\033[0m    detached\n")
+			}
+		} else {
+			fmt.Printf("  \033[1mBranch:\033[0m  %s\n", branch)
+		}
 	}
 
 	if bareDir != "" {
 		st := stack.Load(bareDir)
-		if st.IsTracked(branch) {
+		if branch != "HEAD" && st.IsTracked(branch) {
 			chain := buildStackChain(st, branch)
 			fmt.Printf("  \033[1mStack:\033[0m   %s\n", chain)
 		}

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/tmux"
+	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
 func item(repo, branch string) tmux.PickerItem {
@@ -203,6 +205,82 @@ func TestMoveToFrontWithStack_BranchNotInStack(t *testing.T) {
 	assertBranches(t, got, want)
 }
 
+func TestMoveToFrontWithStack_DetachedOnlyMovesSelectedWorktree(t *testing.T) {
+	st := makeStack("feat-b", "feat-a")
+	loader := mockLoader(map[string]*stack.Stack{"repo": st})
+
+	items := []tmux.PickerItem{
+		item("repo", "feat-a"),
+		{
+			RepoName:  "repo",
+			Branch:    worktree.DetachedBranch,
+			Detached:  true,
+			WtDirName: "scratch-repro",
+			WtPath:    "/fake/repo/scratch-repro",
+		},
+		item("repo", "feat-b"),
+	}
+
+	result := moveToFrontWithStack(items, "repo/scratch-repro", loader)
+	if result[0].WtDirName != "scratch-repro" || !result[0].Detached {
+		t.Fatalf("first item = %#v, want detached scratch-repro", result[0])
+	}
+	assertBranches(t, branches(result[1:]), []string{"feat-a", "feat-b"})
+}
+
+func TestTmuxPickerHeaderFitsEightyColumns(t *testing.T) {
+	if got := len(tmuxPickerHeader); got > 80 {
+		t.Fatalf("tmux picker header length = %d, want <= 80", got)
+	}
+	if strings.Contains(tmuxPickerHeader, "upgrade") {
+		t.Fatal("tmux picker header should not mention the removed upgrade alias")
+	}
+}
+
+func TestTmuxPickDetachedArgs(t *testing.T) {
+	got := tmuxPickDetachedArgs("scratch-repro", "repo", "abcdef123")
+	want := []string{"new", "--detach", "--cd", "--repo", "repo", "--ref", "abcdef123", "--", "scratch-repro"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+
+	got = tmuxPickDetachedArgs("scratch-base", "repo", "")
+	want = []string{"new", "--detach", "--cd", "--repo", "repo", "--", "scratch-base"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args without ref = %v, want %v", got, want)
+	}
+}
+
+func TestTmuxPickPromoteArgsUsesDetachedName(t *testing.T) {
+	item := tmux.PickerItem{
+		RepoName:  "repo",
+		Branch:    worktree.DetachedBranch,
+		Detached:  true,
+		WtDirName: "scratch-repro",
+	}
+
+	got := tmuxPickPromoteArgs(item, "feature/repro")
+	want := []string{"promote", "--repo", "repo", "scratch-repro", "feature/repro"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+}
+
+func TestTmuxPickDeleteArgsDetachedUsesDirName(t *testing.T) {
+	item := tmux.PickerItem{
+		RepoName:  "repo",
+		Branch:    worktree.DetachedBranch,
+		Detached:  true,
+		WtDirName: "scratch-repro",
+	}
+
+	got := tmuxPickDeleteArgs(item)
+	want := []string{"rm", "scratch-repro", "--force", "--repo", "repo"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+}
+
 func TestMergedDeleteCandidates_SkipsCurrentSessionAndKeepsOrder(t *testing.T) {
 	items := []tmux.PickerItem{
 		{RepoName: "repo", Branch: "main", WtDirName: "main"},
@@ -288,6 +366,41 @@ func TestAvailableExistingBranches(t *testing.T) {
 	got := availableExistingBranches(remoteBranches, "repo1", items)
 	want := []string{"feat-b", "shared"}
 	assertBranches(t, got, want)
+}
+
+func TestAvailableExistingBranches_IgnoresDetachedItems(t *testing.T) {
+	remoteBranches := []string{"main", "feat-a", "feat-b"}
+	items := []tmux.PickerItem{
+		item("repo1", "main"),
+		{
+			RepoName:  "repo1",
+			Branch:    "feat-a",
+			Detached:  true,
+			WtDirName: "scratch-repro",
+		},
+	}
+
+	got := availableExistingBranches(remoteBranches, "repo1", items)
+	want := []string{"feat-a", "feat-b"}
+	assertBranches(t, got, want)
+}
+
+func TestFindItemByPath_Detached(t *testing.T) {
+	items := []tmux.PickerItem{
+		{RepoName: "repo", Branch: "main", WtPath: "/fake/repo/main"},
+		{RepoName: "repo", Branch: worktree.DetachedBranch, Detached: true, WtDirName: "scratch", WtPath: "/fake/repo/scratch"},
+	}
+
+	got := findItemByPath(items, "/fake/repo/scratch")
+	if got == nil {
+		t.Fatal("expected item")
+	}
+	if !got.Detached || got.WtDirName != "scratch" {
+		t.Fatalf("item = %#v, want detached scratch", got)
+	}
+	if missing := findItemByPath(items, "/fake/repo/missing"); missing != nil {
+		t.Fatalf("missing item = %#v, want nil", missing)
+	}
 }
 
 func TestExistingBranchCacheRoundTrip(t *testing.T) {

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -16,14 +16,14 @@ import (
 // directory name, or substring match on the branch.
 func findWorktree(worktrees []worktree.Worktree, target string) (*worktree.Worktree, error) {
 	for i := range worktrees {
-		if worktrees[i].Branch == target {
+		if worktrees[i].Branch == target || worktrees[i].MatchName() == target {
 			return &worktrees[i], nil
 		}
 	}
 
 	var matches []worktree.Worktree
 	for _, wt := range worktrees {
-		if strings.Contains(wt.Branch, target) || strings.HasSuffix(wt.Path, "/"+target) {
+		if strings.Contains(wt.MatchName(), target) || strings.Contains(wt.DisplayName(), target) || strings.HasSuffix(wt.Path, "/"+target) {
 			matches = append(matches, wt)
 		}
 	}
@@ -36,7 +36,7 @@ func findWorktree(worktrees []worktree.Worktree, target string) (*worktree.Workt
 	default:
 		lines := fmt.Sprintf("ambiguous match %q, could be:\n", target)
 		for _, wt := range matches {
-			lines += fmt.Sprintf("  %s  %s\n", wt.Branch, wt.Path)
+			lines += fmt.Sprintf("  %s  %s\n", wt.DisplayName(), wt.Path)
 		}
 		return nil, errors.User(fmt.Errorf("%s", strings.TrimRight(lines, "\n")))
 	}
@@ -51,6 +51,10 @@ func filterBareWorktrees(worktrees []worktree.Worktree) []worktree.Worktree {
 		}
 	}
 	return filtered
+}
+
+func worktreeDirName(name string) string {
+	return strings.ReplaceAll(name, "/", "-")
 }
 
 type repoInfo struct {
@@ -115,14 +119,14 @@ func collectAllWorktrees(repos []repoInfo, verbose bool) []repoWorktree {
 
 func findCrossRepoWorktree(rwts []repoWorktree, target string) (*repoWorktree, error) {
 	for i := range rwts {
-		if rwts[i].Worktree.Branch == target {
+		if rwts[i].Worktree.Branch == target || rwts[i].Worktree.MatchName() == target {
 			return &rwts[i], nil
 		}
 	}
 
 	var matches []repoWorktree
 	for _, rwt := range rwts {
-		if strings.Contains(rwt.Worktree.Branch, target) || strings.HasSuffix(rwt.Worktree.Path, "/"+target) {
+		if strings.Contains(rwt.Worktree.MatchName(), target) || strings.Contains(rwt.Worktree.DisplayName(), target) || strings.HasSuffix(rwt.Worktree.Path, "/"+target) {
 			matches = append(matches, rwt)
 		}
 	}
@@ -135,7 +139,7 @@ func findCrossRepoWorktree(rwts []repoWorktree, target string) (*repoWorktree, e
 	default:
 		lines := fmt.Sprintf("ambiguous match %q, could be:\n", target)
 		for _, rwt := range matches {
-			lines += fmt.Sprintf("  %s/%s  %s\n", rwt.Repo.Name, rwt.Worktree.Branch, rwt.Worktree.Path)
+			lines += fmt.Sprintf("  %s/%s  %s\n", rwt.Repo.Name, rwt.Worktree.DisplayName(), rwt.Worktree.Path)
 		}
 		return nil, errors.User(fmt.Errorf("%s", strings.TrimRight(lines, "\n")))
 	}
@@ -175,7 +179,7 @@ func completeWorktreesCrossRepo(ctx context.Context, cmd *cli.Command) {
 		}
 		for _, wt := range wts {
 			if !wt.IsBare {
-				fmt.Fprintln(w, wt.Branch)
+				fmt.Fprintln(w, wt.MatchName())
 			}
 		}
 	}
@@ -201,7 +205,7 @@ func completeWorktreesWithFlag(ctx context.Context, cmd *cli.Command) {
 		w := cmd.Root().Writer
 		for _, wt := range wts {
 			if !wt.IsBare {
-				fmt.Fprintln(w, wt.Branch)
+				fmt.Fprintln(w, wt.MatchName())
 			}
 		}
 		return
@@ -218,7 +222,7 @@ func completeWorktreesWithFlag(ctx context.Context, cmd *cli.Command) {
 		w := cmd.Root().Writer
 		for _, wt := range wts {
 			if !wt.IsBare {
-				fmt.Fprintln(w, wt.Branch)
+				fmt.Fprintln(w, wt.MatchName())
 			}
 		}
 		return
@@ -232,7 +236,7 @@ func completeWorktreesWithFlag(ctx context.Context, cmd *cli.Command) {
 		w := cmd.Root().Writer
 		for _, wt := range wts {
 			if !wt.IsBare {
-				fmt.Fprintln(w, wt.Branch)
+				fmt.Fprintln(w, wt.MatchName())
 			}
 		}
 		return

--- a/internal/cli/util_test.go
+++ b/internal/cli/util_test.go
@@ -47,6 +47,27 @@ func TestFindWorktree_DirectorySuffix(t *testing.T) {
 	}
 }
 
+func TestFindWorktree_DetachedByName(t *testing.T) {
+	worktrees := append([]worktree.Worktree{}, testWorktrees...)
+	worktrees = append(worktrees, worktree.Worktree{
+		Branch:   worktree.DetachedBranch,
+		Path:     "/home/user/.willow/worktrees/repo/scratch-repro",
+		Head:     "abcdef123456",
+		Detached: true,
+	})
+
+	wt, err := findWorktree(worktrees, "scratch-repro")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wt.Detached {
+		t.Fatal("expected detached worktree")
+	}
+	if got := wt.DisplayName(); got != "scratch-repro [detached abcdef1]" {
+		t.Fatalf("DisplayName() = %q", got)
+	}
+}
+
 func TestFindWorktree_Ambiguous(t *testing.T) {
 	_, err := findWorktree(testWorktrees, "feature")
 	if err == nil {

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -280,7 +280,7 @@ func collectData() ([]session, summary) {
 					timeline, _ := claude.ReadTimeline(repoName, wtDir, ss.SessionID, timelineSince)
 					s := session{
 						Repo:      repoName,
-						Branch:    wt.Branch,
+						Branch:    wt.DisplayName(),
 						SessionID: ss.SessionID,
 						Status:    effective,
 						Tool:      ss.Tool,
@@ -302,7 +302,7 @@ func collectData() ([]session, summary) {
 				}
 				s := session{
 					Repo:      repoName,
-					Branch:    wt.Branch,
+					Branch:    wt.DisplayName(),
 					Status:    ws.Status,
 					DiffStats: diff,
 					Age:       claude.TimeSince(ws.Timestamp),

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -30,6 +30,8 @@ const (
 type PickerItem struct {
 	RepoName    string
 	Branch      string
+	Head        string
+	Detached    bool
 	WtDirName   string
 	WtPath      string
 	Status      claude.Status
@@ -92,7 +94,7 @@ func BuildPickerItemsWithOptions(ctx context.Context, repoFilter string, opts Pi
 		branchHeads := make(map[string]string, len(wts))
 		repoDir := ""
 		for _, wt := range wts {
-			if !wt.IsBare && wt.Branch != "" {
+			if !wt.IsBare && !wt.Detached && wt.Branch != "" {
 				if repoDir == "" {
 					repoDir = wt.Path
 				}
@@ -128,13 +130,15 @@ func BuildPickerItemsWithOptions(ctx context.Context, repoFilter string, opts Pi
 			items = append(items, PickerItem{
 				RepoName:   repoName,
 				Branch:     wt.Branch,
+				Head:       wt.Head,
+				Detached:   wt.Detached,
 				WtDirName:  wtDir,
 				WtPath:     wt.Path,
 				Status:     ws.Status,
 				Unread:     ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
 				HasSession: sessionSet[sessName],
 				Sessions:   sessions,
-				Merged:     mergedSet[wt.Branch],
+				Merged:     !wt.Detached && mergedSet[wt.Branch],
 			})
 		}
 		done()
@@ -180,6 +184,9 @@ func buildPickerGroups(items []PickerItem, repoNames []string, loadStack pickerS
 
 	repoBranchSets := make(map[string]map[string]bool)
 	for _, item := range items {
+		if item.Detached {
+			continue
+		}
 		branchSet := repoBranchSets[item.RepoName]
 		if branchSet == nil {
 			branchSet = make(map[string]bool)
@@ -190,6 +197,9 @@ func buildPickerGroups(items []PickerItem, repoNames []string, loadStack pickerS
 
 	itemMap := make(map[string]*PickerItem)
 	for i := range items {
+		if items[i].Detached {
+			continue
+		}
 		key := pickerItemKey(items[i].RepoName, items[i].Branch)
 		itemMap[key] = &items[i]
 	}
@@ -222,7 +232,7 @@ func buildPickerGroups(items []PickerItem, repoNames []string, loadStack pickerS
 					continue
 				}
 				item.StackPrefix = prefixByBranch[branch]
-				groupedKeys[key] = true
+				groupedKeys[pickerStableItemKey(*item)] = true
 				groupItems = append(groupItems, *item)
 			}
 			if len(groupItems) > 0 {
@@ -232,7 +242,7 @@ func buildPickerGroups(items []PickerItem, repoNames []string, loadStack pickerS
 	}
 
 	for _, item := range items {
-		key := pickerItemKey(item.RepoName, item.Branch)
+		key := pickerStableItemKey(item)
 		if !groupedKeys[key] {
 			groups = append(groups, newPickerGroup([]PickerItem{item}))
 		}
@@ -261,6 +271,13 @@ func newPickerGroup(items []PickerItem) pickerGroup {
 
 func pickerItemKey(repoName, branch string) string {
 	return repoName + "/" + branch
+}
+
+func pickerStableItemKey(item PickerItem) string {
+	if item.WtPath == "" {
+		return pickerItemKey(item.RepoName, item.Branch)
+	}
+	return item.RepoName + "/" + item.WtPath
 }
 
 // FormatPickerLines produces ANSI-colored lines for the fzf picker.
@@ -362,10 +379,17 @@ func filterActiveSessions(sessions []*claude.SessionStatus) []*claude.SessionSta
 
 func displayName(item PickerItem, multiRepo bool) string {
 	name := item.Branch
-	if multiRepo {
-		name = item.RepoName + "/" + item.Branch
+	if item.Detached {
+		if item.Head == "" {
+			name = fmt.Sprintf("%s [detached]", item.WtDirName)
+		} else {
+			name = fmt.Sprintf("%s [detached %s]", item.WtDirName, worktree.ShortHead(item.Head))
+		}
 	}
-	if item.StackPrefix != "" {
+	if multiRepo {
+		name = item.RepoName + "/" + name
+	}
+	if item.StackPrefix != "" && !item.Detached {
 		name = item.StackPrefix + name
 	}
 	return name

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -136,6 +136,23 @@ func TestDisplayName(t *testing.T) {
 	}
 }
 
+func TestDisplayName_Detached(t *testing.T) {
+	item := PickerItem{
+		RepoName:  "myrepo",
+		Branch:    "(detached)",
+		Head:      "abcdef123456",
+		Detached:  true,
+		WtDirName: "scratch-repro",
+	}
+
+	if got := displayName(item, false); got != "scratch-repro [detached abcdef1]" {
+		t.Fatalf("displayName(single repo) = %q", got)
+	}
+	if got := displayName(item, true); got != "myrepo/scratch-repro [detached abcdef1]" {
+		t.Fatalf("displayName(multi repo) = %q", got)
+	}
+}
+
 func TestHasMultipleRepos(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,16 +1,49 @@
 package worktree
 
 import (
+	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/git"
 )
 
+const DetachedBranch = "(detached)"
+
 type Worktree struct {
-	Branch string `json:"branch"`
-	Path   string `json:"path"`
-	Head   string `json:"head"`
-	IsBare bool   `json:"-"`
+	Branch   string `json:"branch"`
+	Path     string `json:"path"`
+	Head     string `json:"head"`
+	Detached bool   `json:"detached,omitempty"`
+	IsBare   bool   `json:"-"`
+}
+
+func (wt Worktree) DirName() string {
+	return filepath.Base(wt.Path)
+}
+
+func (wt Worktree) DisplayName() string {
+	if !wt.Detached {
+		return wt.Branch
+	}
+	if wt.Head == "" {
+		return fmt.Sprintf("%s [detached]", wt.DirName())
+	}
+	return fmt.Sprintf("%s [detached %s]", wt.DirName(), ShortHead(wt.Head))
+}
+
+func (wt Worktree) MatchName() string {
+	if wt.Detached {
+		return wt.DirName()
+	}
+	return wt.Branch
+}
+
+func ShortHead(head string) string {
+	if len(head) <= 7 {
+		return head
+	}
+	return head[:7]
 }
 
 func List(g *git.Git) ([]Worktree, error) {
@@ -36,7 +69,8 @@ func parsePorcelain(output string) []Worktree {
 			case line == "bare":
 				wt.IsBare = true
 			case line == "detached":
-				wt.Branch = "(detached)"
+				wt.Branch = DetachedBranch
+				wt.Detached = true
 			}
 		}
 		if wt.Path != "" {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -74,6 +74,15 @@ detached
 	if wts[0].Branch != "(detached)" {
 		t.Errorf("Branch = %q, want %q", wts[0].Branch, "(detached)")
 	}
+	if !wts[0].Detached {
+		t.Error("Detached should be true")
+	}
+	if got := wts[0].DisplayName(); got != "detached [detached ddd444]" {
+		t.Errorf("DisplayName() = %q", got)
+	}
+	if got := wts[0].MatchName(); got != "detached" {
+		t.Errorf("MatchName() = %q", got)
+	}
 }
 
 func TestParsePorcelain_EmptyInput(t *testing.T) {

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -47,13 +47,15 @@ eval "$(willow shell-init --tab-title)"  # with tab titles
 
 ### `ww new <branch> [flags]`
 
-Create a new worktree with a new branch, an existing branch, or a GitHub PR.
+Create a new worktree with a new branch, an existing branch, a named detached HEAD, or a GitHub PR.
 
 ```bash
 ww new feature/auth                    # create worktree
 ww new feature/auth -b develop         # fork from specific branch
 ww new -e existing-branch              # use existing branch
 ww new -e                              # pick from remote branches (fzf)
+ww new scratch-repro --detach          # named detached worktree at default base
+ww new v1-debug --detach --ref v1.2.3  # named detached worktree at a tag/commit
 ww new --pr 123                        # checkout PR #123
 ww new https://github.com/org/repo/pull/123  # checkout a PR by URL
 ww new feature/auth -r myrepo          # target a specific repo
@@ -65,9 +67,21 @@ ww new feature/auth                    # auto-cd via shell integration (tmux-awa
 | `-b, --base` | Base branch to fork from | Config default / auto-detected |
 | `-r, --repo` | Target repo by name | Auto-detected from cwd |
 | `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) | `false` |
+| `--detach` | Create a named detached HEAD worktree | `false` |
+| `--ref` | Commit, tag, or branch to check out in detached mode | Base branch |
 | `--pr` | GitHub PR number or URL | |
 | `--no-fetch` | Skip fetching from remote | `false` |
 | `--cd` | Print only the path (for scripting) | `false` |
+
+#### Detached worktrees
+
+Use `--detach` when you want a named scratch worktree without creating a branch yet. The name becomes the worktree directory and the tmux session identity. Later, promote it in place with `ww promote`; the directory and tmux session stay stable.
+
+```bash
+ww new scratch-repro --detach
+ww new old-release --detach --ref v1.2.3
+ww promote scratch-repro feature/repro-fix
+```
 
 #### Existing branch picker
 
@@ -85,6 +99,23 @@ ww new https://github.com/org/repo/pull/123  # by URL
 ```
 
 This also works from the tmux picker — press `Ctrl-P` for a dedicated PR picker, or paste a PR URL and press `Ctrl-N`.
+
+### `ww promote [worktree] <branch>`
+
+Promote a named detached worktree to a normal branch-backed worktree in place.
+
+If you run it from inside a detached worktree, pass only the branch name. From another directory, pass the detached worktree name first. With one argument outside a detached worktree, Willow uses that name for both the worktree and branch.
+
+```bash
+ww promote feature/auth                 # from inside a detached worktree
+ww promote scratch-repro feature/auth   # promote by worktree name
+ww promote scratch-repro                # promote to branch scratch-repro
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-r, --repo` | Target repo by name | Auto-detected from cwd / all repos |
+| `-b, --base` | Record a stack parent for the promoted branch | |
 
 ### `ww checkout <branch-or-pr-url>` (alias: `co`)
 
@@ -547,7 +578,7 @@ ww tmux install           # print tmux.conf lines to add
 ```
 
 Setup: `ww tmux install` prints the config to add to `~/.tmux.conf`, including a `prefix + w` keybinding for the picker popup.
-Inside the picker, `Ctrl-D` deletes the selected worktree and `Ctrl-X` bulk-deletes safe merged worktrees currently shown, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
+Inside the picker, `Ctrl-T` creates a named detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree, `Ctrl-D` deletes the selected worktree, and `Ctrl-X` bulk-deletes safe merged worktrees currently shown, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
 
 ### Aliases
 

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -32,6 +32,8 @@ The right panel shows a live preview of the tmux pane content (Claude Code outpu
 |-----|--------|
 | `Enter` | Switch to worktree (creates tmux session if needed) |
 | `Ctrl-N` | Create new worktree from typed query (also accepts PR URLs) |
+| `Ctrl-T` | Create a named detached worktree from the selected HEAD |
+| `Ctrl-U` | Promote the selected detached worktree to a branch |
 | `Ctrl-B` | Create new worktree stacked on a base branch (opens branch picker) |
 | `Ctrl-E` | Browse existing remote branches and create a worktree |
 | `Ctrl-P` | Browse open PRs and create a worktree for the selected one |
@@ -50,6 +52,12 @@ Type a prompt in the query field and press `Ctrl-G` to dispatch a Claude Code ag
 Press `Ctrl-P` to list open PRs via `gh pr list`. Each line shows the PR number, title, author, and branch. Select one to create a worktree (or switch to it if one already exists). Requires the [GitHub CLI](https://cli.github.com/).
 
 You can also paste a PR URL into the query field and press `Ctrl-N` for quick one-off access.
+
+### Detached worktrees
+
+Type a name in the query field and press `Ctrl-T` to create a detached worktree from the currently selected row's HEAD. The name becomes both the worktree directory and tmux session name, so it is easy to come back to even before you create a branch.
+
+To keep the work, select the detached worktree and press `Ctrl-U`. If the query field has text, Willow uses it as the new branch name; otherwise it reuses the detached worktree name. Promotion happens in place, so the tmux session and agent status stay attached to the same directory.
 
 ### Existing branch picker
 


### PR DESCRIPTION
## Description of the change
Adds named detached worktree support with `ww new <name> --detach`, promotion via `ww promote`, and tmux picker bindings for detached creation/promotion. Detached worktrees now display and match by their stable directory name, avoid branch-only sync/PR/merged logic, and get removal protection for unanchored commits.

## Test plan
Go test suite, docs production build, and whitespace diff check.

Generated-by: Codex