### PR TITLE
:zap: perf[cli]: parallelize repo scans

### DIFF
--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -119,34 +120,47 @@ func printRepoList(flags Flags) error {
 	header := fmt.Sprintf("  %-*s  %-9s  %-6s  %s", nameW, "REPO", "WORKTREES", "ACTIVE", "UNREAD")
 	u.Info(u.Bold(header))
 
-	for _, r := range repos {
+	type repoListRow struct {
+		repo        string
+		count       int
+		activeCount int
+		unreadCount int
+		ok          bool
+	}
+	rows := parallel.Map(repos, func(_ int, r string) repoListRow {
 		bareDir, err := config.ResolveRepo(r)
 		if err != nil {
-			continue
+			return repoListRow{}
 		}
 		repoGit := &git.Git{Dir: bareDir}
 		wts, err := worktree.List(repoGit)
 		if err != nil {
-			continue
+			return repoListRow{}
 		}
-		count := 0
-		activeCount := 0
-		unreadCount := 0
+		row := repoListRow{repo: r, ok: true}
 		for _, wt := range wts {
 			if wt.IsBare {
 				continue
 			}
-			count++
+			row.count++
 			wtDir := filepath.Base(wt.Path)
-			ws := claude.ReadStatus(r, wtDir)
+			sessions := claude.ReadAllSessions(r, wtDir)
+			ws := claude.AggregateStatus(sessions)
 			if claude.IsActive(ws.Status) {
-				activeCount++
+				row.activeCount++
 			}
-			if claude.IsUnread(r, wtDir) {
-				unreadCount++
+			if claude.CountUnreadIn(r, wtDir, sessions) > 0 {
+				row.unreadCount++
 			}
 		}
-		line := fmt.Sprintf("  %-*s  %-9d  %-6d  %d", nameW, r, count, activeCount, unreadCount)
+		return row
+	})
+
+	for _, row := range rows {
+		if !row.ok {
+			continue
+		}
+		line := fmt.Sprintf("  %-*s  %-9d  %-6d  %d", nameW, row.repo, row.count, row.activeCount, row.unreadCount)
 		u.Info(line)
 	}
 	return nil
@@ -174,6 +188,7 @@ type lsRow struct {
 	merged bool
 	status claude.Status
 	unread bool
+	age    string
 	wt     worktree.Worktree
 }
 
@@ -219,12 +234,14 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 	var rows []lsRow
 	for _, wt := range worktrees {
 		wtDir := filepath.Base(wt.Path)
-		ws := claude.ReadStatus(repoName, wtDir)
+		sessions := claude.ReadAllSessions(repoName, wtDir)
+		ws := claude.AggregateStatus(sessions)
 		rows = append(rows, lsRow{
 			branch: wt.Branch,
 			merged: !wt.Detached && mergedSet[wt.Branch],
 			status: ws.Status,
-			unread: ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir),
+			unread: ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
+			age:    worktreeAge(wt.Path),
 			wt:     wt,
 		})
 	}
@@ -245,9 +262,8 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 		if len(row.wt.Path) > pathW {
 			pathW = len(row.wt.Path)
 		}
-		age := worktreeAge(row.wt.Path)
-		if len(age) > ageW {
-			ageW = len(age)
+		if len(row.age) > ageW {
+			ageW = len(row.age)
 		}
 	}
 
@@ -255,7 +271,6 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 	u.Info(u.Bold(header))
 
 	for _, row := range rows {
-		age := worktreeAge(row.wt.Path)
 		statusLabel := claude.StatusLabel(row.status)
 		if row.unread {
 			statusLabel += "\u25CF" // ●
@@ -273,7 +288,7 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 		}
 		branchCol := branchDisplay + strings.Repeat(" ", padding)
 		pathPadded := fmt.Sprintf("%-*s", pathW, row.wt.Path)
-		agePadded := fmt.Sprintf("%*s", ageW, age)
+		agePadded := fmt.Sprintf("%*s", ageW, row.age)
 		line := fmt.Sprintf("  %s  %-*s  %s  %s", branchCol, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))
 		u.Info(line)
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -37,7 +38,7 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 	for _, wt := range worktrees {
 		wtDir := filepath.Base(wt.Path)
 		sessions := claude.ReadAllSessions(repoName, wtDir)
-		unread := claude.IsUnread(repoName, wtDir)
+		unread := claude.CountUnreadIn(repoName, wtDir, sessions) > 0
 		if unread {
 			rs.UnreadCount++
 		}
@@ -65,7 +66,7 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 				}
 			}
 		} else {
-			ws := claude.ReadStatus(repoName, wtDir)
+			ws := claude.AggregateStatus(sessions)
 			entry := sessionEntry{
 				Repo:   repoName,
 				Branch: wt.DisplayName(),
@@ -83,6 +84,33 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 		}
 	}
 	return rs
+}
+
+func collectRepoStatuses(repos []repoInfo, verbose bool) []repoStatus {
+	type result struct {
+		status repoStatus
+		ok     bool
+	}
+
+	results := parallel.Map(repos, func(_ int, r repoInfo) result {
+		repoGit := &git.Git{Dir: r.BareDir, Verbose: verbose}
+		wts, err := worktree.List(repoGit)
+		if err != nil {
+			return result{}
+		}
+		return result{
+			status: collectRepoStatus(r.Name, filterBareWorktrees(wts)),
+			ok:     true,
+		}
+	})
+
+	statuses := make([]repoStatus, 0, len(repos))
+	for _, result := range results {
+		if result.ok {
+			statuses = append(statuses, result.status)
+		}
+	}
+	return statuses
 }
 
 func statusBranchLabel(branch, sessionID string) string {
@@ -119,16 +147,7 @@ func statusCmd() *cli.Command {
 				return err
 			}
 
-			var allStatuses []repoStatus
-			for _, r := range repos {
-				repoGit := &git.Git{Dir: r.BareDir, Verbose: g.Verbose}
-				wts, err := worktree.List(repoGit)
-				if err != nil {
-					continue
-				}
-				filtered := filterBareWorktrees(wts)
-				allStatuses = append(allStatuses, collectRepoStatus(r.Name, filtered))
-			}
+			allStatuses := collectRepoStatuses(repos, g.Verbose)
 
 			if cmd.Bool("json") {
 				var allEntries []sessionEntry

--- a/internal/cli/sw.go
+++ b/internal/cli/sw.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -129,11 +130,12 @@ func buildWorktreeLines(worktrees []worktree.Worktree, repoName string) []string
 	items := make([]worktreeWithStatus, len(worktrees))
 	for i, wt := range worktrees {
 		wtDir := filepath.Base(wt.Path)
-		ws := claude.ReadStatus(repoName, wtDir)
+		sessions := claude.ReadAllSessions(repoName, wtDir)
+		ws := claude.AggregateStatus(sessions)
 		items[i] = worktreeWithStatus{
 			wt:     wt,
 			status: ws,
-			unread: ws.Status == claude.StatusDone && claude.IsUnread(repoName, wtDir),
+			unread: ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
 			merged: !wt.Detached && mergedSet[wt.Branch],
 		}
 	}
@@ -183,24 +185,37 @@ func buildCrossRepoWorktreeLines(rwts []repoWorktree) []string {
 
 	mergedSets := make(map[string]map[string]bool)
 	grouped := make(map[string][]worktree.Worktree)
+	var repoOrder []repoInfo
 	for _, rwt := range rwts {
+		if _, ok := grouped[rwt.Repo.Name]; !ok {
+			repoOrder = append(repoOrder, rwt.Repo)
+		}
 		grouped[rwt.Repo.Name] = append(grouped[rwt.Repo.Name], rwt.Worktree)
 	}
-	for _, rwt := range rwts {
-		if _, ok := mergedSets[rwt.Repo.Name]; ok {
-			continue
+
+	type mergedResult struct {
+		repoName string
+		merged   map[string]bool
+	}
+	results := parallel.Map(repoOrder, func(_ int, repo repoInfo) mergedResult {
+		return mergedResult{
+			repoName: repo.Name,
+			merged:   mergedBranchSetForRepo(repo.Name, repo.BareDir, grouped[repo.Name]),
 		}
-		mergedSets[rwt.Repo.Name] = mergedBranchSetForRepo(rwt.Repo.Name, rwt.Repo.BareDir, grouped[rwt.Repo.Name])
+	})
+	for _, result := range results {
+		mergedSets[result.repoName] = result.merged
 	}
 
 	items := make([]item, len(rwts))
 	for i, rwt := range rwts {
 		wtDir := filepath.Base(rwt.Worktree.Path)
-		ws := claude.ReadStatus(rwt.Repo.Name, wtDir)
+		sessions := claude.ReadAllSessions(rwt.Repo.Name, wtDir)
+		ws := claude.AggregateStatus(sessions)
 		items[i] = item{
 			rwt:    rwt,
 			status: ws,
-			unread: ws.Status == claude.StatusDone && claude.IsUnread(rwt.Repo.Name, wtDir),
+			unread: ws.Status == claude.StatusDone && claude.CountUnreadIn(rwt.Repo.Name, wtDir, sessions) > 0,
 			merged: !rwt.Worktree.Detached && mergedSets[rwt.Repo.Name][rwt.Worktree.Branch],
 		}
 	}

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/fzf"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/log"
+	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/trace"
@@ -1331,42 +1332,15 @@ func tmuxStatusBarCmd() *cli.Command {
 			sessionSet := tmux.ListSessions()
 			done()
 
-			for _, repoName := range repos {
-				bareDir, err := config.ResolveRepo(repoName)
-				if err != nil {
-					continue
-				}
-				repoGit := &git.Git{Dir: bareDir}
-				done := trace.Span(ctx, "worktree.List/"+repoName)
-				wts, err := worktree.List(repoGit)
-				done()
-				if err != nil {
-					continue
-				}
-				for _, wt := range wts {
-					if wt.IsBare {
-						continue
-					}
-					totalWt++
-					wtDir := filepath.Base(wt.Path)
-					sessions := claude.ReadAllSessions(repoName, wtDir)
-					ws := claude.AggregateStatus(sessions)
+			results := parallel.Map(repos, func(_ int, repoName string) tmuxStatusBarRepoResult {
+				return collectTmuxStatusBarRepo(ctx, repoName, sessionSet)
+			})
 
-					// Clean orphaned sessions whose tmux session no longer exists
-					sessName := tmux.SessionNameForWorktree(repoName, wtDir)
-					if (ws.Status == claude.StatusBusy || ws.Status == claude.StatusWait) && !sessionSet[sessName] {
-						for _, ss := range sessions {
-							if ss.Status == claude.StatusBusy || ss.Status == claude.StatusWait {
-								claude.RemoveSessionFile(repoName, wtDir, ss.SessionID)
-							}
-						}
-						ws = claude.AggregateStatus(claude.ReadAllSessions(repoName, wtDir))
-					}
-
-					currentStatuses[repoName+"/"+wtDir] = ws.Status
-					if claude.IsActive(ws.Status) {
-						activeAgents++
-					}
+			for _, result := range results {
+				totalWt += result.totalWt
+				activeAgents += result.activeAgents
+				for key, status := range result.statuses {
+					currentStatuses[key] = status
 				}
 			}
 
@@ -1382,6 +1356,53 @@ func tmuxStatusBarCmd() *cli.Command {
 			return nil
 		},
 	}
+}
+
+type tmuxStatusBarRepoResult struct {
+	totalWt      int
+	activeAgents int
+	statuses     map[string]claude.Status
+}
+
+func collectTmuxStatusBarRepo(ctx context.Context, repoName string, sessionSet map[string]bool) tmuxStatusBarRepoResult {
+	result := tmuxStatusBarRepoResult{statuses: make(map[string]claude.Status)}
+	bareDir, err := config.ResolveRepo(repoName)
+	if err != nil {
+		return result
+	}
+	repoGit := &git.Git{Dir: bareDir}
+	done := trace.Span(ctx, "worktree.List/"+repoName)
+	wts, err := worktree.List(repoGit)
+	done()
+	if err != nil {
+		return result
+	}
+	for _, wt := range wts {
+		if wt.IsBare {
+			continue
+		}
+		result.totalWt++
+		wtDir := filepath.Base(wt.Path)
+		sessions := claude.ReadAllSessions(repoName, wtDir)
+		ws := claude.AggregateStatus(sessions)
+
+		// Clean orphaned sessions whose tmux session no longer exists.
+		sessName := tmux.SessionNameForWorktree(repoName, wtDir)
+		if (ws.Status == claude.StatusBusy || ws.Status == claude.StatusWait) && !sessionSet[sessName] {
+			for _, ss := range sessions {
+				if ss.Status == claude.StatusBusy || ss.Status == claude.StatusWait {
+					claude.RemoveSessionFile(repoName, wtDir, ss.SessionID)
+				}
+			}
+			ws = claude.AggregateStatus(claude.ReadAllSessions(repoName, wtDir))
+		}
+
+		result.statuses[repoName+"/"+wtDir] = ws.Status
+		if claude.IsActive(ws.Status) {
+			result.activeAgents++
+		}
+	}
+	return result
 }
 
 func tmuxInstallCmd() *cli.Command {

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/errors"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
@@ -103,16 +104,22 @@ func resolveRepos(g *git.Git, repoFlag string) ([]repoInfo, error) {
 }
 
 func collectAllWorktrees(repos []repoInfo, verbose bool) []repoWorktree {
-	var all []repoWorktree
-	for _, r := range repos {
+	results := parallel.Map(repos, func(_ int, r repoInfo) []repoWorktree {
 		repoGit := &git.Git{Dir: r.BareDir, Verbose: verbose}
 		wts, err := worktree.List(repoGit)
 		if err != nil {
-			continue
+			return nil
 		}
+		var repoWts []repoWorktree
 		for _, wt := range filterBareWorktrees(wts) {
-			all = append(all, repoWorktree{Repo: r, Worktree: wt})
+			repoWts = append(repoWts, repoWorktree{Repo: r, Worktree: wt})
 		}
+		return repoWts
+	})
+
+	var all []repoWorktree
+	for _, repoWts := range results {
+		all = append(all, repoWts...)
 	}
 	return all
 }

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -43,6 +44,12 @@ type summary struct {
 	Repos  int
 	Agents int
 	Unread int
+}
+
+type repoData struct {
+	sessions []session
+	agents   int
+	unread   int
 }
 
 type cachedDiff struct {
@@ -237,86 +244,97 @@ func collectData() ([]session, summary) {
 		return nil, summary{}
 	}
 
-	var sessions []session
 	sum := summary{Repos: len(repos)}
+	results := parallel.Map(repos, func(_ int, repoName string) repoData {
+		return collectRepoData(repoName)
+	})
 
-	for _, repoName := range repos {
-		bareDir, err := config.ResolveRepo(repoName)
-		if err != nil {
-			continue
-		}
-
-		repoGit := &git.Git{Dir: bareDir}
-		wts, err := worktree.List(repoGit)
-		if err != nil {
-			continue
-		}
-
-		cfg := config.Load(bareDir)
-		baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
-
-		for _, wt := range wts {
-			if wt.IsBare {
-				continue
-			}
-			wtDir := filepath.Base(wt.Path)
-			allSessions := claude.ReadAllSessions(repoName, wtDir)
-			unread := claude.IsUnread(repoName, wtDir)
-
-			if unread {
-				sum.Unread++
-			}
-
-			diff := getDiffStats(wt.Path, baseBranch)
-
-			timelineSince := time.Now().Add(-60 * time.Minute)
-
-			if len(allSessions) > 0 {
-				for _, ss := range allSessions {
-					effective := claude.EffectiveStatus(ss.Status, ss.Timestamp)
-					if effective == claude.StatusIdle || effective == claude.StatusOffline {
-						continue
-					}
-					timeline, _ := claude.ReadTimeline(repoName, wtDir, ss.SessionID, timelineSince)
-					s := session{
-						Repo:      repoName,
-						Branch:    wt.DisplayName(),
-						SessionID: ss.SessionID,
-						Status:    effective,
-						Tool:      ss.Tool,
-						DiffStats: diff,
-						Age:       claude.TimeSince(ss.Timestamp),
-						Unread:    effective == claude.StatusDone && unread,
-						WtDirName: wtDir,
-						Timeline:  claude.Sparkline(timeline, 30, 60*time.Minute),
-					}
-					sessions = append(sessions, s)
-					if claude.IsActive(effective) {
-						sum.Agents++
-					}
-				}
-			} else {
-				ws := claude.ReadStatus(repoName, wtDir)
-				if ws.Status == claude.StatusOffline || ws.Status == claude.StatusIdle {
-					continue
-				}
-				s := session{
-					Repo:      repoName,
-					Branch:    wt.DisplayName(),
-					Status:    ws.Status,
-					DiffStats: diff,
-					Age:       claude.TimeSince(ws.Timestamp),
-					Unread:    ws.Status == claude.StatusDone && unread,
-					WtDirName: wtDir,
-					Timeline:  strings.Repeat("\033[2m\u00b7\033[0m", 30),
-				}
-				sessions = append(sessions, s)
-				sum.Agents++
-			}
-		}
+	var sessions []session
+	for _, result := range results {
+		sessions = append(sessions, result.sessions...)
+		sum.Agents += result.agents
+		sum.Unread += result.unread
 	}
 
 	return sessions, sum
+}
+
+func collectRepoData(repoName string) repoData {
+	bareDir, err := config.ResolveRepo(repoName)
+	if err != nil {
+		return repoData{}
+	}
+
+	repoGit := &git.Git{Dir: bareDir}
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		return repoData{}
+	}
+
+	cfg := config.Load(bareDir)
+	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
+	timelineSince := time.Now().Add(-60 * time.Minute)
+	var result repoData
+
+	for _, wt := range wts {
+		if wt.IsBare {
+			continue
+		}
+		wtDir := filepath.Base(wt.Path)
+		allSessions := claude.ReadAllSessions(repoName, wtDir)
+		unread := claude.CountUnreadIn(repoName, wtDir, allSessions) > 0
+
+		if unread {
+			result.unread++
+		}
+
+		diff := getDiffStats(wt.Path, baseBranch)
+
+		if len(allSessions) > 0 {
+			for _, ss := range allSessions {
+				effective := claude.EffectiveStatus(ss.Status, ss.Timestamp)
+				if effective == claude.StatusIdle || effective == claude.StatusOffline {
+					continue
+				}
+				timeline, _ := claude.ReadTimeline(repoName, wtDir, ss.SessionID, timelineSince)
+				s := session{
+					Repo:      repoName,
+					Branch:    wt.DisplayName(),
+					SessionID: ss.SessionID,
+					Status:    effective,
+					Tool:      ss.Tool,
+					DiffStats: diff,
+					Age:       claude.TimeSince(ss.Timestamp),
+					Unread:    effective == claude.StatusDone && unread,
+					WtDirName: wtDir,
+					Timeline:  claude.Sparkline(timeline, 30, 60*time.Minute),
+				}
+				result.sessions = append(result.sessions, s)
+				if claude.IsActive(effective) {
+					result.agents++
+				}
+			}
+		} else {
+			ws := claude.AggregateStatus(allSessions)
+			if ws.Status == claude.StatusOffline || ws.Status == claude.StatusIdle {
+				continue
+			}
+			s := session{
+				Repo:      repoName,
+				Branch:    wt.DisplayName(),
+				Status:    ws.Status,
+				DiffStats: diff,
+				Age:       claude.TimeSince(ws.Timestamp),
+				Unread:    ws.Status == claude.StatusDone && unread,
+				WtDirName: wtDir,
+				Timeline:  strings.Repeat("\033[2m\u00b7\033[0m", 30),
+			}
+			result.sessions = append(result.sessions, s)
+			result.agents++
+		}
+	}
+
+	return result
 }
 
 func render(sessions []session, sum summary, width int, selectedIdx int, showTimeline bool, frame int, flashUntil map[string]time.Time) string {

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -1,0 +1,42 @@
+package parallel
+
+import "sync"
+
+const DefaultLimit = 8
+
+// Map applies fn to each item with the default worker limit and preserves input order.
+func Map[T, R any](items []T, fn func(int, T) R) []R {
+	return MapLimit(items, DefaultLimit, fn)
+}
+
+// MapLimit applies fn to each item with at most limit workers and preserves input order.
+func MapLimit[T, R any](items []T, limit int, fn func(int, T) R) []R {
+	results := make([]R, len(items))
+	if len(items) == 0 {
+		return results
+	}
+	if limit <= 0 || limit > len(items) {
+		limit = len(items)
+	}
+
+	var wg sync.WaitGroup
+	jobs := make(chan int)
+
+	for range limit {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				results[i] = fn(i, items[i])
+			}
+		}()
+	}
+
+	for i := range items {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+
+	return results
+}

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -1,0 +1,45 @@
+package parallel
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMapPreservesOrder(t *testing.T) {
+	items := []int{1, 2, 3, 4}
+
+	got := Map(items, func(_ int, item int) int {
+		return item * 10
+	})
+
+	want := []int{10, 20, 30, 40}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("result[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+}
+
+func TestMapLimitBoundsConcurrency(t *testing.T) {
+	items := []int{1, 2, 3, 4, 5, 6}
+	var active atomic.Int32
+	var maxActive atomic.Int32
+
+	MapLimit(items, 2, func(_ int, item int) int {
+		now := active.Add(1)
+		for {
+			prev := maxActive.Load()
+			if now <= prev || maxActive.CompareAndSwap(prev, now) {
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+		active.Add(-1)
+		return item
+	})
+
+	if got := maxActive.Load(); got > 2 {
+		t.Fatalf("max active workers = %d, want <= 2", got)
+	}
+}

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -74,81 +75,107 @@ func BuildPickerItemsWithOptions(ctx context.Context, repoFilter string, opts Pi
 
 	sessionSet := ListSessions()
 
+	results := parallel.Map(repoNames, func(_ int, repoName string) pickerRepoResult {
+		return buildPickerItemsForRepo(ctx, repoName, sessionSet, opts)
+	})
+
 	var items []PickerItem
-	for _, repoName := range repoNames {
-		bareDir, err := config.ResolveRepo(repoName)
-		if err != nil {
+	stacks := make(map[string]*stack.Stack, len(repoNames))
+	for _, result := range results {
+		if result.repoName == "" {
 			continue
 		}
-		repoGit := &git.Git{Dir: bareDir}
-		done := trace.Span(ctx, "worktree.List/"+repoName)
-		wts, err := worktree.List(repoGit)
-		done()
-		if err != nil {
-			continue
-		}
-
-		cfg := config.Load(bareDir)
-		baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
-		branches := make([]string, 0, len(wts))
-		branchHeads := make(map[string]string, len(wts))
-		repoDir := ""
-		for _, wt := range wts {
-			if !wt.IsBare && !wt.Detached && wt.Branch != "" {
-				if repoDir == "" {
-					repoDir = wt.Path
-				}
-				branches = append(branches, wt.Branch)
-				branchHeads[wt.Branch] = wt.Head
-			}
-		}
-		done = trace.Span(ctx, "git.MergedBranchSet/"+repoName)
-		mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
-		done()
-
-		done = trace.Span(ctx, "gh.MergedWorktreeSet/"+repoName)
-		var githubMerged map[string]bool
-		if opts.RefreshGitHubMerged {
-			githubMerged = gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads)
-		} else {
-			githubMerged = gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads)
-		}
-		for branch := range githubMerged {
-			mergedSet[branch] = true
-		}
-		done()
-
-		done = trace.Span(ctx, "per-wt-loop/"+repoName)
-		for _, wt := range wts {
-			if wt.IsBare {
-				continue
-			}
-			wtDir := filepath.Base(wt.Path)
-			sessions := claude.ReadAllSessions(repoName, wtDir)
-			ws := claude.AggregateStatus(sessions)
-			sessName := SessionNameForWorktree(repoName, wtDir)
-			items = append(items, PickerItem{
-				RepoName:   repoName,
-				Branch:     wt.Branch,
-				Head:       wt.Head,
-				Detached:   wt.Detached,
-				WtDirName:  wtDir,
-				WtPath:     wt.Path,
-				Status:     ws.Status,
-				Unread:     ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
-				HasSession: sessionSet[sessName],
-				Sessions:   sessions,
-				Merged:     !wt.Detached && mergedSet[wt.Branch],
-			})
-		}
-		done()
+		items = append(items, result.items...)
+		stacks[result.repoName] = result.stack
 	}
 
 	done := trace.Span(ctx, "sortPickerItems")
-	items = sortPickerItems(items, repoNames, defaultPickerStackLoader)
+	items = sortPickerItems(items, repoNames, func(repoName string) *stack.Stack {
+		return stacks[repoName]
+	})
 	done()
 
 	return items, nil
+}
+
+type pickerRepoResult struct {
+	repoName string
+	items    []PickerItem
+	stack    *stack.Stack
+}
+
+func buildPickerItemsForRepo(ctx context.Context, repoName string, sessionSet map[string]bool, opts PickerBuildOptions) pickerRepoResult {
+	result := pickerRepoResult{repoName: repoName}
+	bareDir, err := config.ResolveRepo(repoName)
+	if err != nil {
+		return pickerRepoResult{}
+	}
+
+	result.stack = stack.Load(bareDir)
+	repoGit := &git.Git{Dir: bareDir}
+	done := trace.Span(ctx, "worktree.List/"+repoName)
+	wts, err := worktree.List(repoGit)
+	done()
+	if err != nil {
+		return result
+	}
+
+	cfg := config.Load(bareDir)
+	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
+	branches := make([]string, 0, len(wts))
+	branchHeads := make(map[string]string, len(wts))
+	repoDir := ""
+	for _, wt := range wts {
+		if !wt.IsBare && !wt.Detached && wt.Branch != "" {
+			if repoDir == "" {
+				repoDir = wt.Path
+			}
+			branches = append(branches, wt.Branch)
+			branchHeads[wt.Branch] = wt.Head
+		}
+	}
+	done = trace.Span(ctx, "git.MergedBranchSet/"+repoName)
+	mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
+	done()
+
+	done = trace.Span(ctx, "gh.MergedWorktreeSet/"+repoName)
+	var githubMerged map[string]bool
+	if opts.RefreshGitHubMerged {
+		githubMerged = gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads)
+	} else {
+		githubMerged = gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads)
+	}
+	for branch := range githubMerged {
+		mergedSet[branch] = true
+	}
+	done()
+
+	done = trace.Span(ctx, "per-wt-loop/"+repoName)
+	for _, wt := range wts {
+		if wt.IsBare {
+			continue
+		}
+		wtDir := filepath.Base(wt.Path)
+		sessions := claude.ReadAllSessions(repoName, wtDir)
+		ws := claude.AggregateStatus(sessions)
+		sessName := SessionNameForWorktree(repoName, wtDir)
+		result.items = append(result.items, PickerItem{
+			RepoName:   repoName,
+			Branch:     wt.Branch,
+			Head:       wt.Head,
+			Detached:   wt.Detached,
+			WtDirName:  wtDir,
+			WtPath:     wt.Path,
+			Status:     ws.Status,
+			Unread:     ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
+			HasSession: sessionSet[sessName],
+			Sessions:   sessions,
+			Merged:     !wt.Detached && mergedSet[wt.Branch],
+		})
+	}
+	done()
+
+	return result
 }
 
 type pickerStackLoader func(repoName string) *stack.Stack
@@ -285,6 +312,7 @@ func pickerStableItemKey(item PickerItem) string {
 // indented below the parent row.
 func FormatPickerLines(items []PickerItem) []string {
 	multiRepo := hasMultipleRepos(items)
+	home, _ := os.UserHomeDir()
 
 	nameW := 0
 	for _, item := range items {
@@ -323,7 +351,7 @@ func FormatPickerLines(items []PickerItem) []string {
 		line := fmt.Sprintf("%s%s %s%s%s | %s | %s%s%s",
 			color, icon, label, dot, colorReset,
 			nameCol,
-			colorDim, shortenPath(item.WtPath), colorReset,
+			colorDim, shortenPathWithHome(item.WtPath, home), colorReset,
 		)
 		lines = append(lines, line)
 
@@ -357,7 +385,7 @@ func FormatPickerLines(items []PickerItem) []string {
 				subLine := fmt.Sprintf("  %s%s %s%s | %s | %s%s%s",
 					subColor, subIcon, subLabel, colorReset,
 					infoCol,
-					colorDim, shortenPath(item.WtPath), colorReset,
+					colorDim, shortenPathWithHome(item.WtPath, home), colorReset,
 				)
 				lines = append(lines, subLine)
 			}
@@ -464,7 +492,11 @@ func shortenPath(path string) string {
 	if err != nil {
 		return path
 	}
-	if strings.HasPrefix(path, home) {
+	return shortenPathWithHome(path, home)
+}
+
+func shortenPathWithHome(path, home string) string {
+	if home != "" && strings.HasPrefix(path, home) {
 		return "~" + path[len(home):]
 	}
 	return path


### PR DESCRIPTION
## Description of the change
Parallelizes multi-repo scan paths used by `ls`, `status`, `sw`, dashboard, and tmux integrations with a bounded ordered worker helper. Reuses session reads and cached formatting inputs to reduce duplicate filesystem work.

## Test plan
Unit tests, race tests, build, and local trace smoke checks:
- `go test ./... -count=1`
- `go test -race ./internal/parallel ./internal/cli ./internal/tmux ./internal/dashboard -count=1`
- `go build -o bin/willow ./cmd/willow`
- `./bin/willow --trace ls/status/tmux list/tmux status-bar`
