### PR TITLE
:art: style[tmux]: expand picker action labels

### DIFF
--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -24,7 +24,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-const tmuxPickerHeader = "Enter | ^N new ^T det ^U prom ^B base ^E ex ^P PR ^G run ^S sync ^D rm ^X prune"
+const tmuxPickerHeader = "^N new ^T detach ^U promote ^B rebase ^E existing ^P PR ^G dispatch ^S sync ^D rm ^X prune"
 
 func tmuxCmd() *cli.Command {
 	return &cli.Command{

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -228,12 +228,10 @@ func TestMoveToFrontWithStack_DetachedOnlyMovesSelectedWorktree(t *testing.T) {
 	assertBranches(t, branches(result[1:]), []string{"feat-a", "feat-b"})
 }
 
-func TestTmuxPickerHeaderFitsEightyColumns(t *testing.T) {
-	if got := len(tmuxPickerHeader); got > 80 {
-		t.Fatalf("tmux picker header length = %d, want <= 80", got)
-	}
-	if strings.Contains(tmuxPickerHeader, "upgrade") {
-		t.Fatal("tmux picker header should not mention the removed upgrade alias")
+func TestTmuxPickerHeaderActions(t *testing.T) {
+	want := "^N new ^T detach ^U promote ^B rebase ^E existing ^P PR ^G dispatch ^S sync ^D rm ^X prune"
+	if tmuxPickerHeader != want {
+		t.Fatalf("tmux picker header = %q, want %q", tmuxPickerHeader, want)
 	}
 }
 


### PR DESCRIPTION
## Description of the change
Expand the tmux picker header labels so shortcuts describe their actions plainly and omit the Enter shortcut.

## Test plan
Unit tests for the tmux picker header and picker helpers.