### PR TITLE
:test_tube: test[coverage]: enforce coverage gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Go test (${{ matrix.os }})
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -25,6 +26,25 @@ jobs:
       - name: Test
         run: go test ./... -count=1 -v
 
+  coverage:
+    name: Go coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Coverage
-        continue-on-error: true
-        run: go test ./... -coverpkg=./... -coverprofile=coverage.out -covermode=count
+        env:
+          GO_COVERAGE_MIN: "70.0"
+          GO_COVERAGE_PROFILE: coverage.out
+        run: scripts/check-go-coverage.sh
+
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: go-coverage
+          path: coverage.out

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,13 +9,14 @@ Prerequisites: Go 1.26+
 ```sh
 go build -o bin/willow ./cmd/willow
 go test ./... -count=1 -v
+GO_COVERAGE_MIN=70.0 scripts/check-go-coverage.sh
 ```
 
 ## Pull Requests
 
 1. Fork the repo and create a branch from `main`.
 2. If you've added code that should be tested, add tests.
-3. Make sure tests pass.
+3. Make sure tests and the Go coverage gate pass. CI enforces at least 70% total Go coverage.
 4. Open a pull request.
 
 For new features, please open an issue first to discuss the change.

--- a/README.md
+++ b/README.md
@@ -583,6 +583,9 @@ go build -o bin/willow ./cmd/willow
 
 # Test
 go test ./...
+
+# Coverage gate
+GO_COVERAGE_MIN=70.0 scripts/check-go-coverage.sh
 ```
 
 Requires Go 1.26+. fzf is bundled into the binary — no external `fzf` install needed.

--- a/cmd/willow/main_test.go
+++ b/cmd/willow/main_test.go
@@ -1,6 +1,30 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
+
+func discardOutput(t *testing.T, fn func()) {
+	t.Helper()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open devnull: %v", err)
+	}
+	defer devNull.Close()
+
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	os.Stdout = devNull
+	os.Stderr = devNull
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
+	fn()
+}
 
 func TestTraceStderrRequested(t *testing.T) {
 	tests := []struct {
@@ -25,4 +49,28 @@ func TestTraceStderrRequested(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunReturnsZeroForHelp(t *testing.T) {
+	origArgs := os.Args
+	os.Args = []string{"willow", "--help"}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	discardOutput(t, func() {
+		if got := run(); got != 0 {
+			t.Fatalf("run(--help) = %d, want 0", got)
+		}
+	})
+}
+
+func TestRunReturnsOneForCLIError(t *testing.T) {
+	origArgs := os.Args
+	os.Args = []string{"willow", "dispatch"}
+	t.Cleanup(func() { os.Args = origArgs })
+
+	discardOutput(t, func() {
+		if got := run(); got != 1 {
+			t.Fatalf("run(dispatch without prompt) = %d, want 1", got)
+		}
+	})
 }

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -117,6 +117,91 @@ func TestConfigEditCreatesFileAndRunsEditor(t *testing.T) {
 	}
 }
 
+func TestConfigInitCreatesGlobalConfigAndRejectsExisting(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdin: %v", err)
+	}
+	if _, err := w.WriteString("n\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	out, err := captureStdout(t, func() error {
+		return runApp("config", "init")
+	})
+	if err != nil {
+		t.Fatalf("config init failed: %v", err)
+	}
+	if !strings.Contains(out, "Created config") {
+		t.Fatalf("config init output missing success:\n%s", out)
+	}
+	cfg, err := config.LoadFile(config.GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Telemetry == nil || *cfg.Telemetry {
+		t.Fatalf("Telemetry = %v, want false", cfg.Telemetry)
+	}
+
+	os.Stdin = origStdin
+	err = runApp("config", "init")
+	if err == nil {
+		t.Fatal("config init should reject existing config")
+	}
+	if !strings.Contains(err.Error(), "config already exists") {
+		t.Fatalf("error = %v, want already exists", err)
+	}
+}
+
+func TestConfigInitForceOverwritesConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeGlobalConfigFile(t, `{"branchPrefix":"old","telemetry":false}`)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdin: %v", err)
+	}
+	if _, err := w.WriteString("y\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	out, err := captureStdout(t, func() error {
+		return runApp("config", "init", "--force")
+	})
+	if err != nil {
+		t.Fatalf("config init --force failed: %v", err)
+	}
+	if !strings.Contains(out, "Created config") {
+		t.Fatalf("config init --force output missing success:\n%s", out)
+	}
+	cfg, err := config.LoadFile(config.GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.BranchPrefix != "" {
+		t.Fatalf("BranchPrefix = %q, want overwritten default", cfg.BranchPrefix)
+	}
+	if cfg.Telemetry == nil || !*cfg.Telemetry {
+		t.Fatalf("Telemetry = %v, want true", cfg.Telemetry)
+	}
+}
+
 func TestFieldSource_String(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -1,6 +1,14 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/ui"
+)
 
 func TestSlugify(t *testing.T) {
 	tests := []struct {
@@ -37,5 +45,79 @@ func TestTruncatePrompt(t *testing.T) {
 	}
 	if got[77:] != "..." {
 		t.Errorf("truncatePrompt(long) should end with '...', got %q", got[77:])
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "'simple'"},
+		{"two words", "'two words'"},
+		{"don't panic", "'don'\\''t panic'"},
+		{"", "''"},
+	}
+
+	for _, tt := range tests {
+		if got := shellQuote(tt.input); got != tt.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestDispatchCmdRequiresPrompt(t *testing.T) {
+	err := runApp("dispatch")
+	if err == nil {
+		t.Fatal("dispatch without prompt should fail")
+	}
+	if !strings.Contains(err.Error(), "prompt is required") {
+		t.Fatalf("error = %v, want prompt required", err)
+	}
+}
+
+func TestDispatchForegroundRunsClaudeInWorktree(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "shell.log")
+	writeTestExecutable(t, binDir, "claude", "#!/bin/sh\nexit 0\n")
+	shellPath := writeTestExecutable(t, binDir, "fake-shell", "#!/bin/sh\n"+
+		"printf 'cwd=%s\\n' \"$PWD\" >> "+logPath+"\n"+
+		"printf 'args=%s|%s|%s\\n' \"$1\" \"$2\" \"$3\" >> "+logPath+"\n")
+	t.Setenv("PATH", binDir)
+	t.Setenv("SHELL", shellPath)
+
+	wtPath := t.TempDir()
+	var buf bytes.Buffer
+	u := &ui.UI{Out: &buf}
+	if err := dispatchForeground(u, wtPath, "dispatch--thing", "fix don't panic", true); err != nil {
+		t.Fatalf("dispatchForeground: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read shell log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "cwd="+wtPath) {
+		t.Fatalf("shell log missing cwd %q:\n%s", wtPath, logText)
+	}
+	for _, want := range []string{"-l", "-c", "claude 'fix don'\\''t panic'", "--dangerously-skip-permissions"} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("shell log missing %q:\n%s", want, logText)
+		}
+	}
+	if !strings.Contains(buf.String(), "Dispatched agent") {
+		t.Fatalf("UI output missing dispatch success:\n%s", buf.String())
+	}
+}
+
+func TestDispatchForegroundMissingClaude(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	err := dispatchForeground(&ui.UI{}, t.TempDir(), "branch", "prompt", false)
+	if err == nil {
+		t.Fatal("dispatchForeground should fail without claude in PATH")
+	}
+	if !strings.Contains(err.Error(), "'claude' CLI not found") {
+		t.Fatalf("error = %v, want missing claude message", err)
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,6 +1,55 @@
 package cli
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
+)
+
+type fakeDoctorUI struct {
+	successes []string
+	warnings  []string
+	infos     []string
+	confirms  []string
+	confirm   bool
+}
+
+func (u *fakeDoctorUI) Success(msg string) { u.successes = append(u.successes, msg) }
+func (u *fakeDoctorUI) Warn(msg string)    { u.warnings = append(u.warnings, msg) }
+func (u *fakeDoctorUI) Info(msg string)    { u.infos = append(u.infos, msg) }
+func (u *fakeDoctorUI) Confirm(msg string) bool {
+	u.confirms = append(u.confirms, msg)
+	return u.confirm
+}
+func (u *fakeDoctorUI) Red(s string) string { return "red:" + s }
+
+func (u *fakeDoctorUI) hasSuccess(substr string) bool { return containsString(u.successes, substr) }
+func (u *fakeDoctorUI) hasWarning(substr string) bool { return containsString(u.warnings, substr) }
+func (u *fakeDoctorUI) hasInfo(substr string) bool    { return containsString(u.infos, substr) }
+
+func containsString(values []string, substr string) bool {
+	for _, value := range values {
+		if strings.Contains(value, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func writeTestExecutable(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", name, err)
+	}
+	return path
+}
 
 func TestDoctorCmd(t *testing.T) {
 	cmd := doctorCmd()
@@ -9,6 +58,63 @@ func TestDoctorCmd(t *testing.T) {
 	}
 	if cmd.Action == nil {
 		t.Error("expected non-nil action")
+	}
+}
+
+func TestCheckGitVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		wantStatus string
+		wantText   string
+	}{
+		{
+			name:       "supported",
+			script:     "#!/bin/sh\nprintf 'git version 2.45.0\\n'\n",
+			wantStatus: "success",
+			wantText:   "git 2.45.0",
+		},
+		{
+			name:       "old",
+			script:     "#!/bin/sh\nprintf 'git version 2.29.0\\n'\n",
+			wantStatus: "warn",
+			wantText:   "recommend >= 2.30",
+		},
+		{
+			name:       "unparseable",
+			script:     "#!/bin/sh\nprintf 'not a version\\n'\n",
+			wantStatus: "stdout",
+			wantText:   "could not be parsed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			binDir := t.TempDir()
+			writeTestExecutable(t, binDir, "git", tt.script)
+			t.Setenv("PATH", binDir)
+
+			u := &fakeDoctorUI{}
+			out, _ := captureStdout(t, func() error {
+				checkGitVersion(u)
+				return nil
+			})
+
+			switch tt.wantStatus {
+			case "success":
+				if !u.hasSuccess(tt.wantText) {
+					t.Fatalf("successes = %v, want %q", u.successes, tt.wantText)
+				}
+			case "warn":
+				if !u.hasWarning(tt.wantText) {
+					t.Fatalf("warnings = %v, want %q", u.warnings, tt.wantText)
+				}
+			case "stdout":
+				if !strings.Contains(out, tt.wantText) {
+					t.Fatalf("stdout = %q, want %q", out, tt.wantText)
+				}
+			}
+		})
 	}
 }
 
@@ -44,5 +150,166 @@ func TestParseGitVersion(t *testing.T) {
 				t.Errorf("got %d.%d.%d, want %d.%d.%d", major, minor, patch, tt.major, tt.minor, tt.patch)
 			}
 		})
+	}
+}
+
+func TestCheckBinary(t *testing.T) {
+	binDir := t.TempDir()
+	writeTestExecutable(t, binDir, "gh", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir)
+
+	u := &fakeDoctorUI{}
+	checkBinary(u, "gh", "gh CLI", "https://cli.github.com")
+	checkBinary(u, "tmux", "tmux", "https://github.com/tmux/tmux")
+
+	if !u.hasSuccess("gh CLI installed") {
+		t.Fatalf("successes = %v, want gh installed", u.successes)
+	}
+	if !u.hasWarning("tmux not found") {
+		t.Fatalf("warnings = %v, want tmux missing", u.warnings)
+	}
+}
+
+func TestCheckClaudeHooks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	u := &fakeDoctorUI{}
+	checkClaudeHooks(u, false)
+	if !u.hasWarning("hooks not installed") {
+		t.Fatalf("warnings = %v, want missing hooks warning", u.warnings)
+	}
+
+	if _, err := claude.Install(); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+
+	settingsPath := filepath.Join(home, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("parse settings: %v", err)
+	}
+	hooks := settings["hooks"].(map[string]any)
+	hooks["Stop"] = append(hooks["Stop"].([]any), map[string]any{
+		"command": "/opt/homebrew/bin/willow hook",
+	})
+	updated, err := json.Marshal(settings)
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, updated, 0o644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	u = &fakeDoctorUI{}
+	checkClaudeHooks(u, false)
+	if !u.hasSuccess("hooks installed") {
+		t.Fatalf("successes = %v, want installed hooks", u.successes)
+	}
+	if !u.hasWarning("legacy willow hook") {
+		t.Fatalf("warnings = %v, want legacy hook warning", u.warnings)
+	}
+	if !u.hasInfo("doctor --fix") {
+		t.Fatalf("infos = %v, want fix hint", u.infos)
+	}
+
+	u = &fakeDoctorUI{confirm: true}
+	checkClaudeHooks(u, true)
+	if len(u.confirms) != 1 {
+		t.Fatalf("confirms = %v, want one confirmation", u.confirms)
+	}
+	if !u.hasSuccess("Removed 1 legacy hook") {
+		t.Fatalf("successes = %v, want legacy hook removal", u.successes)
+	}
+	if got := claude.UnmarkedLegacyHooks(); len(got) != 0 {
+		t.Fatalf("legacy hooks after fix = %v, want none", got)
+	}
+}
+
+func TestCheckWillowDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	u := &fakeDoctorUI{}
+	out, _ := captureStdout(t, func() error {
+		checkWillowDirs(u)
+		return nil
+	})
+	if !strings.Contains(out, "missing") {
+		t.Fatalf("stdout = %q, want missing directory output", out)
+	}
+
+	for _, dir := range []string{config.WillowHome(), config.ReposDir(), config.WorktreesDir()} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	u = &fakeDoctorUI{}
+	checkWillowDirs(u)
+	if len(u.successes) != 3 {
+		t.Fatalf("successes = %v, want three directory successes", u.successes)
+	}
+}
+
+func TestCheckStaleSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	u := &fakeDoctorUI{}
+	checkStaleSessions(u)
+	if !u.hasSuccess("no stale session") {
+		t.Fatalf("successes = %v, want no stale sessions", u.successes)
+	}
+
+	statusDir := filepath.Join(claude.StatusDir(), "repo", "worktree")
+	if err := os.MkdirAll(statusDir, 0o755); err != nil {
+		t.Fatalf("mkdir status dir: %v", err)
+	}
+	session := claude.SessionStatus{
+		Status:    claude.StatusBusy,
+		SessionID: "s1",
+		Timestamp: time.Now().Add(-31 * time.Minute),
+	}
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatalf("marshal session: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(statusDir, "s1.json"), data, 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	u = &fakeDoctorUI{}
+	checkStaleSessions(u)
+	if !u.hasWarning("1 stale session") {
+		t.Fatalf("warnings = %v, want stale session warning", u.warnings)
+	}
+}
+
+func TestCheckConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	u := &fakeDoctorUI{}
+	checkConfig(u)
+	if !u.hasSuccess("config valid") {
+		t.Fatalf("successes = %v, want config valid", u.successes)
+	}
+
+	cfgPath := config.GlobalConfigPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{"tmux":{"panes":[{"command":"echo hi"}]}}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	u = &fakeDoctorUI{}
+	checkConfig(u)
+	if !u.hasWarning("config:") {
+		t.Fatalf("warnings = %v, want config warning", u.warnings)
 	}
 }

--- a/internal/cli/migrate_base_test.go
+++ b/internal/cli/migrate_base_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestCopyDirCopiesFilesDirectoriesAndSymlinks(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source")
+	dest := filepath.Join(t.TempDir(), "dest")
+	nested := filepath.Join(source, "nested")
+	if err := os.MkdirAll(nested, 0o750); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	filePath := filepath.Join(nested, "file.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0o640); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := os.Symlink("nested/file.txt", filepath.Join(source, "link.txt")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := copyDir(source, dest); err != nil {
+		t.Fatalf("copyDir: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dest, "nested", "file.txt"))
+	if err != nil {
+		t.Fatalf("read copied file: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("copied file = %q, want hello", data)
+	}
+	linkTarget, err := os.Readlink(filepath.Join(dest, "link.txt"))
+	if err != nil {
+		t.Fatalf("read copied symlink: %v", err)
+	}
+	if linkTarget != "nested/file.txt" {
+		t.Fatalf("symlink target = %q, want nested/file.txt", linkTarget)
+	}
+	info, err := os.Stat(filepath.Join(dest, "nested"))
+	if err != nil {
+		t.Fatalf("stat copied dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o750 {
+		t.Fatalf("copied dir mode = %o, want 750", got)
+	}
+}
+
+func TestCopyDirRejectsNonDirectorySource(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source.txt")
+	if err := os.WriteFile(source, []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	err := copyDir(source, filepath.Join(t.TempDir(), "dest"))
+	if err == nil {
+		t.Fatal("copyDir should reject non-directory source")
+	}
+	if !strings.Contains(err.Error(), "source is not a directory") {
+		t.Fatalf("error = %v, want non-directory message", err)
+	}
+}
+
+func TestCopyFileCopiesContentsAndMode(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source.txt")
+	dest := filepath.Join(t.TempDir(), "dest.txt")
+	if err := os.WriteFile(source, []byte("copy me"), 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	if err := copyFile(source, dest, 0o640); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if string(data) != "copy me" {
+		t.Fatalf("dest contents = %q, want copy me", data)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat dest: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o640 {
+		t.Fatalf("dest mode = %o, want 640", got)
+	}
+}
+
+func TestMoveWillowBaseCopiesWhenDestinationExists(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "source")
+	dest := filepath.Join(t.TempDir(), "dest")
+	if err := os.MkdirAll(source, 0o755); err != nil {
+		t.Fatalf("mkdir source: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(source, "state.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+
+	if err := moveWillowBase(source, dest); err != nil {
+		t.Fatalf("moveWillowBase: %v", err)
+	}
+	if _, err := os.Stat(source); !os.IsNotExist(err) {
+		t.Fatalf("source should be removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "state.json")); err != nil {
+		t.Fatalf("dest file missing: %v", err)
+	}
+}
+
+func TestIsCrossDeviceError(t *testing.T) {
+	if !isCrossDeviceError(syscall.EXDEV) {
+		t.Fatal("syscall.EXDEV should be cross-device")
+	}
+	if !isCrossDeviceError(&os.LinkError{Op: "rename", Old: "a", New: "b", Err: syscall.EXDEV}) {
+		t.Fatal("LinkError wrapping EXDEV should be cross-device")
+	}
+	if isCrossDeviceError(errors.New("boom")) {
+		t.Fatal("plain error should not be cross-device")
+	}
+}
+
+func TestPrefixLines(t *testing.T) {
+	got := prefixLines([]string{"one", "two"}, "  ")
+	want := []string{"  one", "  two"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("prefixLines() = %v, want %v", got, want)
+	}
+}

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/ui"
+)
+
+func TestDetachedWorktreeDirNameValidation(t *testing.T) {
+	if got, err := detachedWorktreeDirName("feature/test"); err != nil || got != "feature-test" {
+		t.Fatalf("detachedWorktreeDirName() = %q, %v; want feature-test", got, err)
+	}
+	for _, name := range []string{"", ".", ".."} {
+		if _, err := detachedWorktreeDirName(name); err == nil {
+			t.Fatalf("detachedWorktreeDirName(%q) should fail", name)
+		}
+	}
+}
+
+func TestRunHooksRunsCommandsInDirectory(t *testing.T) {
+	dir := t.TempDir()
+	stdoutPath := filepath.Join(t.TempDir(), "stdout.log")
+	stdout, err := os.Create(stdoutPath)
+	if err != nil {
+		t.Fatalf("create stdout: %v", err)
+	}
+	defer stdout.Close()
+
+	var buf bytes.Buffer
+	u := &ui.UI{Out: &buf}
+	if err := runHooks([]string{"printf 'hello\\n'", "pwd"}, dir, u, stdout); err != nil {
+		t.Fatalf("runHooks: %v", err)
+	}
+	if err := stdout.Close(); err != nil {
+		t.Fatalf("close stdout: %v", err)
+	}
+
+	data, err := os.ReadFile(stdoutPath)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "hello") || !strings.Contains(out, dir) {
+		t.Fatalf("hook stdout = %q, want command output and working dir", out)
+	}
+	if !strings.Contains(buf.String(), "printf") || !strings.Contains(buf.String(), "pwd") {
+		t.Fatalf("UI output = %q, want hook commands", buf.String())
+	}
+}
+
+func TestRunHooksStopsOnFailure(t *testing.T) {
+	stdout, err := os.Create(filepath.Join(t.TempDir(), "stdout.log"))
+	if err != nil {
+		t.Fatalf("create stdout: %v", err)
+	}
+	defer stdout.Close()
+
+	err = runHooks([]string{"exit 7"}, t.TempDir(), &ui.UI{}, stdout)
+	if err == nil {
+		t.Fatal("runHooks should return failed hook error")
+	}
+	if !strings.Contains(err.Error(), "hook failed: exit 7") {
+		t.Fatalf("error = %v, want hook failed context", err)
+	}
+}
+
+func TestRunPostCheckoutHookInvokesConfiguredHook(t *testing.T) {
+	repoDir := t.TempDir()
+	repoGit := &git.Git{Dir: repoDir}
+	if _, err := repoGit.Run("init"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	configureGitUser(t, repoDir)
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	if _, err := repoGit.Run("add", "."); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if _, err := repoGit.Run("commit", "-m", "initial"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "hook.log")
+	hookDir := filepath.Join(repoDir, ".hooks")
+	if err := os.MkdirAll(hookDir, 0o755); err != nil {
+		t.Fatalf("mkdir hook dir: %v", err)
+	}
+	hookPath := filepath.Join(hookDir, "post-checkout")
+	hookScript := "#!/bin/sh\nprintf '%s|%s|%s\\n' \"$1\" \"$2\" \"$3\" > " + logPath + "\n"
+	if err := os.WriteFile(hookPath, []byte(hookScript), 0o755); err != nil {
+		t.Fatalf("write hook: %v", err)
+	}
+
+	runPostCheckoutHook("", repoDir, &ui.UI{}, false)
+	runPostCheckoutHook(".hooks/missing", repoDir, &ui.UI{}, false)
+	runPostCheckoutHook(".hooks/post-checkout", repoDir, &ui.UI{}, true)
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read hook log: %v", err)
+	}
+	logText := string(data)
+	if !strings.HasPrefix(logText, "0000000000000000000000000000000000000000|") {
+		t.Fatalf("hook log = %q, want null old ref", logText)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(logText), "|1") {
+		t.Fatalf("hook log = %q, want checkout flag 1", logText)
+	}
+}

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+)
+
+func TestSetupCmdInstallsHooksWithExistingTelemetryPreference(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeGlobalConfigFile(t, `{"telemetry":false}`)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("cc-setup")
+	})
+	if err != nil {
+		t.Fatalf("cc-setup failed: %v", err)
+	}
+
+	for _, want := range []string{"Installed Claude Code hooks", "hook:", "status:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cc-setup output missing %q:\n%s", want, out)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(home, ".claude", "settings.json")); err != nil {
+		t.Fatalf("settings.json not written: %v", err)
+	}
+	cfg, err := config.LoadFile(config.GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Telemetry == nil || *cfg.Telemetry {
+		t.Fatalf("telemetry preference = %v, want false", cfg.Telemetry)
+	}
+}
+
+func TestSetupCmdPromptsForTelemetryWhenUnset(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdin: %v", err)
+	}
+	if _, err := w.WriteString("y\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	out, err := captureStdout(t, func() error {
+		return runApp("cc-setup")
+	})
+	if err != nil {
+		t.Fatalf("cc-setup failed: %v", err)
+	}
+	if !strings.Contains(out, "Enable anonymous error telemetry") {
+		t.Fatalf("cc-setup output missing telemetry prompt:\n%s", out)
+	}
+	if !strings.Contains(out, "Telemetry enabled") {
+		t.Fatalf("cc-setup output missing telemetry enabled:\n%s", out)
+	}
+
+	cfg, err := config.LoadFile(config.GlobalConfigPath())
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Telemetry == nil || !*cfg.Telemetry {
+		t.Fatalf("telemetry preference = %v, want true", cfg.Telemetry)
+	}
+}

--- a/internal/cli/shellinit_test.go
+++ b/internal/cli/shellinit_test.go
@@ -113,3 +113,74 @@ func TestShellInitScriptsHandleRenameCd(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectShell(t *testing.T) {
+	tests := []struct {
+		shell string
+		want  string
+	}{
+		{"/bin/bash", "bash"},
+		{"/opt/homebrew/bin/zsh", "zsh"},
+		{"/usr/local/bin/fish", "fish"},
+		{"/bin/nu", "bash"},
+		{"", "bash"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.shell, func(t *testing.T) {
+			t.Setenv("SHELL", tt.shell)
+			if got := detectShell(); got != tt.want {
+				t.Fatalf("detectShell() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShellInitCommandPrintsDetectedShellScript(t *testing.T) {
+	tests := []struct {
+		name  string
+		shell string
+		want  string
+	}{
+		{"bash", "/bin/bash", "ww()"},
+		{"zsh", "/bin/zsh", "ww()"},
+		{"fish", "/usr/local/bin/fish", "function ww"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("SHELL", tt.shell)
+
+			out, err := captureStdout(t, func() error {
+				return runApp("shell-init", "--tab-title")
+			})
+			if err != nil {
+				t.Fatalf("shell-init failed: %v", err)
+			}
+			if !strings.Contains(out, tt.want) {
+				t.Fatalf("shell-init output missing %q:\n%s", tt.want, out)
+			}
+			if !strings.Contains(out, "WILLOW_WORKTREES_DIR") {
+				t.Fatalf("shell-init output missing worktrees dir:\n%s", out)
+			}
+			if !strings.Contains(out, "tab") && !strings.Contains(out, "title") && !strings.Contains(out, "precmd") && !strings.Contains(out, "fish_prompt") {
+				t.Fatalf("shell-init --tab-title output missing tab-title integration:\n%s", out)
+			}
+		})
+	}
+}
+
+func TestShellInitCommandDefaultsToBash(t *testing.T) {
+	t.Setenv("SHELL", "")
+	out, err := captureStdout(t, func() error {
+		return runApp("shell-init")
+	})
+	if err != nil {
+		t.Fatalf("shell-init failed: %v", err)
+	}
+	if !strings.Contains(out, "ww()") {
+		t.Fatalf("default shell-init output should be bash script:\n%s", out)
+	}
+}

--- a/internal/fzf/fzf.go
+++ b/internal/fzf/fzf.go
@@ -120,7 +120,9 @@ func buildArgs(cfg *config) []string {
 	return args
 }
 
-func runFzf(lines []string, extraArgs []string, cfg *config) ([]string, int, error) {
+var runFzf = runFzfWithLib
+
+func runFzfWithLib(lines []string, extraArgs []string, cfg *config) ([]string, int, error) {
 	args := append(extraArgs, buildArgs(cfg)...)
 
 	opts, err := fzflib.ParseOptions(true, args)

--- a/internal/fzf/fzf_pos_test.go
+++ b/internal/fzf/fzf_pos_test.go
@@ -1,8 +1,12 @@
 package fzf
 
 import (
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
+
+	fzflib "github.com/junegunn/fzf/src"
 )
 
 // TestPosBinding verifies that pos() is correctly included in the fzf args
@@ -95,5 +99,157 @@ func TestBuildArgsIncludesAllOptionsInOrder(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("buildArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestRunReturnsSelectionAndHandlesCancel(t *testing.T) {
+	oldRunFzf := runFzf
+	t.Cleanup(func() { runFzf = oldRunFzf })
+
+	runFzf = func(lines []string, extraArgs []string, cfg *config) ([]string, int, error) {
+		if !reflect.DeepEqual(lines, []string{"one", "two"}) {
+			t.Fatalf("lines = %v, want [one two]", lines)
+		}
+		if !reflect.DeepEqual(extraArgs, []string{"--no-multi"}) {
+			t.Fatalf("extraArgs = %v, want --no-multi", extraArgs)
+		}
+		return []string{"two"}, 0, nil
+	}
+	got, err := Run([]string{"one", "two"})
+	if err != nil || got != "two" {
+		t.Fatalf("Run() = %q, %v; want two, nil", got, err)
+	}
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, fzflib.ExitInterrupt, nil
+	}
+	got, err = Run([]string{"one"})
+	if err != nil || got != "" {
+		t.Fatalf("Run interrupt = %q, %v; want empty, nil", got, err)
+	}
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, fzflib.ExitNoMatch, nil
+	}
+	got, err = Run([]string{"one"})
+	if err != nil || got != "" {
+		t.Fatalf("Run no match = %q, %v; want empty, nil", got, err)
+	}
+}
+
+func TestRunWrapsErrorsAndEmptyOutput(t *testing.T) {
+	oldRunFzf := runFzf
+	t.Cleanup(func() { runFzf = oldRunFzf })
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, 0, errors.New("boom")
+	}
+	if _, err := Run([]string{"one"}); err == nil || !strings.Contains(err.Error(), "fzf failed") {
+		t.Fatalf("Run error = %v, want wrapped fzf error", err)
+	}
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, 0, nil
+	}
+	got, err := Run([]string{"one"})
+	if err != nil || got != "" {
+		t.Fatalf("Run empty output = %q, %v; want empty, nil", got, err)
+	}
+}
+
+func TestRunExpectParsesQueryKeyAndSelection(t *testing.T) {
+	oldRunFzf := runFzf
+	t.Cleanup(func() { runFzf = oldRunFzf })
+
+	runFzf = func(lines []string, extraArgs []string, cfg *config) ([]string, int, error) {
+		if !reflect.DeepEqual(extraArgs, []string{"--no-multi"}) {
+			t.Fatalf("extraArgs = %v, want --no-multi", extraArgs)
+		}
+		return []string{"feature", "ctrl-n", "selected"}, 0, nil
+	}
+
+	got, err := RunExpect([]string{"selected"}, WithPrintQuery(), WithExpectKeys("ctrl-n"))
+	if err != nil {
+		t.Fatalf("RunExpect: %v", err)
+	}
+	if got.Query != "feature" || got.Key != "ctrl-n" || got.Selection != "selected" {
+		t.Fatalf("RunExpect() = %+v, want parsed query/key/selection", got)
+	}
+}
+
+func TestRunExpectHandlesCancelAndErrors(t *testing.T) {
+	oldRunFzf := runFzf
+	t.Cleanup(func() { runFzf = oldRunFzf })
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, fzflib.ExitInterrupt, nil
+	}
+	got, err := RunExpect([]string{"one"})
+	if err != nil || got != nil {
+		t.Fatalf("RunExpect interrupt = %+v, %v; want nil, nil", got, err)
+	}
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, 0, errors.New("boom")
+	}
+	got, err = RunExpect([]string{"one"})
+	if err == nil || !strings.Contains(err.Error(), "fzf failed") || got != nil {
+		t.Fatalf("RunExpect error = %+v, %v; want wrapped error", got, err)
+	}
+}
+
+func TestRunMultiReturnsSelectionsAndHandlesEmpty(t *testing.T) {
+	oldRunFzf := runFzf
+	t.Cleanup(func() { runFzf = oldRunFzf })
+
+	runFzf = func(lines []string, extraArgs []string, cfg *config) ([]string, int, error) {
+		wantArgs := []string{"--multi", "--bind=ctrl-a:select-all"}
+		if !reflect.DeepEqual(extraArgs, wantArgs) {
+			t.Fatalf("extraArgs = %v, want %v", extraArgs, wantArgs)
+		}
+		return []string{"one", "two"}, 0, nil
+	}
+	got, err := RunMulti([]string{"one", "two"})
+	if err != nil || !reflect.DeepEqual(got, []string{"one", "two"}) {
+		t.Fatalf("RunMulti() = %v, %v; want selections, nil", got, err)
+	}
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, fzflib.ExitNoMatch, nil
+	}
+	got, err = RunMulti([]string{"one"})
+	if err != nil || got != nil {
+		t.Fatalf("RunMulti no match = %v, %v; want nil, nil", got, err)
+	}
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, 0, nil
+	}
+	got, err = RunMulti([]string{"one"})
+	if err != nil || got != nil {
+		t.Fatalf("RunMulti empty = %v, %v; want nil, nil", got, err)
+	}
+}
+
+func TestRunMultiWrapsErrors(t *testing.T) {
+	oldRunFzf := runFzf
+	t.Cleanup(func() { runFzf = oldRunFzf })
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, 0, errors.New("boom")
+	}
+	got, err := RunMulti([]string{"one"})
+	if err == nil || !strings.Contains(err.Error(), "fzf failed") || got != nil {
+		t.Fatalf("RunMulti error = %v, %v; want wrapped error", got, err)
+	}
+}
+
+func TestRunFzfWithLibReturnsParseError(t *testing.T) {
+	_, _, err := runFzfWithLib([]string{"one"}, []string{"--definitely-not-a-real-fzf-option"}, defaults())
+	if err == nil {
+		t.Fatal("runFzfWithLib should return parse error for invalid option")
+	}
+	if !strings.Contains(err.Error(), "fzf:") {
+		t.Fatalf("error = %v, want fzf parse context", err)
 	}
 }

--- a/internal/tmux/notify.go
+++ b/internal/tmux/notify.go
@@ -7,6 +7,14 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 )
 
+var (
+	currentSession = CurrentSession
+	startNotify    = func(command string) {
+		cmd := exec.Command("sh", "-c", command)
+		cmd.Start()
+	}
+)
+
 const (
 	defaultNotifyCommand     = "afplay /System/Library/Sounds/Glass.aiff"
 	defaultNotifyWaitCommand = "afplay /System/Library/Sounds/Funk.aiff"
@@ -20,9 +28,9 @@ func CheckTransitions(current map[string]claude.Status) []claude.Transition {
 // NotifyWithContext sends sound notifications for transitions, skipping the current
 // tmux session.
 func NotifyWithContext(transitions []claude.Transition, cfg *config.Config) {
-	currentSession, _ := CurrentSession()
+	session, _ := currentSession()
 	for _, t := range transitions {
-		if t.Key == currentSession {
+		if t.Key == session {
 			continue
 		}
 		switch t.ToStatus {
@@ -43,6 +51,5 @@ func Notify(command string) {
 	if command == "" {
 		command = defaultNotifyCommand
 	}
-	cmd := exec.Command("sh", "-c", command)
-	cmd.Start()
+	startNotify(command)
 }

--- a/internal/tmux/notify_test.go
+++ b/internal/tmux/notify_test.go
@@ -3,10 +3,12 @@ package tmux
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"testing"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
 )
 
 // ensureWillowDir creates the ~/.willow directory so saveState can write the state file.
@@ -154,5 +156,76 @@ func TestCheckTransitions_MultipleTransitions(t *testing.T) {
 	}
 	if got[1].Key != "repo/wt2" || got[1].ToStatus != claude.StatusWait {
 		t.Errorf("transition[1]: expected repo/wt2->WAIT, got %s->%s", got[1].Key, got[1].ToStatus)
+	}
+}
+
+func TestNotifyUsesDefaultAndCustomCommands(t *testing.T) {
+	var commands []string
+	oldStart := startNotify
+	startNotify = func(command string) {
+		commands = append(commands, command)
+	}
+	t.Cleanup(func() { startNotify = oldStart })
+
+	Notify("")
+	Notify("printf custom")
+
+	want := []string{defaultNotifyCommand, "printf custom"}
+	if !reflect.DeepEqual(commands, want) {
+		t.Fatalf("commands = %v, want %v", commands, want)
+	}
+}
+
+func TestNotifyWithContextSkipsCurrentSessionAndChoosesCommands(t *testing.T) {
+	oldCurrent := currentSession
+	oldStart := startNotify
+	currentSession = func() (string, error) { return "repo/current", nil }
+	var commands []string
+	startNotify = func(command string) {
+		commands = append(commands, command)
+	}
+	t.Cleanup(func() {
+		currentSession = oldCurrent
+		startNotify = oldStart
+	})
+
+	NotifyWithContext([]claude.Transition{
+		{Key: "repo/current", ToStatus: claude.StatusDone},
+		{Key: "repo/wait", ToStatus: claude.StatusWait},
+		{Key: "repo/done", ToStatus: claude.StatusDone},
+		{Key: "repo/busy", ToStatus: claude.StatusBusy},
+	}, &config.Config{
+		Tmux: config.TmuxConfig{
+			NotifyCommand:     "done-command",
+			NotifyWaitCommand: "wait-command",
+		},
+	})
+
+	want := []string{"wait-command", "done-command"}
+	if !reflect.DeepEqual(commands, want) {
+		t.Fatalf("commands = %v, want %v", commands, want)
+	}
+}
+
+func TestNotifyWithContextDefaultsWaitCommand(t *testing.T) {
+	oldCurrent := currentSession
+	oldStart := startNotify
+	currentSession = func() (string, error) { return "", nil }
+	var commands []string
+	startNotify = func(command string) {
+		commands = append(commands, command)
+	}
+	t.Cleanup(func() {
+		currentSession = oldCurrent
+		startNotify = oldStart
+	})
+
+	NotifyWithContext([]claude.Transition{
+		{Key: "repo/wait", ToStatus: claude.StatusWait},
+	}, &config.Config{})
+
+	want := []string{defaultNotifyWaitCommand}
+	if !reflect.DeepEqual(commands, want) {
+		t.Fatalf("commands = %v, want %v", commands, want)
 	}
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,8 +1,34 @@
 package tmux
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/config"
 )
+
+func installFakeTmux(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "tmux.log")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + logPath + "\n" +
+		"case \"$1\" in\n" +
+		"  list-sessions) printf 'alpha\\nbeta\\n' ;;\n" +
+		"  display-message) printf 'current-session\\n' ;;\n" +
+		"  capture-pane) printf 'pane output\\n' ;;\n" +
+		"  list-panes) printf '%%1\\n%%2\\n' ;;\n" +
+		"  has-session) [ \"$3\" = \"exists\" ] ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+	return logPath
+}
 
 func TestPrepareLayoutCmd_InjectsSessionTarget(t *testing.T) {
 	args := prepareLayoutCmd([]string{"split-window", "-h"}, "mysession", "/tmp/dir")
@@ -87,5 +113,99 @@ func TestPrepareLayoutCmd_EmptyArgs(t *testing.T) {
 	args := prepareLayoutCmd([]string{}, "sess", "/work")
 	if len(args) != 0 {
 		t.Errorf("expected empty args, got %v", args)
+	}
+}
+
+func TestTmuxCommandWrappersUseTmuxCLI(t *testing.T) {
+	logPath := installFakeTmux(t)
+
+	t.Setenv("TMUX", "")
+	if InTmux() {
+		t.Fatal("InTmux() = true with empty TMUX")
+	}
+	t.Setenv("TMUX", "/tmp/tmux.sock")
+	if !InTmux() {
+		t.Fatal("InTmux() = false with TMUX set")
+	}
+
+	if !SessionExists("exists") {
+		t.Fatal("SessionExists(exists) = false")
+	}
+	if SessionExists("missing") {
+		t.Fatal("SessionExists(missing) = true")
+	}
+
+	sessions := ListSessions()
+	if !sessions["alpha"] || !sessions["beta"] || len(sessions) != 2 {
+		t.Fatalf("ListSessions() = %v, want alpha and beta", sessions)
+	}
+	if err := SendKeys("target", "echo hi", "Enter"); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+	if err := KillSession("target"); err != nil {
+		t.Fatalf("KillSession: %v", err)
+	}
+	if err := RenameSession("old", "new"); err != nil {
+		t.Fatalf("RenameSession: %v", err)
+	}
+	if err := SwitchClient("target"); err != nil {
+		t.Fatalf("SwitchClient in tmux: %v", err)
+	}
+	t.Setenv("TMUX", "")
+	if err := SwitchClient("target"); err != nil {
+		t.Fatalf("SwitchClient outside tmux: %v", err)
+	}
+	if got, err := CurrentSession(); err != nil || got != "current-session" {
+		t.Fatalf("CurrentSession() = %q, %v; want current-session", got, err)
+	}
+	if got, err := CapturePane("target"); err != nil || got != "pane output" {
+		t.Fatalf("CapturePane() = %q, %v; want pane output", got, err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+	logText := string(logData)
+	for _, want := range []string{
+		"send-keys -t target echo hi Enter",
+		"kill-session -t target",
+		"rename-session -t old new",
+		"switch-client -t target",
+		"attach-session -t target",
+		"capture-pane -ept target -S -",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("tmux log missing %q:\n%s", want, logText)
+		}
+	}
+}
+
+func TestNewSessionRunsLayoutAndPaneCommands(t *testing.T) {
+	logPath := installFakeTmux(t)
+
+	err := NewSession("sess", "/work", []string{"split-window -h"}, []config.PaneConfig{
+		{Command: "echo one"},
+		{Command: "echo two"},
+	})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+	logText := string(logData)
+	for _, want := range []string{
+		"new-session -d -s sess -c /work",
+		"split-window -t sess -h -c /work",
+		"list-panes -t sess -s -F #{pane_id}",
+		"send-keys -t %1 echo one Enter",
+		"send-keys -t %2 echo two Enter",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("tmux log missing %q:\n%s", want, logText)
+		}
 	}
 }

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"bytes"
+	"io"
+	"os"
 	"strings"
 	"testing"
 )
@@ -97,6 +99,72 @@ func TestUI_CustomOutDoesNotWriteToStdout(t *testing.T) {
 	// Verify output went to buf, not stdout
 	if !strings.Contains(buf.String(), "redirected") {
 		t.Error("output should go to custom Out")
+	}
+}
+
+func TestUI_ErrorfWritesToStderr(t *testing.T) {
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	u := &UI{}
+	u.Errorf("failed: %s", "boom")
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	os.Stderr = origStderr
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	out := string(data)
+	if !strings.Contains(out, "error:") || !strings.Contains(out, "failed: boom") {
+		t.Fatalf("stderr = %q, want formatted error", out)
+	}
+}
+
+func TestUI_ConfirmReadsYesOnly(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"n\n", false},
+		{"\n", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.TrimSpace(tt.input), func(t *testing.T) {
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("pipe stdin: %v", err)
+			}
+			if _, err := w.WriteString(tt.input); err != nil {
+				t.Fatalf("write stdin: %v", err)
+			}
+			if err := w.Close(); err != nil {
+				t.Fatalf("close stdin writer: %v", err)
+			}
+			origStdin := os.Stdin
+			os.Stdin = r
+			t.Cleanup(func() { os.Stdin = origStdin })
+
+			var buf bytes.Buffer
+			u := &UI{Out: &buf}
+			if got := u.Confirm("continue?"); got != tt.want {
+				t.Fatalf("Confirm(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			if !strings.Contains(buf.String(), "continue? [y/N]") {
+				t.Fatalf("prompt output = %q, want prompt", buf.String())
+			}
+			os.Stdin = origStdin
+		})
 	}
 }
 

--- a/scripts/check-go-coverage.sh
+++ b/scripts/check-go-coverage.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+min_coverage="${GO_COVERAGE_MIN:-70.0}"
+profile="${GO_COVERAGE_PROFILE:-coverage.out}"
+
+mkdir -p "$(dirname "$profile")"
+
+go test ./... -count=1 -coverpkg=./... -coverprofile="$profile" -covermode=count
+
+coverage_with_percent="$(go tool cover -func="$profile" | awk '/^total:/ {print $3}')"
+coverage="${coverage_with_percent%%%}"
+if [[ -z "$coverage" ]]; then
+	printf 'Could not determine total Go coverage from %s\n' "$profile" >&2
+	exit 1
+fi
+
+printf 'Go coverage: %s%%\n' "$coverage"
+printf 'Required:    %s%%\n' "$min_coverage"
+printf 'Profile:     %s\n' "$profile"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+	{
+		printf '### Go coverage\n\n'
+		printf '| Metric | Value |\n'
+		printf '| --- | --- |\n'
+		printf '| Coverage | `%s%%` |\n' "$coverage"
+		printf '| Required | `%s%%` |\n' "$min_coverage"
+		printf '| Profile | `%s` |\n' "$profile"
+	} >>"$GITHUB_STEP_SUMMARY"
+fi
+
+if ! awk -v coverage="$coverage" -v minimum="$min_coverage" 'BEGIN { exit !(coverage + 0 >= minimum + 0) }'; then
+	printf 'Go coverage %s%% is below required %s%%\n' "$coverage" "$min_coverage" >&2
+	exit 1
+fi


### PR DESCRIPTION
## Description of the change
Raises Willow's Go coverage above the new 70% floor with focused CLI, tmux, fzf, command, and UI tests. Adds a reusable Go coverage script and makes CI block merges on the Ubuntu coverage gate while keeping the Go test matrix on Ubuntu and macOS.

## Test plan
Unit tests and coverage gate validation:
- `go test ./... -count=1 -v`
- `GO_COVERAGE_MIN=70.0 GO_COVERAGE_PROFILE=/tmp/willow-coverage.out scripts/check-go-coverage.sh`
- `GO_COVERAGE_MIN=99.9 GO_COVERAGE_PROFILE=/tmp/willow-coverage-fail.out scripts/check-go-coverage.sh` (expected failure)

## Loom or screenshots
N/A

## Considerations
The repository ruleset now requires `Go test (ubuntu-latest)`, `Go test (macos-latest)`, and `Go coverage` before merges to `main`.