### PR TITLE
:test_tube: test[coverage]: raise go coverage to 80

### DIFF
--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -117,6 +117,33 @@ func TestConfigEditCreatesFileAndRunsEditor(t *testing.T) {
 	}
 }
 
+func TestConfigEditLocalUsesRepoConfigPath(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	logPath := filepath.Join(home, "editor.log")
+	editorPath := filepath.Join(home, "editor")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$1\" >> " + logPath + "\n"
+	if err := os.WriteFile(editorPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write editor: %v", err)
+	}
+	t.Setenv("VISUAL", editorPath)
+
+	if err := runApp("config", "edit", "--local", "--repo", "repo"); err != nil {
+		t.Fatalf("config edit --local failed: %v", err)
+	}
+
+	cfgPath := filepath.Join(home, ".willow", "repos", "repo.git", "willow.json")
+	if _, err := os.Stat(cfgPath); err != nil {
+		t.Fatalf("expected local config file to be created: %v", err)
+	}
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read editor log: %v", err)
+	}
+	if strings.TrimSpace(string(logData)) != cfgPath {
+		t.Fatalf("editor invoked with %q, want %q", strings.TrimSpace(string(logData)), cfgPath)
+	}
+}
+
 func TestConfigInitCreatesGlobalConfigAndRejectsExisting(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -159,6 +186,40 @@ func TestConfigInitCreatesGlobalConfigAndRejectsExisting(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "config already exists") {
 		t.Fatalf("error = %v, want already exists", err)
+	}
+}
+
+func TestConfigInitCreatesLocalConfigForRepo(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdin: %v", err)
+	}
+	if _, err := w.WriteString("y\n"); err != nil {
+		t.Fatalf("write stdin: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stdin writer: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+
+	out, err := captureStdout(t, func() error {
+		return runApp("config", "init", "--local", "--repo", "repo")
+	})
+	if err != nil {
+		t.Fatalf("config init --local failed: %v", err)
+	}
+	if !strings.Contains(out, "Created config") {
+		t.Fatalf("config init --local output missing success:\n%s", out)
+	}
+	cfg, err := config.LoadFile(filepath.Join(home, ".willow", "repos", "repo.git", "willow.json"))
+	if err != nil {
+		t.Fatalf("load local config: %v", err)
+	}
+	if cfg.Telemetry == nil || !*cfg.Telemetry {
+		t.Fatalf("Telemetry = %v, want true", cfg.Telemetry)
 	}
 }
 

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -76,6 +76,41 @@ func TestDispatchCmdRequiresPrompt(t *testing.T) {
 	}
 }
 
+func TestDispatchCmdCreatesWorktreeAndRunsForegroundClaude(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	helperLog := filepath.Join(t.TempDir(), "willow-helper.log")
+	t.Setenv("WILLOW_TEST_HELPER_PROCESS", "willow")
+	t.Setenv("WILLOW_TEST_HELPER_WT_ROOT", filepath.Join(home, ".willow", "worktrees"))
+	t.Setenv("WILLOW_TEST_HELPER_LOG", helperLog)
+
+	binDir := t.TempDir()
+	writeTestExecutable(t, binDir, "claude", "#!/bin/sh\nexit 0\n")
+	shellLog := filepath.Join(t.TempDir(), "shell.log")
+	shellPath := writeTestExecutable(t, binDir, "fake-shell", "#!/bin/sh\n"+
+		"printf 'cwd=%s\\n' \"$PWD\" >> "+shellQuote(shellLog)+"\n"+
+		"printf 'args=%s|%s|%s\\n' \"$1\" \"$2\" \"$3\" >> "+shellQuote(shellLog)+"\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("SHELL", shellPath)
+
+	if err := runApp("dispatch", "Fix dispatch command", "--repo", "repo", "--name", "dispatch-test", "--base", "main", "--no-fetch", "--yolo"); err != nil {
+		t.Fatalf("dispatch command failed: %v", err)
+	}
+
+	helperText := readTestFile(t, helperLog)
+	if !strings.Contains(helperText, "new --cd --repo repo --base main --no-fetch -- dispatch-test") {
+		t.Fatalf("helper log missing dispatch new command:\n%s", helperText)
+	}
+	shellText := readTestFile(t, shellLog)
+	for _, want := range []string{
+		filepath.Join(home, ".willow", "worktrees", "repo", "dispatch-test"),
+		"claude 'Fix dispatch command' --dangerously-skip-permissions",
+	} {
+		if !strings.Contains(shellText, want) {
+			t.Fatalf("shell log missing %q:\n%s", want, shellText)
+		}
+	}
+}
+
 func TestDispatchForegroundRunsClaudeInWorktree(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "shell.log")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -61,6 +61,33 @@ func TestDoctorCmd(t *testing.T) {
 	}
 }
 
+func TestDoctorCommandRunsChecks(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir := t.TempDir()
+	writeTestExecutable(t, binDir, "git", "#!/bin/sh\nprintf 'git version 2.45.0\\n'\n")
+	writeTestExecutable(t, binDir, "gh", "#!/bin/sh\nexit 0\n")
+	writeTestExecutable(t, binDir, "tmux", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir)
+	for _, dir := range []string{config.WillowHome(), config.ReposDir(), config.WorktreesDir()} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("doctor")
+	})
+	if err != nil {
+		t.Fatalf("doctor command failed: %v", err)
+	}
+	for _, want := range []string{"git 2.45.0", "gh CLI installed", "tmux installed", "config valid"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("doctor output missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestCheckGitVersion(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/cli/helper_process_test.go
+++ b/internal/cli/helper_process_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv("WILLOW_TEST_HELPER_PROCESS") == "willow" {
+		willowTestHelperProcess()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func willowTestHelperProcess() {
+	logPath := os.Getenv("WILLOW_TEST_HELPER_LOG")
+	if logPath != "" {
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+		if err == nil {
+			_, _ = fmt.Fprintln(f, strings.Join(os.Args[1:], " "))
+			_ = f.Close()
+		}
+	}
+	if len(os.Args) < 2 {
+		os.Exit(2)
+	}
+
+	switch os.Args[1] {
+	case "new", "checkout":
+		repo := "repo"
+		for i, arg := range os.Args[2:] {
+			if arg == "--repo" && i+3 < len(os.Args) {
+				repo = os.Args[i+3]
+			}
+		}
+		branch := os.Args[len(os.Args)-1]
+		root := os.Getenv("WILLOW_TEST_HELPER_WT_ROOT")
+		if root == "" {
+			root = filepath.Join(os.TempDir(), "willow-helper-worktrees")
+		}
+		path := filepath.Join(root, repo, branch)
+		_ = os.MkdirAll(path, 0o755)
+		fmt.Println(path)
+		os.Exit(0)
+	case "rm":
+		os.Exit(0)
+	default:
+		os.Exit(2)
+	}
+}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -319,6 +319,29 @@ func captureStdout(t *testing.T, fn func() error) (string, error) {
 	return string(out), runErr
 }
 
+func captureStderr(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	runErr := fn()
+	_ = w.Close()
+	os.Stderr = origStderr
+
+	out, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatalf("read stderr: %v", readErr)
+	}
+	return string(out), runErr
+}
+
 func installMergedStatusGH(t *testing.T, baseBranch, branch, headOID string) string {
 	t.Helper()
 

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -113,3 +113,120 @@ func TestRunPostCheckoutHookInvokesConfiguredHook(t *testing.T) {
 		t.Fatalf("hook log = %q, want checkout flag 1", logText)
 	}
 }
+
+func TestNewDetachedWithoutExplicitRefUsesBaseBranch(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, "detachedbase"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	worktreeRoot := filepath.Join(home, ".willow", "worktrees", "detachedbase")
+	baseBranch := firstWorktreeDir(t, worktreeRoot)
+	if err := os.Chdir(filepath.Join(worktreeRoot, baseBranch)); err != nil {
+		t.Fatalf("chdir base worktree: %v", err)
+	}
+
+	if err := runApp("new", "scratch-from-base", "--detach", "--base", baseBranch, "--no-fetch"); err != nil {
+		t.Fatalf("new detached from base failed: %v", err)
+	}
+
+	wtPath := filepath.Join(worktreeRoot, "scratch-from-base")
+	if _, err := os.Stat(wtPath); err != nil {
+		t.Fatalf("detached worktree missing at %s: %v", wtPath, err)
+	}
+	head, err := (&git.Git{Dir: wtPath}).Run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse detached head: %v", err)
+	}
+	if head != "HEAD" {
+		t.Fatalf("detached worktree branch = %q, want HEAD", head)
+	}
+}
+
+func TestResolvePRRefUsesGHCLI(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "gh.log")
+	writeTestExecutable(t, binDir, "gh", "#!/bin/sh\n"+
+		"printf '%s\\n' \"$*\" >> "+shellQuote(logPath)+"\n"+
+		"printf 'feature-pr\\n'\n")
+	t.Setenv("PATH", binDir)
+
+	got, err := resolvePRRef("42", t.TempDir())
+	if err != nil {
+		t.Fatalf("resolvePRRef: %v", err)
+	}
+	if got != "feature-pr" {
+		t.Fatalf("resolvePRRef() = %q, want feature-pr", got)
+	}
+	if logText := readTestFile(t, logPath); !strings.Contains(logText, "pr view 42 --json headRefName -q .headRefName") {
+		t.Fatalf("gh log missing pr view invocation:\n%s", logText)
+	}
+}
+
+func TestResolvePRRefReportsGHFailures(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if _, err := resolvePRRef("42", t.TempDir()); err == nil || !strings.Contains(err.Error(), "'gh' CLI not found") {
+		t.Fatalf("missing gh error = %v", err)
+	}
+
+	binDir := t.TempDir()
+	writeTestExecutable(t, binDir, "gh", "#!/bin/sh\nprintf 'bad pr\\n' >&2\nexit 1\n")
+	t.Setenv("PATH", binDir)
+	if _, err := resolvePRRef("42", t.TempDir()); err == nil || !strings.Contains(err.Error(), "bad pr") {
+		t.Fatalf("gh failure error = %v", err)
+	}
+}
+
+func TestPickExistingBranchReportsNoRemoteBranches(t *testing.T) {
+	bareDir := filepath.Join(t.TempDir(), "empty.git")
+	if _, err := (&git.Git{}).Run("init", "--bare", bareDir); err != nil {
+		t.Fatalf("init bare repo: %v", err)
+	}
+	repoGit := &git.Git{Dir: bareDir}
+	if got, err := pickExistingBranchWithQuery(repoGit, "main"); err == nil || got != "" || !strings.Contains(err.Error(), "no remote branches found") {
+		t.Fatalf("pickExistingBranchWithQuery = %q, %v; want no-remotes error", got, err)
+	}
+}
+
+func TestPickExistingBranchWithQueryFiltersCurrentWorktrees(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	seed := filepath.Join(home, "seed-existing")
+	if _, err := (&git.Git{}).Run("clone", origin, seed); err != nil {
+		t.Fatalf("clone seed: %v", err)
+	}
+	configureGitUser(t, seed)
+	seedGit := &git.Git{Dir: seed}
+	if _, err := seedGit.Run("checkout", "-b", "remote-only"); err != nil {
+		t.Fatalf("checkout remote branch: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "remote.txt"), []byte("remote\n"), 0o644); err != nil {
+		t.Fatalf("write remote file: %v", err)
+	}
+	if _, err := seedGit.Run("add", "."); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if _, err := seedGit.Run("commit", "-m", "remote branch"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	if _, err := seedGit.Run("push", "origin", "remote-only"); err != nil {
+		t.Fatalf("git push remote-only: %v", err)
+	}
+
+	if err := runApp("clone", origin, "existingpick"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	bareDir := filepath.Join(home, ".willow", "repos", "existingpick.git")
+	repoGit := &git.Git{Dir: bareDir}
+	if _, err := repoGit.Run("fetch", "origin", "remote-only:refs/remotes/origin/remote-only"); err != nil {
+		t.Fatalf("fetch remote-only: %v", err)
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=remote-only")
+
+	if got, err := pickExistingBranch(repoGit); err != nil || got != "remote-only" {
+		t.Fatalf("pickExistingBranch = %q, %v; want remote-only, nil", got, err)
+	}
+	if got, err := pickExistingBranchWithQuery(repoGit, "remote"); err != nil || got != "remote-only" {
+		t.Fatalf("pickExistingBranchWithQuery = %q, %v; want remote-only, nil", got, err)
+	}
+}

--- a/internal/cli/rm_test.go
+++ b/internal/cli/rm_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -19,6 +20,61 @@ func TestReadGitAdminDir_Absolute(t *testing.T) {
 	}
 	if got != adminDir {
 		t.Errorf("got %q, want %q", got, adminDir)
+	}
+}
+
+func TestRmCommandPickerSingleRepoRemovesSelectedWorktree(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, "rmpicker"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	worktreeRoot := filepath.Join(home, ".willow", "worktrees", "rmpicker")
+	mainDir := filepath.Join(worktreeRoot, firstWorktreeDir(t, worktreeRoot))
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatalf("chdir main: %v", err)
+	}
+	if err := runApp("new", "remove-picker", "--no-fetch"); err != nil {
+		t.Fatalf("new remove-picker failed: %v", err)
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=remove-picker")
+
+	if err := runApp("rm", "--repo", "rmpicker", "--force", "--keep-branch"); err != nil {
+		t.Fatalf("rm picker failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktreeRoot, "remove-picker")); !os.IsNotExist(err) {
+		t.Fatalf("remove-picker worktree still exists or stat failed unexpectedly: %v", err)
+	}
+}
+
+func TestRmCommandPickerMultiRepoRemovesSelectedWorktree(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, "rmone"); err != nil {
+		t.Fatalf("clone rmone failed: %v", err)
+	}
+	if err := runApp("clone", origin, "rmtwo"); err != nil {
+		t.Fatalf("clone rmtwo failed: %v", err)
+	}
+	if err := os.Chdir(home); err != nil {
+		t.Fatalf("chdir home: %v", err)
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=rmtwo/")
+
+	if err := runApp("rm", "--force", "--keep-branch"); err != nil {
+		t.Fatalf("multi-repo rm picker failed: %v", err)
+	}
+	rmtwoRoot := filepath.Join(home, ".willow", "worktrees", "rmtwo")
+	entries, err := os.ReadDir(rmtwoRoot)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read rmtwo worktree root: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			names = append(names, entry.Name())
+		}
+		t.Fatalf("rmtwo worktree root entries = %s, want selected worktree removed", strings.Join(names, ", "))
 	}
 }
 

--- a/internal/cli/stack_cmd_test.go
+++ b/internal/cli/stack_cmd_test.go
@@ -123,4 +123,16 @@ exit 1
 	if got["feature-b"].BaseRefName != "feature-a" {
 		t.Fatalf("feature-b PR = %+v, want base feature-a", got["feature-b"])
 	}
+
+	out, err = captureStdout(t, func() error {
+		return runApp("stack", "status", "--repo", "stackstatus")
+	})
+	if err != nil {
+		t.Fatalf("stack status failed: %v", err)
+	}
+	for _, want := range []string{"feature-a", "feature-b", "#10", "#11", "CI", "Review"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stack status output missing %q:\n%s", want, out)
+		}
+	}
 }

--- a/internal/cli/sw_test.go
+++ b/internal/cli/sw_test.go
@@ -208,3 +208,130 @@ func TestBuildCrossRepoWorktreeLines_UrgencyOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestSwCommandPickerSingleRepoPrintsSelectedPath(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, "swpicker"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=master")
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sw", "--repo", "swpicker")
+	})
+	if err != nil {
+		t.Fatalf("sw picker failed: %v", err)
+	}
+	wtDir := firstWorktreeDir(t, filepath.Join(home, ".willow", "worktrees", "swpicker"))
+	if !strings.Contains(out, filepath.Join(".willow", "worktrees", "swpicker", wtDir)) {
+		t.Fatalf("sw output = %q, want selected worktree path", out)
+	}
+}
+
+func TestSwCommandPickerMultiRepoPrintsSelectedPath(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, "swone"); err != nil {
+		t.Fatalf("clone swone failed: %v", err)
+	}
+	if err := runApp("clone", origin, "swtwo"); err != nil {
+		t.Fatalf("clone swtwo failed: %v", err)
+	}
+	if err := os.Chdir(home); err != nil {
+		t.Fatalf("chdir home: %v", err)
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=swtwo/")
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sw")
+	})
+	if err != nil {
+		t.Fatalf("sw multi picker failed: %v", err)
+	}
+	if !strings.Contains(out, filepath.Join(".willow", "worktrees", "swtwo")) {
+		t.Fatalf("sw multi output = %q, want swtwo path", out)
+	}
+}
+
+func TestSwShellCompletionWithRepoFlagListsWorktrees(t *testing.T) {
+	origin := setupTestEnv(t)
+	if err := runApp("clone", origin, "swcomplete"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sw", "--repo", "swcomplete", "--generate-shell-completion")
+	})
+	if err != nil {
+		t.Fatalf("sw shell completion failed: %v", err)
+	}
+	if !strings.Contains(out, "master") && !strings.Contains(out, "main") {
+		t.Fatalf("completion output = %q, want worktree match name", out)
+	}
+}
+
+func TestSwShellCompletionCrossRepoFallbackListsAllWorktrees(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	if err := runApp("clone", origin, "swcompone"); err != nil {
+		t.Fatalf("clone swcompone failed: %v", err)
+	}
+	if err := runApp("clone", origin, "swcomptwo"); err != nil {
+		t.Fatalf("clone swcomptwo failed: %v", err)
+	}
+	if err := os.Chdir(home); err != nil {
+		t.Fatalf("chdir home: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("sw", "--generate-shell-completion")
+	})
+	if err != nil {
+		t.Fatalf("sw cross-repo shell completion failed: %v", err)
+	}
+	if !strings.Contains(out, "master") && !strings.Contains(out, "main") {
+		t.Fatalf("cross-repo completion output = %q, want worktree names", out)
+	}
+}
+
+func TestFzfPickWorktreeFilterModeReturnsSelectedPathAndHandlesNoMatch(t *testing.T) {
+	wts := []worktree.Worktree{
+		{Branch: "main", Path: "/wt/repo/main"},
+		{Branch: "feature", Path: "/wt/repo/feature"},
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=feature")
+
+	got, err := fzfPickWorktree(wts, "repo")
+	if err != nil {
+		t.Fatalf("fzfPickWorktree: %v", err)
+	}
+	if got != "/wt/repo/feature" {
+		t.Fatalf("fzfPickWorktree() = %q, want feature path", got)
+	}
+
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=missing")
+	got, err = fzfPickWorktree(wts, "repo")
+	if err != nil || got != "" {
+		t.Fatalf("fzfPickWorktree no match = %q, %v; want empty, nil", got, err)
+	}
+}
+
+func TestFzfPickWorktreesFilterModeReturnsSelectedPaths(t *testing.T) {
+	wts := []worktree.Worktree{
+		{Branch: "main", Path: "/wt/repo/main"},
+		{Branch: "feature", Path: "/wt/repo/feature"},
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=repo/")
+
+	got, err := fzfPickWorktrees(wts, "repo")
+	if err != nil {
+		t.Fatalf("fzfPickWorktrees: %v", err)
+	}
+	want := []string{"/wt/repo/feature", "/wt/repo/main"}
+	for _, path := range want {
+		if !containsString(got, path) {
+			t.Fatalf("fzfPickWorktrees = %v, want %s", got, path)
+		}
+	}
+}

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -41,6 +41,65 @@ func nilLoader(_ string) *stack.Stack {
 	return nil
 }
 
+func installFakeTmuxForCLI(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "tmux.log")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + shellQuote(logPath) + "\n" +
+		"case \"$1\" in\n" +
+		"  has-session) case \"$3\" in */existing|*/current|exists) exit 0 ;; *) exit 1 ;; esac ;;\n" +
+		"  list-panes) printf '%%1\\n%%2\\n' ;;\n" +
+		"  list-sessions) printf 'repo/existing\\nrepo/current\\n' ;;\n" +
+		"  display-message) printf 'repo/current\\n' ;;\n" +
+		"  capture-pane) printf 'pane output\\n' ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+	writeTestExecutable(t, binDir, "tmux", script)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func installFakeWillowForTmux(t *testing.T, wtRoot string) (string, string) {
+	t.Helper()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "willow.log")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" >> " + shellQuote(logPath) + "\n" +
+		"last=''\n" +
+		"repo='repo'\n" +
+		"prev=''\n" +
+		"for arg in \"$@\"; do\n" +
+		"  if [ \"$prev\" = '--repo' ]; then repo=\"$arg\"; fi\n" +
+		"  last=\"$arg\"\n" +
+		"  prev=\"$arg\"\n" +
+		"done\n" +
+		"case \"$1\" in\n" +
+		"  new|checkout) path=" + shellQuote(wtRoot) + "/\"$repo\"/\"$last\"; mkdir -p \"$path\"; printf '%s\\n' \"$path\" ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+	path := writeTestExecutable(t, binDir, "willow-test", script)
+	return path, logPath
+}
+
+func setupTmuxCommandHome(t *testing.T, repos ...string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if len(repos) == 0 {
+		repos = []string{"repo"}
+	}
+	for _, repo := range repos {
+		if err := os.MkdirAll(filepath.Join(home, ".willow", "repos", repo+".git"), 0o755); err != nil {
+			t.Fatalf("mkdir repo %s: %v", repo, err)
+		}
+		if err := os.MkdirAll(filepath.Join(home, ".willow", "worktrees", repo), 0o755); err != nil {
+			t.Fatalf("mkdir worktrees %s: %v", repo, err)
+		}
+	}
+	return home
+}
+
 // makeStack builds a Stack from parent→child pairs.
 func makeStack(pairs ...string) *stack.Stack {
 	s := &stack.Stack{Parents: make(map[string]string)}
@@ -524,6 +583,434 @@ func TestTmuxInstallCommand_PrintsConfig(t *testing.T) {
 	}
 }
 
+func TestLsShellCompletionListsRepos(t *testing.T) {
+	setupTmuxCommandHome(t, "alpha", "beta")
+	out, err := captureStdout(t, func() error {
+		return runApp("ls", "--generate-shell-completion")
+	})
+	if err != nil {
+		t.Fatalf("ls shell completion failed: %v", err)
+	}
+	if !strings.Contains(out, "alpha") || !strings.Contains(out, "beta") {
+		t.Fatalf("ls completion output = %q, want repo names", out)
+	}
+}
+
+func TestTmuxPickCommandReturnsWhenNoWorktrees(t *testing.T) {
+	setupTmuxCommandHome(t, "empty")
+	out, err := captureStderr(t, func() error {
+		return runApp("tmux", "pick", "--repo", "empty")
+	})
+	if err != nil {
+		t.Fatalf("tmux pick empty repo should not fail: %v", err)
+	}
+	if !strings.Contains(out, "No worktrees found.") {
+		t.Fatalf("tmux pick stderr = %q, want no-worktrees message", out)
+	}
+}
+
+func TestTmuxPreviewCommandPrintsMetadataForOfflineSession(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	installFakeTmuxForCLI(t)
+	if err := runApp("clone", origin, "tmuxpreview"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	wtDir := firstWorktreeDir(t, filepath.Join(home, ".willow", "worktrees", "tmuxpreview"))
+	wtPath := filepath.Join(home, ".willow", "worktrees", "tmuxpreview", wtDir)
+	line := tmux.FormatPickerLines([]tmux.PickerItem{
+		{RepoName: "tmuxpreview", Branch: wtDir, WtDirName: wtDir, WtPath: wtPath},
+	})[0]
+
+	out, err := captureStdout(t, func() error {
+		return runApp("tmux", "preview", line)
+	})
+	if err != nil {
+		t.Fatalf("tmux preview failed: %v", err)
+	}
+	for _, want := range []string{"tmuxpreview/" + wtDir, "Branch:", "Session 'tmuxpreview/" + wtDir + "' is offline"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("preview output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestTmuxPickSwitchCreatesAndSwitchesSession(t *testing.T) {
+	setupTmuxCommandHome(t, "repo")
+	logPath := installFakeTmuxForCLI(t)
+	t.Setenv("TMUX", "/tmp/tmux.sock")
+
+	items := []tmux.PickerItem{
+		{RepoName: "repo", Branch: "feature", WtDirName: "feature", WtPath: "/work/repo/feature"},
+	}
+	selection := tmux.FormatPickerLines(items)[0]
+
+	if err := tmuxPickSwitch(selection, items); err != nil {
+		t.Fatalf("tmuxPickSwitch: %v", err)
+	}
+
+	logText := readTestFile(t, logPath)
+	for _, want := range []string{
+		"has-session -t repo/feature",
+		"new-session -d -s repo/feature -c /work/repo/feature",
+		"switch-client -t repo/feature",
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("tmux log missing %q:\n%s", want, logText)
+		}
+	}
+	if err := tmuxPickSwitch(selection, nil); err == nil || !strings.Contains(err.Error(), "worktree not found") {
+		t.Fatalf("missing item error = %v, want worktree not found", err)
+	}
+}
+
+func TestTmuxPickerCreateActionsRunWillowAndEnsureSession(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	tmuxLog := installFakeTmuxForCLI(t)
+	self, willowLog := installFakeWillowForTmux(t, filepath.Join(home, ".willow", "worktrees"))
+	t.Setenv("TMUX", "/tmp/tmux.sock")
+
+	baseItem := tmux.PickerItem{
+		RepoName:  "repo",
+		Branch:    "main",
+		Head:      "abcdef1234567890",
+		WtDirName: "main",
+		WtPath:    filepath.Join(home, ".willow", "worktrees", "repo", "main"),
+	}
+	detachedItem := tmux.PickerItem{
+		RepoName:  "repo",
+		Branch:    worktree.DetachedBranch,
+		Head:      "feedface12345678",
+		Detached:  true,
+		WtDirName: "scratch",
+		WtPath:    filepath.Join(home, ".willow", "worktrees", "repo", "scratch"),
+	}
+	items := []tmux.PickerItem{baseItem, detachedItem}
+	lines := tmux.FormatPickerLines(items)
+
+	if err := tmuxPickNew(self, "feature-new", "repo", "", items); err != nil {
+		t.Fatalf("tmuxPickNew: %v", err)
+	}
+	if err := tmuxPickDetached(self, "scratch-copy", lines[0], "", "", items); err != nil {
+		t.Fatalf("tmuxPickDetached: %v", err)
+	}
+	if err := tmuxPickPromote(self, "feature-promoted", lines[1], items); err != nil {
+		t.Fatalf("tmuxPickPromote: %v", err)
+	}
+	if err := tmuxPickSync(self, "repo", "", items, "feature-new"); err != nil {
+		t.Fatalf("tmuxPickSync: %v", err)
+	}
+
+	willowText := readTestFile(t, willowLog)
+	for _, want := range []string{
+		"new --cd --repo repo -- feature-new",
+		"new --detach --cd --repo repo --ref abcdef1234567890 -- scratch-copy",
+		"promote --repo repo scratch feature-promoted",
+		"sync --repo repo feature-new",
+	} {
+		if !strings.Contains(willowText, want) {
+			t.Fatalf("willow log missing %q:\n%s", want, willowText)
+		}
+	}
+
+	tmuxText := readTestFile(t, tmuxLog)
+	for _, want := range []string{
+		"new-session -d -s repo/feature-new",
+		"new-session -d -s repo/scratch-copy",
+		"switch-client -t repo/scratch",
+	} {
+		if !strings.Contains(tmuxText, want) {
+			t.Fatalf("tmux log missing %q:\n%s", want, tmuxText)
+		}
+	}
+}
+
+func TestTmuxPickerActionValidationErrors(t *testing.T) {
+	setupTmuxCommandHome(t, "repo")
+	self, _ := installFakeWillowForTmux(t, filepath.Join(t.TempDir(), "worktrees"))
+	item := tmux.PickerItem{RepoName: "repo", Branch: "main", WtDirName: "main", WtPath: "/work/repo/main"}
+	selection := tmux.FormatPickerLines([]tmux.PickerItem{item})[0]
+
+	if err := tmuxPickNew(self, "", "repo", "", nil); err == nil || !strings.Contains(err.Error(), "enter a branch name") {
+		t.Fatalf("tmuxPickNew empty query error = %v", err)
+	}
+	if err := tmuxPickDetached(self, "", selection, "repo", "", []tmux.PickerItem{item}); err == nil || !strings.Contains(err.Error(), "detached worktree name") {
+		t.Fatalf("tmuxPickDetached empty query error = %v", err)
+	}
+	if err := tmuxPickPromote(self, "feature", selection, []tmux.PickerItem{item}); err == nil || !strings.Contains(err.Error(), "already on branch") {
+		t.Fatalf("tmuxPickPromote branch error = %v", err)
+	}
+	if err := tmuxPickDispatch(self, "", "repo", "", nil); err == nil || !strings.Contains(err.Error(), "type a prompt first") {
+		t.Fatalf("tmuxPickDispatch empty prompt error = %v", err)
+	}
+	if err := tmuxPickNewWithBase(self, "", "repo", "", nil); err == nil || !strings.Contains(err.Error(), "enter a branch name") {
+		t.Fatalf("tmuxPickNewWithBase empty prompt error = %v", err)
+	}
+}
+
+func TestTmuxPickExistingUsesCachedBranchesAndSelectedQuery(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	installFakeTmuxForCLI(t)
+	self, willowLog := installFakeWillowForTmux(t, filepath.Join(home, ".willow", "worktrees"))
+	if err := saveExistingBranchCache("repo", []string{"main", "remote-only"}); err != nil {
+		t.Fatalf("save cache: %v", err)
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=remote-only")
+
+	items := []tmux.PickerItem{{RepoName: "repo", Branch: "main", WtDirName: "main", WtPath: filepath.Join(home, ".willow", "worktrees", "repo", "main")}}
+	if err := tmuxPickExisting(self, "repo", "", items, "remote"); err != nil {
+		t.Fatalf("tmuxPickExisting: %v", err)
+	}
+
+	willowText := readTestFile(t, willowLog)
+	if !strings.Contains(willowText, "new -e --cd --repo repo -- remote-only") {
+		t.Fatalf("willow log missing checkout of cached branch:\n%s", willowText)
+	}
+}
+
+func TestTmuxPickNewWithBaseUsesSelectedWorktreeBranch(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	installFakeTmuxForCLI(t)
+	self, willowLog := installFakeWillowForTmux(t, filepath.Join(home, ".willow", "worktrees"))
+
+	if err := runApp("clone", origin, "tmuxbase"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "tmuxbase")
+	entries, err := os.ReadDir(worktreeDir)
+	if err != nil {
+		t.Fatalf("read worktrees dir: %v", err)
+	}
+	if err := os.Chdir(filepath.Join(worktreeDir, entries[0].Name())); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	if err := runApp("new", "feature-base", "--no-fetch"); err != nil {
+		t.Fatalf("new feature-base failed: %v", err)
+	}
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=feature-base")
+
+	if err := tmuxPickNewWithBase(self, "feature-child", "tmuxbase", "", nil); err != nil {
+		t.Fatalf("tmuxPickNewWithBase: %v", err)
+	}
+
+	willowText := readTestFile(t, willowLog)
+	if !strings.Contains(willowText, "new --base feature-base --cd --repo tmuxbase -- feature-child") {
+		t.Fatalf("willow log missing base new:\n%s", willowText)
+	}
+}
+
+func TestTmuxPickPRChecksOutSelectedBranch(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	installFakeTmuxForCLI(t)
+	self, willowLog := installFakeWillowForTmux(t, filepath.Join(home, ".willow", "worktrees"))
+	binDir := t.TempDir()
+	writeTestExecutable(t, binDir, "gh", "#!/bin/sh\nprintf '#42  Fix picker  (raj)  [feature-pr]\\n'\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=feature-pr")
+
+	if err := tmuxPickPR(self, "repo", "", nil); err != nil {
+		t.Fatalf("tmuxPickPR: %v", err)
+	}
+	willowText := readTestFile(t, willowLog)
+	if !strings.Contains(willowText, "checkout --cd --repo repo -- feature-pr") {
+		t.Fatalf("willow log missing PR checkout:\n%s", willowText)
+	}
+}
+
+func TestTmuxPickPRReportsMissingCLIAndNoOpenPRs(t *testing.T) {
+	setupTmuxCommandHome(t, "repo")
+	t.Setenv("PATH", t.TempDir())
+	if err := tmuxPickPR("willow", "repo", "", nil); err == nil || !strings.Contains(err.Error(), "gh CLI is required") {
+		t.Fatalf("tmuxPickPR missing gh error = %v", err)
+	}
+
+	binDir := t.TempDir()
+	writeTestExecutable(t, binDir, "gh", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir)
+	if err := tmuxPickPR("willow", "repo", "", nil); err == nil || !strings.Contains(err.Error(), "no open PRs found") {
+		t.Fatalf("tmuxPickPR empty list error = %v", err)
+	}
+}
+
+func TestTmuxSwCommandSwitchesToWorktreeSession(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	tmuxLog := installFakeTmuxForCLI(t)
+	t.Setenv("TMUX", "/tmp/tmux.sock")
+	wtPath := filepath.Join(home, ".willow", "worktrees", "repo", "feature")
+
+	if err := runApp("tmux", "sw", wtPath); err != nil {
+		t.Fatalf("tmux sw failed: %v", err)
+	}
+	tmuxText := readTestFile(t, tmuxLog)
+	for _, want := range []string{
+		"has-session -t repo/feature",
+		"new-session -d -s repo/feature",
+		"switch-client -t repo/feature",
+	} {
+		if !strings.Contains(tmuxText, want) {
+			t.Fatalf("tmux log missing %q:\n%s", want, tmuxText)
+		}
+	}
+}
+
+func TestTmuxPickDispatchWritesPromptAndStartsClaude(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	tmuxLog := installFakeTmuxForCLI(t)
+	self, willowLog := installFakeWillowForTmux(t, filepath.Join(home, ".willow", "worktrees"))
+	t.Setenv("TMUX", "/tmp/tmux.sock")
+
+	if err := tmuxPickDispatch(self, "Fix a gnarly bug", "repo", "", nil); err != nil {
+		t.Fatalf("tmuxPickDispatch: %v", err)
+	}
+
+	willowText := readTestFile(t, willowLog)
+	if !strings.Contains(willowText, "new --cd --repo repo -- dispatch--fix-a-gnarly-bug") {
+		t.Fatalf("willow log missing dispatch new:\n%s", willowText)
+	}
+	promptPath := filepath.Join(home, ".willow", "prompts", "repo", "dispatch--fix-a-gnarly-bug.prompt")
+	if got := strings.TrimSpace(readTestFile(t, promptPath)); got != "Fix a gnarly bug" {
+		t.Fatalf("prompt file = %q, want original prompt", got)
+	}
+	tmuxText := readTestFile(t, tmuxLog)
+	for _, want := range []string{
+		"new-session -d -s repo/dispatch--fix-a-gnarly-bug",
+		"send-keys -t repo/dispatch--fix-a-gnarly-bug",
+		"claude \"$(cat",
+	} {
+		if !strings.Contains(tmuxText, want) {
+			t.Fatalf("tmux log missing %q:\n%s", want, tmuxText)
+		}
+	}
+}
+
+func TestTmuxPickDeleteKillsSessionAndRunsWillowRm(t *testing.T) {
+	setupTmuxCommandHome(t, "repo")
+	tmuxLog := installFakeTmuxForCLI(t)
+	self, willowLog := installFakeWillowForTmux(t, filepath.Join(t.TempDir(), "worktrees"))
+
+	item := tmux.PickerItem{RepoName: "repo", Branch: "existing", WtDirName: "existing", WtPath: "/work/repo/existing"}
+	selection := tmux.FormatPickerLines([]tmux.PickerItem{item})[0]
+	if err := tmuxPickDelete(self, selection, []tmux.PickerItem{item}); err != nil {
+		t.Fatalf("tmuxPickDelete: %v", err)
+	}
+
+	if tmuxText := readTestFile(t, tmuxLog); !strings.Contains(tmuxText, "kill-session -t repo/existing") {
+		t.Fatalf("tmux log missing kill-session:\n%s", tmuxText)
+	}
+	if willowText := readTestFile(t, willowLog); !strings.Contains(willowText, "rm existing --force --repo repo") {
+		t.Fatalf("willow log missing rm:\n%s", willowText)
+	}
+}
+
+func TestTmuxPickDeleteMergedReportsNoCandidates(t *testing.T) {
+	self, _ := installFakeWillowForTmux(t, filepath.Join(t.TempDir(), "worktrees"))
+	if err := tmuxPickDeleteMerged(self, "", nil); err == nil || !strings.Contains(err.Error(), "no merged worktrees") {
+		t.Fatalf("tmuxPickDeleteMerged empty error = %v", err)
+	}
+	items := []tmux.PickerItem{{RepoName: "repo", Branch: "merged", WtDirName: "merged", Merged: true}}
+	if err := tmuxPickDeleteMerged(self, "repo/merged", items); err == nil || !strings.Contains(err.Error(), "current session skipped") {
+		t.Fatalf("tmuxPickDeleteMerged current-only error = %v", err)
+	}
+}
+
+func TestTmuxPickDeleteMergedConfirmsAndDeletesSafeCandidates(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+	installFakeTmuxForCLI(t)
+	self, willowLog := installFakeWillowForTmux(t, filepath.Join(home, ".willow", "worktrees"))
+
+	if err := runApp("clone", origin, "mergeddelete"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	worktreeRoot := filepath.Join(home, ".willow", "worktrees", "mergeddelete")
+	baseDir := filepath.Join(worktreeRoot, firstWorktreeDir(t, worktreeRoot))
+	if err := os.Chdir(baseDir); err != nil {
+		t.Fatalf("chdir base: %v", err)
+	}
+	if err := runApp("new", "safe-merged", "--no-fetch"); err != nil {
+		t.Fatalf("new safe-merged failed: %v", err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdin: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		_ = r.Close()
+	})
+	if _, err := w.WriteString("y\n"); err != nil {
+		t.Fatalf("write confirmation: %v", err)
+	}
+	_ = w.Close()
+
+	item := tmux.PickerItem{
+		RepoName:  "mergeddelete",
+		Branch:    "safe-merged",
+		WtDirName: "safe-merged",
+		WtPath:    filepath.Join(worktreeRoot, "safe-merged"),
+		Merged:    true,
+	}
+	if err := tmuxPickDeleteMerged(self, "", []tmux.PickerItem{item}); err != nil {
+		t.Fatalf("tmuxPickDeleteMerged: %v", err)
+	}
+	os.Stdin = origStdin
+
+	if willowText := readTestFile(t, willowLog); !strings.Contains(willowText, "rm safe-merged --force --repo mergeddelete") {
+		t.Fatalf("willow log missing merged delete rm:\n%s", willowText)
+	}
+}
+
+func TestResolveRepoSingleAndNoRepos(t *testing.T) {
+	setupTmuxCommandHome(t, "solo")
+	if got, err := resolveRepo("", "", nil); err != nil || got != "solo" {
+		t.Fatalf("resolveRepo single = %q, %v; want solo, nil", got, err)
+	}
+	if got, err := resolveRepo("explicit", "", nil); err != nil || got != "explicit" {
+		t.Fatalf("resolveRepo explicit = %q, %v; want explicit, nil", got, err)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if _, err := resolveRepo("", "", nil); err == nil || !strings.Contains(err.Error(), "no repos found") {
+		t.Fatalf("resolveRepo no repos error = %v, want no repos found", err)
+	}
+}
+
+func TestResolveRepoOrdersCurrentAndActiveRepos(t *testing.T) {
+	setupTmuxCommandHome(t, "alpha", "beta", "gamma")
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=gamma")
+	items := []tmux.PickerItem{{RepoName: "gamma", Status: claude.StatusBusy}}
+
+	if got, err := resolveRepo("", "beta/current", items); err != nil || got != "gamma" {
+		t.Fatalf("resolveRepo multi = %q, %v; want gamma, nil", got, err)
+	}
+}
+
+func TestReadTrimmedStdinLine(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		_ = r.Close()
+	})
+	if _, err := w.WriteString("  y  \n"); err != nil {
+		t.Fatalf("write pipe: %v", err)
+	}
+	_ = w.Close()
+
+	if got := readTrimmedStdinLine(); got != "y" {
+		t.Fatalf("readTrimmedStdinLine() = %q, want y", got)
+	}
+}
+
 func TestTmuxExistingBranchesCommand_ListsAvailableRemoteBranches(t *testing.T) {
 	origin := setupTestEnv(t)
 	home, _ := os.UserHomeDir()
@@ -624,6 +1111,27 @@ func TestTmuxStatusBarCommand_CountsWorktreesAndAgents(t *testing.T) {
 	if !strings.Contains(out, " 1") {
 		t.Fatalf("expected one active agent in status bar, got %q", out)
 	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func firstWorktreeDir(t *testing.T, worktreeRoot string) string {
+	t.Helper()
+	entries, err := os.ReadDir(worktreeRoot)
+	if err != nil {
+		t.Fatalf("read worktree root: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("no worktree dirs in %s", worktreeRoot)
+	}
+	return entries[0].Name()
 }
 
 func assertBranches(t *testing.T, got, want []string) {

--- a/internal/fzf/fzf_pos_test.go
+++ b/internal/fzf/fzf_pos_test.go
@@ -253,3 +253,30 @@ func TestRunFzfWithLibReturnsParseError(t *testing.T) {
 		t.Fatalf("error = %v, want fzf parse context", err)
 	}
 }
+
+func TestRunFzfWithLibFilterMode(t *testing.T) {
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=two")
+
+	results, code, err := runFzfWithLib([]string{"one", "two"}, []string{"--no-multi"}, defaults())
+	if err != nil {
+		t.Fatalf("runFzfWithLib filter mode error = %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("runFzfWithLib filter mode code = %d, want 0", code)
+	}
+	if !reflect.DeepEqual(results, []string{"two"}) {
+		t.Fatalf("runFzfWithLib filter mode results = %v, want [two]", results)
+	}
+}
+
+func TestRunExpectFilterModeReportsFilterOutput(t *testing.T) {
+	t.Setenv("FZF_DEFAULT_OPTS", "--filter=two")
+
+	result, err := RunExpect([]string{"one", "two"}, WithPrintQuery(), WithExpectKeys("ctrl-n"))
+	if err != nil {
+		t.Fatalf("RunExpect filter mode error = %v", err)
+	}
+	if result == nil || result.Query != "two" || result.Key != "two" || result.Selection != "" {
+		t.Fatalf("RunExpect filter mode = %+v, want query and filter output", result)
+	}
+}

--- a/internal/gh/pr_test.go
+++ b/internal/gh/pr_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -253,6 +254,122 @@ func TestSelectMatchingPR(t *testing.T) {
 	}
 	if got := selectMatchingPR(prs, ""); got != nil {
 		t.Fatalf("selectMatchingPR() with ambiguous empty head = %+v, want nil", got)
+	}
+}
+
+func TestFindOpenPRRunsGHAndSelectsMatchingHead(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "gh.log")
+	ghPath := filepath.Join(binDir, "gh")
+	script := `#!/bin/sh
+set -eu
+printf 'cwd=%s\n' "$PWD" >> "` + logPath + `"
+printf 'args=%s\n' "$*" >> "` + logPath + `"
+/bin/cat <<'JSON'
+[
+  {
+    "number": 42,
+    "title": "Feature",
+    "headRefName": "feature-a",
+    "headRefOid": "sha-match",
+    "baseRefName": "main",
+    "state": "OPEN",
+    "reviewDecision": "APPROVED",
+    "mergeable": "MERGEABLE",
+    "additions": 4,
+    "deletions": 2,
+    "url": "https://github.com/org/repo/pull/42",
+    "statusCheckRollup": []
+  },
+  {
+    "number": 43,
+    "title": "Other",
+    "headRefName": "feature-a",
+    "headRefOid": "sha-other",
+    "baseRefName": "main",
+    "state": "OPEN",
+    "reviewDecision": "",
+    "mergeable": "UNKNOWN",
+    "additions": 1,
+    "deletions": 1,
+    "url": "https://github.com/org/repo/pull/43",
+    "statusCheckRollup": []
+  }
+]
+JSON
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	dir := t.TempDir()
+	got, err := FindOpenPR(dir, "feature-a", "sha-match")
+	if err != nil {
+		t.Fatalf("FindOpenPR() error = %v", err)
+	}
+	if got == nil || got.Number != 42 || got.HeadRefOID != "sha-match" {
+		t.Fatalf("FindOpenPR() = %+v, want PR #42", got)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read gh log: %v", err)
+	}
+	wantArgs := "args=pr list --head feature-a --state open --json " + prJSONFields + " --limit 20\n"
+	if !strings.HasSuffix(string(logData), "\n"+wantArgs) {
+		t.Fatalf("unexpected gh invocation:\n%s", logData)
+	}
+}
+
+func TestFindOpenPRReturnsCommandOutputOnFailure(t *testing.T) {
+	binDir := t.TempDir()
+	ghPath := filepath.Join(binDir, "gh")
+	script := "#!/bin/sh\nprintf 'no auth\\n' >&2\nexit 7\n"
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	got, err := FindOpenPR(t.TempDir(), "feature-a", "")
+	if err == nil || got != nil {
+		t.Fatalf("FindOpenPR failure = %+v, %v; want nil error", got, err)
+	}
+	if err.Error() != "gh pr list failed: no auth" {
+		t.Fatalf("FindOpenPR error = %v, want gh output", err)
+	}
+}
+
+func TestCreatePRRunsGHAndReturnsURL(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "gh.log")
+	ghPath := filepath.Join(binDir, "gh")
+	script := `#!/bin/sh
+set -eu
+printf 'cwd=%s\n' "$PWD" >> "` + logPath + `"
+printf 'args=%s\n' "$*" >> "` + logPath + `"
+printf 'https://github.com/org/repo/pull/99\n'
+`
+	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	dir := t.TempDir()
+	got, err := CreatePR(dir, "main", "feature-a", true)
+	if err != nil {
+		t.Fatalf("CreatePR() error = %v", err)
+	}
+	if got != "https://github.com/org/repo/pull/99" {
+		t.Fatalf("CreatePR() = %q, want PR URL", got)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read gh log: %v", err)
+	}
+	if !strings.HasSuffix(string(logData), "\nargs=pr create --fill --base main --head feature-a --draft\n") {
+		t.Fatalf("unexpected gh invocation:\n%s", logData)
 	}
 }
 

--- a/internal/stack/stack_test.go
+++ b/internal/stack/stack_test.go
@@ -227,3 +227,18 @@ func TestTreeLinesEmptyStack(t *testing.T) {
 		t.Fatalf("empty TreeLines() = %+v, want nil", got)
 	}
 }
+
+func TestHasDescendantIn(t *testing.T) {
+	s := &Stack{Parents: map[string]string{
+		"a": "main",
+		"b": "a",
+		"c": "b",
+		"x": "main",
+	}}
+	if !s.hasDescendantIn("a", map[string]bool{"c": true}) {
+		t.Fatal("a should report visible descendant c")
+	}
+	if s.hasDescendantIn("x", map[string]bool{"c": true}) {
+		t.Fatal("x should not report descendant c")
+	}
+}

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -1,11 +1,16 @@
 package tmux
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
 )
 
@@ -318,12 +323,136 @@ func TestFormatPickerLinesMultiRepoMergedUnreadAndSubSessions(t *testing.T) {
 	}
 }
 
+func TestBuildPickerItemsUsesRepoWorktreesAndStatuses(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bareDir := pickerTestBareRepo(t, home, "repo")
+	wtPath := filepath.Join(home, ".willow", "worktrees", "repo", "main")
+	if _, err := (&git.Git{Dir: bareDir}).Run("worktree", "add", wtPath, "main"); err != nil {
+		t.Fatalf("git worktree add: %v", err)
+	}
+	writePickerSessionStatus(t, "repo", "main", claude.StatusDone)
+
+	items, err := BuildPickerItemsWithOptions(contextBackground(), "repo", PickerBuildOptions{RefreshGitHubMerged: false})
+	if err != nil {
+		t.Fatalf("BuildPickerItems: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("BuildPickerItems returned %d items, want 1: %+v", len(items), items)
+	}
+	item := items[0]
+	resolvedWtPath, err := filepath.EvalSymlinks(wtPath)
+	if err != nil {
+		t.Fatalf("resolve worktree path: %v", err)
+	}
+	if item.RepoName != "repo" || item.Branch != "main" || item.WtPath != resolvedWtPath {
+		t.Fatalf("picker item = %+v, want repo/main at %s", item, wtPath)
+	}
+	if item.Status != claude.StatusDone || !item.Unread {
+		t.Fatalf("picker item status/unread = %s/%v, want DONE/unread", item.Status, item.Unread)
+	}
+}
+
+func TestBuildPickerItemsMissingRepoReturnsEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	items, err := BuildPickerItems(contextBackground(), "missing")
+	if err != nil {
+		t.Fatalf("BuildPickerItems missing repo error = %v, want nil", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("BuildPickerItems missing repo = %+v, want empty", items)
+	}
+}
+
+func TestDefaultPickerStackLoader(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bareDir := filepath.Join(home, ".willow", "repos", "repo.git")
+	if err := os.MkdirAll(bareDir, 0o755); err != nil {
+		t.Fatalf("mkdir bare dir: %v", err)
+	}
+	st := pickerStack("child", "main")
+	if err := st.Save(bareDir); err != nil {
+		t.Fatalf("save stack: %v", err)
+	}
+	got := defaultPickerStackLoader("repo")
+	if got == nil || got.Parent("child") != "main" {
+		t.Fatalf("defaultPickerStackLoader() = %+v, want child parent main", got)
+	}
+	if got := defaultPickerStackLoader("missing"); got != nil {
+		t.Fatalf("defaultPickerStackLoader missing = %+v, want nil", got)
+	}
+}
+
 func pickerStack(pairs ...string) *stack.Stack {
 	st := &stack.Stack{Parents: make(map[string]string)}
 	for i := 0; i+1 < len(pairs); i += 2 {
 		st.Parents[pairs[i]] = pairs[i+1]
 	}
 	return st
+}
+
+func pickerTestBareRepo(t *testing.T, home, repo string) string {
+	t.Helper()
+	bareDir := filepath.Join(home, ".willow", "repos", repo+".git")
+	if err := os.MkdirAll(filepath.Dir(bareDir), 0o755); err != nil {
+		t.Fatalf("mkdir repos dir: %v", err)
+	}
+	if _, err := (&git.Git{}).Run("init", "--bare", bareDir); err != nil {
+		t.Fatalf("git init --bare: %v", err)
+	}
+	seed := filepath.Join(home, "seed")
+	if _, err := (&git.Git{}).Run("clone", bareDir, seed); err != nil {
+		t.Fatalf("git clone seed: %v", err)
+	}
+	seedGit := &git.Git{Dir: seed}
+	if _, err := seedGit.Run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("git config email: %v", err)
+	}
+	if _, err := seedGit.Run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("git config name: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(seed, "README.md"), []byte("# repo\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	if _, err := seedGit.Run("add", "."); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if _, err := seedGit.Run("commit", "-m", "initial"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+	if _, err := seedGit.Run("branch", "-M", "main"); err != nil {
+		t.Fatalf("git branch main: %v", err)
+	}
+	if _, err := seedGit.Run("push", "origin", "main"); err != nil {
+		t.Fatalf("git push main: %v", err)
+	}
+	return bareDir
+}
+
+func writePickerSessionStatus(t *testing.T, repo, wt string, status claude.Status) {
+	t.Helper()
+	dir := filepath.Join(claude.StatusDir(), repo, wt)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir status dir: %v", err)
+	}
+	data, err := json.Marshal(claude.SessionStatus{
+		Status:    status,
+		SessionID: "session-1",
+		Timestamp: time.Now(),
+		Worktree:  wt,
+	})
+	if err != nil {
+		t.Fatalf("marshal status: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "session-1.json"), data, 0o644); err != nil {
+		t.Fatalf("write status: %v", err)
+	}
+}
+
+func contextBackground() context.Context {
+	return context.Background()
 }
 
 func pickerLoader(stacks map[string]*stack.Stack) pickerStackLoader {

--- a/internal/ui/ui_test.go
+++ b/internal/ui/ui_test.go
@@ -2,10 +2,12 @@ package ui
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBold(t *testing.T) {
@@ -190,5 +192,51 @@ func TestTerminalControlSequences(t *testing.T) {
 				t.Errorf("%s() should start with ESC", tt.name)
 			}
 		})
+	}
+}
+
+func TestSpinNoColorPrintsLabelAndReturnsError(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	origStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = w
+	t.Cleanup(func() { os.Stderr = origStderr })
+
+	wantErr := errors.New("boom")
+	u := &UI{}
+	gotErr := u.Spin("working", func() error { return wantErr })
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("Spin error = %v, want boom", gotErr)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close stderr: %v", err)
+	}
+	os.Stderr = origStderr
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if !strings.Contains(string(data), "working") {
+		t.Fatalf("Spin stderr = %q, want label", string(data))
+	}
+}
+
+func TestSpinnerStartStopWritesFrameAndClearsLine(t *testing.T) {
+	var buf bytes.Buffer
+	s := newSpinner(&UI{}, &buf, "loading")
+	s.start()
+	time.Sleep(125 * time.Millisecond)
+	s.stop()
+
+	out := buf.String()
+	if !strings.Contains(out, "loading") {
+		t.Fatalf("spinner output = %q, want label", out)
+	}
+	if !strings.Contains(out, "\r\033[K") {
+		t.Fatalf("spinner output = %q, want clear-line sequence", out)
 	}
 }


### PR DESCRIPTION
## Description of the change
Raises Willow Go coverage to 80.2% with focused behavior tests around CLI picker flows, tmux helpers, config/dispatch/doctor paths, fzf filter-mode behavior, GitHub PR helpers, stack visibility, and UI spinner behavior. This keeps the CI enforcement threshold at 70% while giving the suite a higher actual coverage baseline.

Codex-assisted test coverage work.

**Ticket:**

## Test plan
Unit and integration-style Go tests, plus coverage gate validation:
- `go test ./... -count=1 -v`
- `GO_COVERAGE_MIN=80.0 GO_COVERAGE_PROFILE=/tmp/willow-coverage-80.out scripts/check-go-coverage.sh`
- `GO_COVERAGE_MIN=70.0 GO_COVERAGE_PROFILE=/tmp/willow-coverage-ci.out scripts/check-go-coverage.sh`

## Loom or screenshots

## Considerations
CI coverage floor remains at 70%; this PR only raises actual Go coverage toward 80%.