### PR TITLE
:sparkles: feat[worktree]: add nameless detached worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This gives you:
 | `ww <cmd>` | Alias for `willow` |
 | `ww sw` | fzf worktree switcher (cd's into selection) |
 | `ww new <branch>` | Create worktree + cd into it (tmux-aware) |
-| `ww new <name> --detach` | Create a named detached worktree |
+| `ww new [name] --detach` | Create a detached worktree without a branch |
 | `ww promote [name] <branch>` | Promote a detached worktree to a branch |
 | `ww rename [worktree] <name>` | Rename a worktree, branch, status dir, and tmux session |
 | `ww checkout <branch>` | Smart checkout + cd (switch or create, tmux-aware) |
@@ -169,15 +169,16 @@ ww clone git@github.com:org/repo.git myrepo    # custom name
 ww clone git@github.com:org/repo.git --force    # re-clone from scratch
 ```
 
-### `ww new <branch> [flags]`
+### `ww new [branch] [flags]`
 
-Create a new worktree with a new branch, an existing branch, a named detached HEAD, or a GitHub PR.
+Create a new worktree with a new branch, an existing branch, a detached HEAD, or a GitHub PR.
 
 ```bash
 ww new feature/auth                    # create worktree
 ww new feature/auth -b develop         # fork from specific branch
 ww new -e existing-branch              # use existing branch
 ww new -e                              # pick from remote branches (fzf)
+ww new --detach                        # detached worktree named detached-<sha>
 ww new scratch-repro --detach          # named detached worktree at default base
 ww new v1-debug --detach --ref v1.2.3  # named detached worktree at a tag/commit
 ww new --pr 123                        # checkout PR #123
@@ -186,14 +187,14 @@ ww new feature/auth -r myrepo          # target a specific repo
 ww new feature/auth                    # auto-cd via shell integration (tmux-aware)
 ```
 
-From the tmux picker, `Ctrl-T` creates a named detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree to a branch, and `Ctrl-E` opens the existing-branch flow from cached refs first, then refreshes remote branches in the background so large repos feel instant to open.
+From the tmux picker, `Ctrl-T` creates a detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree to a branch, and `Ctrl-E` opens the existing-branch flow from cached refs first, then refreshes remote branches in the background so large repos feel instant to open.
 
 | Flag | Description |
 |------|-------------|
 | `-b, --base` | Base branch to fork from |
 | `-r, --repo` | Target repo by name |
 | `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) |
-| `--detach` | Create a named detached HEAD worktree |
+| `--detach` | Create a detached HEAD worktree; name is optional |
 | `--ref` | Commit, tag, or branch to check out in detached mode |
 | `--pr` | GitHub PR number or URL |
 | `--no-fetch` | Skip fetching from remote |
@@ -201,7 +202,7 @@ From the tmux picker, `Ctrl-T` creates a named detached worktree from the select
 
 ### `ww promote [worktree] <branch>`
 
-Promote a named detached worktree to a normal branch-backed worktree in place. The directory and tmux session name stay the same, so active panes and agent status do not move.
+Promote a detached worktree to a normal branch-backed worktree. Nameless detached worktrees use generated labels like `detached-a13f09c`; when promoted, Willow moves their directory, Claude status dir, and tmux session to the promoted branch identity. Explicitly named detached worktrees keep their directory and tmux session name unless you rename them.
 
 ```bash
 ww promote feature/auth                 # from inside a detached worktree
@@ -213,6 +214,7 @@ ww promote scratch-repro                # promote to branch scratch-repro
 |------|-------------|
 | `-r, --repo` | Target repo by name |
 | `-b, --base` | Record a stack parent for the promoted branch |
+| `--cd` | Print the final path (for scripting) |
 
 ### `ww rename [worktree] <name>` (alias: `mv`)
 

--- a/internal/cli/detached.go
+++ b/internal/cli/detached.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+
+	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/tmux"
+	"github.com/iamrajjoshi/willow/internal/worktree"
+)
+
+var generatedDetachedDirPattern = regexp.MustCompile(`^detached-[0-9a-f]{7}(-[0-9]+)?$`)
+
+func isGeneratedDetachedDirName(name string) bool {
+	return generatedDetachedDirPattern.MatchString(name)
+}
+
+func resolveDetachedCommit(repoGit *git.Git, ref string) (string, error) {
+	head, err := repoGit.Run("rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve detached commit for %s: %w", ref, err)
+	}
+	return head, nil
+}
+
+func generatedDetachedWorktreeDirName(repoName, head string) string {
+	base := "detached-" + worktree.ShortHead(head)
+	for i := 1; ; i++ {
+		candidate := base
+		if i > 1 {
+			candidate = fmt.Sprintf("%s-%d", base, i)
+		}
+		if detachedGeneratedNameAvailable(repoName, candidate) {
+			return candidate
+		}
+	}
+}
+
+func detachedGeneratedNameAvailable(repoName, dirName string) bool {
+	wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)
+	if pathExists(wtPath) {
+		return false
+	}
+	if pathExists(claude.StatusWorktreeDir(repoName, dirName)) {
+		return false
+	}
+	return !tmux.SessionExists(tmux.SessionNameForWorktree(repoName, dirName))
+}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -525,6 +525,56 @@ func TestNew_DetachedCreatesNamedWorktree(t *testing.T) {
 	}
 }
 
+func TestNew_DetachedCreatesGeneratedWorktree(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	mainDir := filepath.Join(worktreeDir, firstWorktreeDir(t, worktreeDir))
+	os.Chdir(mainDir)
+
+	head, err := (&git.Git{Dir: mainDir}).Run("rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	wantFirst := "detached-" + worktree.ShortHead(head)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("new", "--detach", "--ref", "HEAD", "--no-fetch", "--cd")
+	})
+	if err != nil {
+		t.Fatalf("new nameless --detach failed: %v", err)
+	}
+	firstPath := strings.TrimSpace(out)
+	if got := filepath.Base(firstPath); got != wantFirst {
+		t.Fatalf("generated dir = %q, want %q", got, wantFirst)
+	}
+
+	out, err = captureStdout(t, func() error {
+		return runApp("new", "--detach", "--ref", "HEAD", "--no-fetch", "--cd")
+	})
+	if err != nil {
+		t.Fatalf("second nameless --detach failed: %v", err)
+	}
+	secondPath := strings.TrimSpace(out)
+	if got := filepath.Base(secondPath); got != wantFirst+"-2" {
+		t.Fatalf("second generated dir = %q, want %q", got, wantFirst+"-2")
+	}
+
+	wtGit := &git.Git{Dir: firstPath}
+	branch, err := wtGit.Run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse detached HEAD: %v", err)
+	}
+	if branch != "HEAD" {
+		t.Fatalf("generated detached branch = %q, want HEAD", branch)
+	}
+}
+
 func TestPromote_DetachedWorktreeInPlace(t *testing.T) {
 	origin := setupTestEnv(t)
 	home, _ := os.UserHomeDir()
@@ -583,6 +633,81 @@ func TestPromote_DetachedWorktreeInPlace(t *testing.T) {
 		}
 	}
 	t.Fatalf("promoted worktree missing from git worktree list")
+}
+
+func TestPromote_GeneratedDetachedWorktreeMovesToBranchName(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "testrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "testrepo")
+	mainDir := filepath.Join(worktreeDir, firstWorktreeDir(t, worktreeDir))
+	os.Chdir(mainDir)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("new", "--detach", "--ref", "HEAD", "--no-fetch", "--cd")
+	})
+	if err != nil {
+		t.Fatalf("new nameless --detach failed: %v", err)
+	}
+	detachedDir := strings.TrimSpace(out)
+	oldDir := filepath.Base(detachedDir)
+	if !isGeneratedDetachedDirName(oldDir) {
+		t.Fatalf("generated dir = %q, want generated detached name", oldDir)
+	}
+
+	if err := runApp("promote", oldDir); err == nil || !strings.Contains(err.Error(), "branch name is required for generated detached worktree") {
+		t.Fatalf("promote generated without branch error = %v", err)
+	}
+
+	writeActiveSessionFile(t, "testrepo", oldDir, "s1", claude.StatusDone)
+	binDir := t.TempDir()
+	tmuxLog := filepath.Join(t.TempDir(), "tmux.log")
+	installFakeTmuxForRename(t, binDir, tmuxLog, "testrepo/"+oldDir, "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := os.Chdir(detachedDir); err != nil {
+		t.Fatalf("chdir detached: %v", err)
+	}
+	out, err = captureStdout(t, func() error {
+		return runApp("promote", "feature/generated", "--cd")
+	})
+	if err != nil {
+		t.Fatalf("promote generated failed: %v", err)
+	}
+
+	finalPath := strings.TrimSpace(out)
+	wantPath := filepath.Join(worktreeDir, "feature-generated")
+	if comparablePath(finalPath) != comparablePath(wantPath) {
+		t.Fatalf("promote --cd path = %q, want %q", finalPath, wantPath)
+	}
+	if _, err := os.Stat(detachedDir); !os.IsNotExist(err) {
+		t.Fatalf("old generated path should be gone, err=%v", err)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("promoted path missing: %v", err)
+	}
+
+	branch, err := (&git.Git{Dir: wantPath}).Run("rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse promoted branch: %v", err)
+	}
+	if branch != "feature/generated" {
+		t.Fatalf("branch = %q, want feature/generated", branch)
+	}
+
+	if _, err := os.Stat(claude.StatusWorktreeDir("testrepo", oldDir)); !os.IsNotExist(err) {
+		t.Fatalf("old status dir should be gone, err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(claude.StatusWorktreeDir("testrepo", "feature-generated"), "s1.json")); err != nil {
+		t.Fatalf("new status file missing: %v", err)
+	}
+	if !strings.Contains(readTestFile(t, tmuxLog), "rename-session|-t|testrepo/"+oldDir+"|testrepo/feature-generated") {
+		t.Fatalf("tmux rename not recorded:\n%s", readTestFile(t, tmuxLog))
+	}
 }
 
 func TestPromote_DetachedByNameFromAnotherWorktree(t *testing.T) {

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -143,7 +143,7 @@ func newCmd() *cli.Command {
 		Arguments: []cli.Argument{
 			&cli.StringArg{
 				Name:      "branch",
-				UsageText: "<branch>",
+				UsageText: "[branch]",
 			},
 		},
 		Flags: []cli.Flag{
@@ -165,7 +165,7 @@ func newCmd() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "detach",
 				Aliases: []string{"detached"},
-				Usage:   "Create a detached HEAD worktree named <branch>",
+				Usage:   "Create a detached HEAD worktree with an optional name",
 			},
 			&cli.StringFlag{
 				Name:  "ref",
@@ -232,18 +232,26 @@ func newCmd() *cli.Command {
 				if cmd.String("pr") != "" {
 					return errors.Userf("--detach cannot be used with --pr")
 				}
-				if branch == "" {
-					return errors.Userf("worktree name is required\n\nUsage: ww new <name> --detach [--ref <commit-ish>]")
-				}
 
-				name := branch
-				dirName, err := detachedWorktreeDirName(name)
-				if err != nil {
-					return err
-				}
 				ref, refLabel, err := resolveDetachedRef(ctx, tr, cmd, cfg, repoGit, u, cdOnly)
 				if err != nil {
 					return err
+				}
+
+				name := branch
+				var dirName string
+				if name == "" {
+					head, err := resolveDetachedCommit(repoGit, ref)
+					if err != nil {
+						return err
+					}
+					dirName = generatedDetachedWorktreeDirName(repoName, head)
+					name = dirName
+				} else {
+					dirName, err = detachedWorktreeDirName(name)
+					if err != nil {
+						return err
+					}
 				}
 
 				wtPath := filepath.Join(config.WorktreesDir(), repoName, dirName)

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -22,6 +22,19 @@ func TestDetachedWorktreeDirNameValidation(t *testing.T) {
 	}
 }
 
+func TestGeneratedDetachedDirNamePattern(t *testing.T) {
+	for _, name := range []string{"detached-abcdef1", "detached-0123abc-2", "detached-9999999-42"} {
+		if !isGeneratedDetachedDirName(name) {
+			t.Fatalf("isGeneratedDetachedDirName(%q) = false, want true", name)
+		}
+	}
+	for _, name := range []string{"scratch", "detached-abcdef", "detached-abcdef12", "detached-zzzzzzz", "detached-abcdef1-copy"} {
+		if isGeneratedDetachedDirName(name) {
+			t.Fatalf("isGeneratedDetachedDirName(%q) = true, want false", name)
+		}
+	}
+}
+
 func TestRunHooksRunsCommandsInDirectory(t *testing.T) {
 	dir := t.TempDir()
 	stdoutPath := filepath.Join(t.TempDir(), "stdout.log")

--- a/internal/cli/promote.go
+++ b/internal/cli/promote.go
@@ -3,14 +3,17 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/errors"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/log"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -41,6 +44,10 @@ func promoteCmd() *cli.Command {
 				Aliases: []string{"b"},
 				Usage:   "Record a stack parent for the promoted branch",
 			},
+			&cli.BoolFlag{
+				Name:  "cd",
+				Usage: "Print the final worktree path to stdout",
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			flags := parseFlags(cmd)
@@ -48,8 +55,12 @@ func promoteCmd() *cli.Command {
 			defer tr.Total()
 			g := flags.NewGit()
 			u := flags.NewUI()
+			cdOnly := cmd.Bool("cd")
+			if cdOnly {
+				u.Out = os.Stderr
+			}
 
-			target, branch := promotionArgs(g, cmd.StringArg("target"), cmd.StringArg("branch"))
+			target, branch, explicitBranch := promotionArgs(g, cmd.StringArg("target"), cmd.StringArg("branch"))
 			if branch == "" {
 				return errors.Userf("branch name is required\n\nUsage: ww promote [worktree] <branch>")
 			}
@@ -64,6 +75,10 @@ func promoteCmd() *cli.Command {
 			if !rwt.Worktree.Detached {
 				return errors.Userf("worktree %q is already on branch %q", rwt.Worktree.MatchName(), rwt.Worktree.Branch)
 			}
+			generatedDetached := isGeneratedDetachedDirName(rwt.Worktree.DirName())
+			if generatedDetached && !explicitBranch {
+				return errors.Userf("branch name is required for generated detached worktree %q\n\nUsage: ww promote %s <branch>", rwt.Worktree.MatchName(), rwt.Worktree.MatchName())
+			}
 
 			done = tr.StartCtx(ctx, "load config")
 			cfg := config.Load(rwt.Repo.BareDir)
@@ -76,6 +91,17 @@ func promoteCmd() *cli.Command {
 			repoGit := &git.Git{Dir: rwt.Repo.BareDir, Verbose: g.Verbose}
 			if repoGit.LocalBranchExists(branch) {
 				return errors.Userf("branch %q already exists", branch)
+			}
+
+			finalPath := rwt.Worktree.Path
+			oldDir := rwt.Worktree.DirName()
+			newDir := oldDir
+			if generatedDetached {
+				newDir = worktreeDirName(branch)
+				if err := checkGeneratedPromotionCollisions(rwt.Repo.Name, oldDir, newDir, finalPath, filepath.Join(filepath.Dir(finalPath), newDir)); err != nil {
+					return err
+				}
+				finalPath = filepath.Join(filepath.Dir(rwt.Worktree.Path), newDir)
 			}
 
 			done = tr.StartCtx(ctx, "git checkout branch")
@@ -93,6 +119,30 @@ func promoteCmd() *cli.Command {
 			}
 			done()
 
+			if generatedDetached && comparablePath(rwt.Worktree.Path) != comparablePath(finalPath) {
+				done = tr.StartCtx(ctx, "git worktree move promoted")
+				if _, err := repoGit.Run("worktree", "move", rwt.Worktree.Path, finalPath); err != nil {
+					return fmt.Errorf("failed to move promoted worktree: %w", err)
+				}
+				done()
+
+				done = tr.StartCtx(ctx, "move promoted status dir")
+				if err := claude.MoveStatusDir(rwt.Repo.Name, oldDir, newDir); err != nil {
+					return fmt.Errorf("failed to move status directory: %w", err)
+				}
+				done()
+
+				done = tr.StartCtx(ctx, "rename promoted tmux session")
+				oldSession := tmux.SessionNameForWorktree(rwt.Repo.Name, oldDir)
+				newSession := tmux.SessionNameForWorktree(rwt.Repo.Name, newDir)
+				if tmux.SessionExists(oldSession) {
+					if err := tmux.RenameSession(oldSession, newSession); err != nil {
+						return fmt.Errorf("failed to rename tmux session: %w", err)
+					}
+				}
+				done()
+			}
+
 			baseBranch := cmd.String("base")
 			if baseBranch != "" {
 				done = tr.StartCtx(ctx, "record stack parent")
@@ -106,15 +156,23 @@ func promoteCmd() *cli.Command {
 
 			meta := map[string]string{
 				"from": rwt.Worktree.MatchName(),
-				"path": rwt.Worktree.Path,
+				"path": finalPath,
+			}
+			if finalPath != rwt.Worktree.Path {
+				meta["old_path"] = rwt.Worktree.Path
 			}
 			if baseBranch != "" {
 				meta["base"] = baseBranch
 			}
 			_ = log.Append(log.Event{Action: "promote", Repo: rwt.Repo.Name, Branch: branch, Metadata: meta})
 
+			if cdOnly {
+				fmt.Println(finalPath)
+				return nil
+			}
+
 			u.Success(fmt.Sprintf("Promoted %s to branch %s", u.Bold(rwt.Worktree.MatchName()), u.Bold(branch)))
-			u.Info(fmt.Sprintf("  path:   %s", u.Dim(rwt.Worktree.Path)))
+			u.Info(fmt.Sprintf("  path:   %s", u.Dim(finalPath)))
 			if baseBranch != "" {
 				u.Info(fmt.Sprintf("  base:   %s", u.Dim(baseBranch)))
 			}
@@ -123,17 +181,37 @@ func promoteCmd() *cli.Command {
 	}
 }
 
-func promotionArgs(g *git.Git, first, second string) (target, branch string) {
+func promotionArgs(g *git.Git, first, second string) (target, branch string, explicitBranch bool) {
 	if second != "" {
-		return first, second
+		return first, second, true
 	}
 	if first == "" {
-		return "", ""
+		return "", "", false
 	}
 	if current, err := currentManagedWorktree(g); err == nil && current.Worktree.Detached {
-		return "", first
+		return "", first, true
 	}
-	return first, first
+	return first, first, false
+}
+
+func checkGeneratedPromotionCollisions(repoName, oldDir, newDir, oldPath, newPath string) error {
+	if oldDir == newDir {
+		return nil
+	}
+	if comparablePath(oldPath) != comparablePath(newPath) && pathExists(newPath) {
+		return errors.Userf("worktree path already exists: %s", newPath)
+	}
+	oldStatus := claude.StatusWorktreeDir(repoName, oldDir)
+	newStatus := claude.StatusWorktreeDir(repoName, newDir)
+	if comparablePath(oldStatus) != comparablePath(newStatus) && pathExists(newStatus) {
+		return errors.Userf("status directory already exists: %s", newStatus)
+	}
+	oldSession := tmux.SessionNameForWorktree(repoName, oldDir)
+	newSession := tmux.SessionNameForWorktree(repoName, newDir)
+	if oldSession != newSession && tmux.SessionExists(newSession) {
+		return errors.Userf("tmux session already exists: %s", newSession)
+	}
+	return nil
 }
 
 func resolvePromotionTarget(g *git.Git, repoFlag, target string) (*repoWorktree, error) {

--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -77,6 +77,18 @@ ww() {
     fi
     return
   fi
+  if [ "$1" = "promote" ]; then
+    local dir
+    dir="$(command willow promote "${@:2}" --cd)" || return
+    if [ -n "$TMUX" ] && [ -n "$dir" ]; then
+      command willow tmux sw "$dir"
+      return
+    fi
+    if [ -n "$dir" ]; then
+      cd "$dir" || return
+    fi
+    return
+  fi
   if [ "$1" = "rm" ]; then
     local cwd="$PWD"
     command willow "$@"
@@ -201,6 +213,18 @@ ww() {
     fi
     return
   fi
+  if [ "$1" = "promote" ]; then
+    local dir
+    dir="$(command willow promote "${@:2}" --cd)" || return
+    if [ -n "$TMUX" ] && [ -n "$dir" ]; then
+      command willow tmux sw "$dir"
+      return
+    fi
+    if [ -n "$dir" ]; then
+      cd "$dir" || return
+    fi
+    return
+  fi
   if [ "$1" = "rm" ]; then
     local cwd="$PWD"
     command willow "$@"
@@ -309,6 +333,18 @@ function ww
   if test (count $argv) -gt 0; and test "$argv[1]" = "rename" -o "$argv[1]" = "mv"
     set -l dir (command willow rename $argv[2..] --cd)
     or return
+    if test -n "$dir"
+      cd $dir
+    end
+    return
+  end
+  if test (count $argv) -gt 0; and test "$argv[1]" = "promote"
+    set -l dir (command willow promote $argv[2..] --cd)
+    or return
+    if test -n "$TMUX"; and test -n "$dir"
+      command willow tmux sw "$dir"
+      return
+    end
     if test -n "$dir"
       cd $dir
     end

--- a/internal/cli/shellinit_test.go
+++ b/internal/cli/shellinit_test.go
@@ -114,6 +114,38 @@ func TestShellInitScriptsHandleRenameCd(t *testing.T) {
 	}
 }
 
+func TestShellInitScriptsHandlePromoteCd(t *testing.T) {
+	tests := []struct {
+		name   string
+		script string
+		want   string
+	}{
+		{
+			name:   "bash",
+			script: renderBashInitScript(),
+			want:   `command willow promote "${@:2}" --cd`,
+		},
+		{
+			name:   "zsh",
+			script: renderZshInitScript(),
+			want:   `command willow promote "${@:2}" --cd`,
+		},
+		{
+			name:   "fish",
+			script: renderFishInitScript(),
+			want:   `command willow promote $argv[2..] --cd`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.Contains(tt.script, tt.want) {
+				t.Fatalf("script missing promote cd hook %q:\n%s", tt.want, tt.script)
+			}
+		})
+	}
+}
+
 func TestDetectShell(t *testing.T) {
 	tests := []struct {
 		shell string

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -316,9 +316,6 @@ func tmuxPickNew(self, query, repoFilter, sessionName string, items []tmux.Picke
 
 func tmuxPickDetached(self, query, selection, repoFilter, sessionName string, items []tmux.PickerItem) error {
 	name := strings.TrimSpace(query)
-	if name == "" {
-		return errors.Userf("enter a detached worktree name first")
-	}
 
 	repo := ""
 	ref := ""
@@ -356,7 +353,10 @@ func tmuxPickDetachedArgs(name, repo, ref string) []string {
 	if ref != "" {
 		args = append(args, "--ref", ref)
 	}
-	return append(args, "--", name)
+	if name != "" {
+		args = append(args, "--", name)
+	}
+	return args
 }
 
 func tmuxPickPromote(self, query, selection string, items []tmux.PickerItem) error {
@@ -371,21 +371,29 @@ func tmuxPickPromote(self, query, selection string, items []tmux.PickerItem) err
 
 	branch := strings.TrimSpace(query)
 	if branch == "" {
+		if isGeneratedDetachedDirName(item.WtDirName) {
+			return errors.Userf("enter a branch name to promote generated detached worktree %s", item.WtDirName)
+		}
 		branch = item.WtDirName
 	}
 
 	cmd := exec.Command(self, tmuxPickPromoteArgs(*item, branch)...)
-	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	out, err := cmd.Output()
+	if err != nil {
 		return fmt.Errorf("failed to promote detached worktree: %w", err)
 	}
 
-	return ensureTmuxSession(item.RepoName, item.WtDirName, item.WtPath)
+	wtPath = strings.TrimSpace(string(out))
+	if wtPath == "" {
+		return fmt.Errorf("no path returned from willow promote")
+	}
+
+	return ensureTmuxSessionFromPath(wtPath)
 }
 
 func tmuxPickPromoteArgs(item tmux.PickerItem, branch string) []string {
-	return []string{"promote", "--repo", item.RepoName, item.WtDirName, branch}
+	return []string{"promote", "--cd", "--repo", item.RepoName, item.WtDirName, branch}
 }
 
 func tmuxPickNewWithBase(self, query, repoFilter, sessionName string, items []tmux.PickerItem) error {

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -75,7 +75,7 @@ func installFakeWillowForTmux(t *testing.T, wtRoot string) (string, string) {
 		"  prev=\"$arg\"\n" +
 		"done\n" +
 		"case \"$1\" in\n" +
-		"  new|checkout) path=" + shellQuote(wtRoot) + "/\"$repo\"/\"$last\"; mkdir -p \"$path\"; printf '%s\\n' \"$path\" ;;\n" +
+		"  new|checkout|promote) path=" + shellQuote(wtRoot) + "/\"$repo\"/\"$last\"; mkdir -p \"$path\"; printf '%s\\n' \"$path\" ;;\n" +
 		"  *) exit 0 ;;\n" +
 		"esac\n"
 	path := writeTestExecutable(t, binDir, "willow-test", script)
@@ -306,6 +306,12 @@ func TestTmuxPickDetachedArgs(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args without ref = %v, want %v", got, want)
 	}
+
+	got = tmuxPickDetachedArgs("", "repo", "abcdef123")
+	want = []string{"new", "--detach", "--cd", "--repo", "repo", "--ref", "abcdef123"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("args without name = %v, want %v", got, want)
+	}
 }
 
 func TestTmuxPickPromoteArgsUsesDetachedName(t *testing.T) {
@@ -317,7 +323,7 @@ func TestTmuxPickPromoteArgsUsesDetachedName(t *testing.T) {
 	}
 
 	got := tmuxPickPromoteArgs(item, "feature/repro")
-	want := []string{"promote", "--repo", "repo", "scratch-repro", "feature/repro"}
+	want := []string{"promote", "--cd", "--repo", "repo", "scratch-repro", "feature/repro"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("args = %v, want %v", got, want)
 	}
@@ -705,7 +711,7 @@ func TestTmuxPickerCreateActionsRunWillowAndEnsureSession(t *testing.T) {
 	for _, want := range []string{
 		"new --cd --repo repo -- feature-new",
 		"new --detach --cd --repo repo --ref abcdef1234567890 -- scratch-copy",
-		"promote --repo repo scratch feature-promoted",
+		"promote --cd --repo repo scratch feature-promoted",
 		"sync --repo repo feature-new",
 	} {
 		if !strings.Contains(willowText, want) {
@@ -717,7 +723,8 @@ func TestTmuxPickerCreateActionsRunWillowAndEnsureSession(t *testing.T) {
 	for _, want := range []string{
 		"new-session -d -s repo/feature-new",
 		"new-session -d -s repo/scratch-copy",
-		"switch-client -t repo/scratch",
+		"new-session -d -s repo/feature-promoted",
+		"switch-client -t repo/feature-promoted",
 	} {
 		if !strings.Contains(tmuxText, want) {
 			t.Fatalf("tmux log missing %q:\n%s", want, tmuxText)
@@ -734,11 +741,13 @@ func TestTmuxPickerActionValidationErrors(t *testing.T) {
 	if err := tmuxPickNew(self, "", "repo", "", nil); err == nil || !strings.Contains(err.Error(), "enter a branch name") {
 		t.Fatalf("tmuxPickNew empty query error = %v", err)
 	}
-	if err := tmuxPickDetached(self, "", selection, "repo", "", []tmux.PickerItem{item}); err == nil || !strings.Contains(err.Error(), "detached worktree name") {
-		t.Fatalf("tmuxPickDetached empty query error = %v", err)
-	}
 	if err := tmuxPickPromote(self, "feature", selection, []tmux.PickerItem{item}); err == nil || !strings.Contains(err.Error(), "already on branch") {
 		t.Fatalf("tmuxPickPromote branch error = %v", err)
+	}
+	generated := tmux.PickerItem{RepoName: "repo", Branch: worktree.DetachedBranch, Detached: true, WtDirName: "detached-abcdef1", WtPath: "/work/repo/detached-abcdef1"}
+	generatedSelection := tmux.FormatPickerLines([]tmux.PickerItem{generated})[0]
+	if err := tmuxPickPromote(self, "", generatedSelection, []tmux.PickerItem{generated}); err == nil || !strings.Contains(err.Error(), "enter a branch name") {
+		t.Fatalf("tmuxPickPromote generated empty query error = %v", err)
 	}
 	if err := tmuxPickDispatch(self, "", "repo", "", nil); err == nil || !strings.Contains(err.Error(), "type a prompt first") {
 		t.Fatalf("tmuxPickDispatch empty prompt error = %v", err)

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -45,15 +45,16 @@ eval "$(willow shell-init --tab-title)"  # with tab titles
 
 ## Worktrees
 
-### `ww new <branch> [flags]`
+### `ww new [branch] [flags]`
 
-Create a new worktree with a new branch, an existing branch, a named detached HEAD, or a GitHub PR.
+Create a new worktree with a new branch, an existing branch, a detached HEAD, or a GitHub PR.
 
 ```bash
 ww new feature/auth                    # create worktree
 ww new feature/auth -b develop         # fork from specific branch
 ww new -e existing-branch              # use existing branch
 ww new -e                              # pick from remote branches (fzf)
+ww new --detach                        # detached worktree named detached-<sha>
 ww new scratch-repro --detach          # named detached worktree at default base
 ww new v1-debug --detach --ref v1.2.3  # named detached worktree at a tag/commit
 ww new --pr 123                        # checkout PR #123
@@ -67,7 +68,7 @@ ww new feature/auth                    # auto-cd via shell integration (tmux-awa
 | `-b, --base` | Base branch to fork from | Config default / auto-detected |
 | `-r, --repo` | Target repo by name | Auto-detected from cwd |
 | `-e, --existing` | Use an existing branch (or pick from fzf if no branch given) | `false` |
-| `--detach` | Create a named detached HEAD worktree | `false` |
+| `--detach` | Create a detached HEAD worktree; name is optional | `false` |
 | `--ref` | Commit, tag, or branch to check out in detached mode | Base branch |
 | `--pr` | GitHub PR number or URL | |
 | `--no-fetch` | Skip fetching from remote | `false` |
@@ -75,9 +76,10 @@ ww new feature/auth                    # auto-cd via shell integration (tmux-awa
 
 #### Detached worktrees
 
-Use `--detach` when you want a named scratch worktree without creating a branch yet. The name becomes the worktree directory and the tmux session identity. Later, promote it in place with `ww promote`; the directory and tmux session stay stable.
+Use `--detach` when you want a scratch worktree without creating a branch yet. Without a name, Willow creates a generated label like `detached-a13f09c`; with a name, that name becomes the worktree directory and tmux session identity.
 
 ```bash
+ww new --detach
 ww new scratch-repro --detach
 ww new old-release --detach --ref v1.2.3
 ww promote scratch-repro feature/repro-fix
@@ -102,9 +104,11 @@ This also works from the tmux picker — press `Ctrl-P` for a dedicated PR picke
 
 ### `ww promote [worktree] <branch>`
 
-Promote a named detached worktree to a normal branch-backed worktree in place.
+Promote a detached worktree to a normal branch-backed worktree.
 
-If you run it from inside a detached worktree, pass only the branch name. From another directory, pass the detached worktree name first. With one argument outside a detached worktree, Willow uses that name for both the worktree and branch.
+If you run it from inside a detached worktree, pass only the branch name. From another directory, pass the detached worktree name first. With one argument outside an explicitly named detached worktree, Willow uses that name for both the worktree and branch.
+
+Generated detached worktrees like `detached-a13f09c` require an explicit branch name. When promoted, Willow moves their directory, Claude status dir, and tmux session to the promoted branch identity. Explicitly named detached worktrees keep their existing directory and tmux session name.
 
 ```bash
 ww promote feature/auth                 # from inside a detached worktree
@@ -116,6 +120,7 @@ ww promote scratch-repro                # promote to branch scratch-repro
 |------|-------------|---------|
 | `-r, --repo` | Target repo by name | Auto-detected from cwd / all repos |
 | `-b, --base` | Record a stack parent for the promoted branch | |
+| `--cd` | Print the final worktree path | `false` |
 
 ### `ww rename [worktree] <name>` (alias: `mv`)
 
@@ -599,7 +604,7 @@ ww tmux install           # print tmux.conf lines to add
 ```
 
 Setup: `ww tmux install` prints the config to add to `~/.tmux.conf`, including a `prefix + w` keybinding for the picker popup.
-Inside the picker, `Ctrl-T` creates a named detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree, `Ctrl-D` deletes the selected worktree, and `Ctrl-X` bulk-deletes safe merged worktrees currently shown, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
+Inside the picker, `Ctrl-T` creates a detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree, `Ctrl-D` deletes the selected worktree, and `Ctrl-X` bulk-deletes safe merged worktrees currently shown, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
 
 ### Aliases
 

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -32,7 +32,7 @@ The right panel shows a live preview of the tmux pane content (Claude Code outpu
 |-----|--------|
 | `Enter` | Switch to worktree (creates tmux session if needed) |
 | `Ctrl-N` | Create new worktree from typed query (also accepts PR URLs) |
-| `Ctrl-T` | Create a named detached worktree from the selected HEAD |
+| `Ctrl-T` | Create a detached worktree from the selected HEAD |
 | `Ctrl-U` | Promote the selected detached worktree to a branch |
 | `Ctrl-B` | Create new worktree stacked on a base branch (opens branch picker) |
 | `Ctrl-E` | Browse existing remote branches and create a worktree |
@@ -55,9 +55,9 @@ You can also paste a PR URL into the query field and press `Ctrl-N` for quick on
 
 ### Detached worktrees
 
-Type a name in the query field and press `Ctrl-T` to create a detached worktree from the currently selected row's HEAD. The name becomes both the worktree directory and tmux session name, so it is easy to come back to even before you create a branch.
+Press `Ctrl-T` to create a detached worktree from the currently selected row's HEAD. If the query field is empty, Willow generates a label like `detached-a13f09c`; if the query has text, that text becomes the worktree directory and tmux session name.
 
-To keep the work, select the detached worktree and press `Ctrl-U`. If the query field has text, Willow uses it as the new branch name; otherwise it reuses the detached worktree name. Promotion happens in place, so the tmux session and agent status stay attached to the same directory.
+To keep the work, select the detached worktree, type a branch name, and press `Ctrl-U`. Explicitly named detached worktrees can still promote with an empty query and reuse their detached name. Generated detached worktrees require a branch name; promotion moves their tmux session and agent status to the promoted branch identity.
 
 ### Renaming worktrees
 


### PR DESCRIPTION
## Description of the change
Allow detached worktrees to be created without a user-provided name. Willow now generates disposable `detached-<sha>` labels, keeps explicitly named detached worktrees compatible, and moves generated detached worktrees to the promoted branch identity when they are promoted.

**Ticket:** 

## Test plan
Go unit/integration tests and website production build.

## Loom or screenshots

## Considerations
Generated detached labels matching `detached-<sha>` are treated as disposable infrastructure names during promotion.
