### PR TITLE
:bug: fix[tmux]: keep picker errors visible

### DIFF
--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -207,7 +207,13 @@ func tmuxPickCmd() *cli.Command {
 					if result.Selection == "" {
 						return nil
 					}
-					return tmuxPickSwitch(result.Selection, items)
+					if err := tmuxPickSwitch(result.Selection, items); err != nil {
+						fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+						fmt.Fprintf(os.Stderr, "\nPress Enter to return to picker...\n")
+						fmt.Fscanln(os.Stdin)
+						continue
+					}
+					return nil
 				}
 			}
 		},

--- a/internal/fzf/fzf.go
+++ b/internal/fzf/fzf.go
@@ -193,7 +193,7 @@ func RunExpect(lines []string, opts ...Option) (*ExpectResult, error) {
 	}
 
 	results, code, err := runFzf(lines, []string{"--no-multi"}, cfg)
-	if code == fzflib.ExitInterrupt {
+	if code == fzflib.ExitInterrupt || code == fzflib.ExitNoMatch {
 		return nil, nil
 	}
 	if err != nil {

--- a/internal/fzf/fzf_pos_test.go
+++ b/internal/fzf/fzf_pos_test.go
@@ -190,6 +190,14 @@ func TestRunExpectHandlesCancelAndErrors(t *testing.T) {
 	}
 
 	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return nil, fzflib.ExitNoMatch, nil
+	}
+	got, err = RunExpect([]string{"one"})
+	if err != nil || got != nil {
+		t.Fatalf("RunExpect no match = %+v, %v; want nil, nil", got, err)
+	}
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
 		return nil, 0, errors.New("boom")
 	}
 	got, err = RunExpect([]string{"one"})


### PR DESCRIPTION
## Description of the change
Keep tmux picker failures visible inside the popup instead of letting tmux collapse them into a generic returned-1 wrapper message. Also treats fzf no-match exits as cancel for expect-mode pickers, matching the other fzf helpers.

**Ticket:**

## Test plan
go test ./... -count=1

## Loom or screenshots

## Considerations