### PR TITLE
:bug: fix[tmux]: allow new branch from no-match query

### DIFF
--- a/internal/fzf/fzf.go
+++ b/internal/fzf/fzf.go
@@ -193,7 +193,7 @@ func RunExpect(lines []string, opts ...Option) (*ExpectResult, error) {
 	}
 
 	results, code, err := runFzf(lines, []string{"--no-multi"}, cfg)
-	if code == fzflib.ExitInterrupt || code == fzflib.ExitNoMatch {
+	if code == fzflib.ExitInterrupt {
 		return nil, nil
 	}
 	if err != nil {
@@ -213,6 +213,9 @@ func RunExpect(lines []string, opts ...Option) (*ExpectResult, error) {
 	}
 	if len(results) > 2 {
 		result.Selection = results[2]
+	}
+	if code == fzflib.ExitNoMatch && result.Key == "" && result.Selection == "" {
+		return nil, nil
 	}
 	return result, nil
 }

--- a/internal/fzf/fzf_pos_test.go
+++ b/internal/fzf/fzf_pos_test.go
@@ -198,6 +198,14 @@ func TestRunExpectHandlesCancelAndErrors(t *testing.T) {
 	}
 
 	runFzf = func([]string, []string, *config) ([]string, int, error) {
+		return []string{"new-branch", "ctrl-n"}, fzflib.ExitNoMatch, nil
+	}
+	got, err = RunExpect([]string{"one"}, WithPrintQuery(), WithExpectKeys("ctrl-n"))
+	if err != nil || got == nil || got.Query != "new-branch" || got.Key != "ctrl-n" || got.Selection != "" {
+		t.Fatalf("RunExpect no match with expect key = %+v, %v; want query/key result", got, err)
+	}
+
+	runFzf = func([]string, []string, *config) ([]string, int, error) {
 		return nil, 0, errors.New("boom")
 	}
 	got, err = RunExpect([]string{"one"})


### PR DESCRIPTION
## Description of the change
Preserve fzf expect-key output when a typed query has no matching picker row, so Ctrl-N can still create a new branch from the typed name. A no-match exit only behaves like cancel when there is no expected key or selected row.

**Ticket:**

## Test plan
go test ./... -count=1

## Loom or screenshots

## Considerations
Follow-up patch for v2.5.2 regression.