### PR TITLE
:sparkles: feat[tmux]: add compact picker preview toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Config merges two tiers (local wins):
     "autoSetupRemote": true
   },
   "tmux": {
+    "switcherPreview": true,
     "layout": ["split-window -h", "select-layout even-horizontal"],
     "panes": [
       { "command": "cd website" },
@@ -536,6 +537,8 @@ Config merges two tiers (local wins):
   "telemetry": true
 }
 ```
+
+Set `"tmux": {"switcherPreview": false}` to hide the right-side live preview in the tmux picker and give the fzf list the full popup width. Leaving it unset keeps the preview enabled. When preview is disabled, `ww tmux install` prints a compact `70%` by `70%` popup binding instead of the default `90%` by `80%` binding.
 
 ## Telemetry
 

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -1429,14 +1429,22 @@ func tmuxInstallCmd() *cli.Command {
 			if err != nil {
 				self = "willow"
 			}
+			popupWidth, popupHeight := tmuxPickerPopupSize(config.Load(""))
 
 			fmt.Println("# Willow tmux integration")
 			fmt.Println("# Add these lines to your tmux.conf:")
 			fmt.Println()
-			fmt.Printf("bind w run-shell -b 'tmux display-popup -E -w 90%% -h 80%% \"%s tmux pick --session #S\"'\n", self)
+			fmt.Printf("bind w run-shell -b 'tmux display-popup -E -w %s -h %s \"%s tmux pick --session #S\"'\n", popupWidth, popupHeight, self)
 			fmt.Printf("set -g status-right '#(%s tmux status-bar) %%l:%%M %%a'\n", self)
 			fmt.Println("set -g status-interval 3")
 			return nil
 		},
 	}
+}
+
+func tmuxPickerPopupSize(cfg *config.Config) (string, string) {
+	if cfg.Tmux.SwitcherPreview != nil && !*cfg.Tmux.SwitcherPreview {
+		return "70%", "70%"
+	}
+	return "90%", "80%"
 }

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -576,16 +576,33 @@ func TestBuildStackChain(t *testing.T) {
 }
 
 func TestTmuxInstallCommand_PrintsConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
 	out, err := captureStdout(t, func() error {
 		return runApp("tmux", "install")
 	})
 	if err != nil {
 		t.Fatalf("tmux install failed: %v", err)
 	}
-	for _, want := range []string{"bind w run-shell", "tmux pick", "status-right", "status-interval 3"} {
+	for _, want := range []string{"bind w run-shell", "-w 90% -h 80%", "tmux pick", "status-right", "status-interval 3"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("tmux install output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestTmuxInstallCommand_UsesCompactPopupWithoutPreview(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	writeGlobalConfigFile(t, `{"tmux":{"switcherPreview":false}}`)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("tmux", "install")
+	})
+	if err != nil {
+		t.Fatalf("tmux install failed: %v", err)
+	}
+	if !strings.Contains(out, "-w 70% -h 70%") {
+		t.Fatalf("tmux install output = %q, want compact popup size", out)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,9 @@ func DefaultConfig() *Config {
 			Fetch:           BoolPtr(true),
 			AutoSetupRemote: BoolPtr(true),
 		},
+		Tmux: TmuxConfig{
+			SwitcherPreview: BoolPtr(true),
+		},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -25,6 +25,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Defaults.AutoSetupRemote == nil || !*cfg.Defaults.AutoSetupRemote {
 		t.Error("Defaults.AutoSetupRemote should be true")
 	}
+	if cfg.Tmux.SwitcherPreview == nil || !*cfg.Tmux.SwitcherPreview {
+		t.Error("Tmux.SwitcherPreview should be true")
+	}
 }
 
 func TestMerge_StringOverride(t *testing.T) {
@@ -99,6 +102,27 @@ func TestMerge_BoolPointerOverride(t *testing.T) {
 	}
 	if *base.Defaults.AutoSetupRemote != true {
 		t.Error("Defaults.AutoSetupRemote should remain true (not overridden)")
+	}
+}
+
+func TestMerge_TmuxSwitcherPreviewFalseOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"tmux": {"switcherPreview": false}}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	overlay, err := LoadFile(path)
+	if err != nil {
+		t.Fatalf("LoadFile() error: %v", err)
+	}
+	base := DefaultConfig()
+	base.Tmux.SwitcherPreview = BoolPtr(true)
+
+	merge(base, overlay)
+
+	if base.Tmux.SwitcherPreview == nil || *base.Tmux.SwitcherPreview {
+		t.Fatalf("Tmux.SwitcherPreview = %v, want explicit false", base.Tmux.SwitcherPreview)
 	}
 }
 

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -605,6 +605,7 @@ ww tmux install           # print tmux.conf lines to add
 
 Setup: `ww tmux install` prints the config to add to `~/.tmux.conf`, including a `prefix + w` keybinding for the picker popup.
 Inside the picker, `Ctrl-T` creates a detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree, `Ctrl-D` deletes the selected worktree, and `Ctrl-X` bulk-deletes safe merged worktrees currently shown, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
+By default, the picker shows a right-side live preview. Set `"tmux": {"switcherPreview": false}` in config to hide it, use the full popup for fzf, and make `ww tmux install` emit a compact `70%` by `70%` popup binding.
 
 ### Aliases
 

--- a/website/src/app/(docs)/configuration/page.mdx
+++ b/website/src/app/(docs)/configuration/page.mdx
@@ -42,6 +42,7 @@ The local config lives inside the bare repo directory, so it's private to your m
   "tmux": {
     "notification": true,
     "notifyCommand": "afplay /System/Library/Sounds/Glass.aiff",
+    "switcherPreview": true,
     "layout": ["split-window -h"],
     "panes": [
       {},
@@ -66,6 +67,7 @@ The local config lives inside the bare repo directory, so it's private to your m
 | `defaults.autoSetupRemote` | `boolean` | Auto-configure remote tracking for new branches |
 | `tmux.notification` | `boolean` | Play sound on BUSY→DONE transitions (default: `true`) |
 | `tmux.notifyCommand` | `string` | Command to run for notifications (default: `afplay Glass.aiff`) |
+| `tmux.switcherPreview` | `boolean` | Show the right-side live preview in the tmux picker. Set to `false` for an fzf-only picker and compact `ww tmux install` popup binding (default: `true`) |
 | `tmux.layout` | `string[]` | Raw tmux subcommands to run after session creation (e.g. `["split-window -h", "select-layout even-horizontal"]`) |
 | `tmux.panes` | `PaneConfig[]` | Per-pane commands, indexed by pane order. Pane 0 is the initial pane, pane 1 is the first split, etc. Each entry: `{ "command": "..." }` |
 | `telemetry` | `boolean` | Enable/disable anonymous error telemetry. Willow is opt-in by default. Also controllable via `WILLOW_TELEMETRY=off` env var |

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -20,11 +20,18 @@ set -g status-interval 3
 
 Then reload: `tmux source ~/.tmux.conf`
 
+If `"tmux": {"switcherPreview": false}` is set before running `ww tmux install`, Willow prints a compact `70%` by `70%` popup binding instead:
+
+```bash
+bind w run-shell -b 'tmux display-popup -E -w 70% -h 70% "/path/to/willow tmux pick --session #S"'
+```
+
 ## Picker (`prefix + w`)
 
 Press `prefix + w` to open the worktree picker in a popup.
 
 The right panel shows a live preview of the tmux pane content (Claude Code output).
+Set `"tmux": {"switcherPreview": false}` in config to hide that panel, use the full popup for the fzf picker, and make `ww tmux install` emit the smaller popup binding.
 
 ### Keybindings
 


### PR DESCRIPTION
## Description of the change
Adds a configurable tmux picker preview toggle and makes the generated tmux popup binding compact when the preview is disabled. This lets fzf-only picker users avoid the oversized preview-oriented popup while preserving the existing preview default.

**Ticket:**

## Test plan
Go unit tests, docs production build, config smoke check, tmux binding smoke check.

## Loom or screenshots

## Considerations
`tmux.switcherPreview` remains enabled by default for backward compatibility. Existing tmux.conf bindings need to be regenerated or manually resized to pick up the compact popup.
