### PR TITLE
:wrench: chore[tmux]: rename stack picker label

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ ww new feature/auth -r myrepo          # target a specific repo
 ww new feature/auth                    # auto-cd via shell integration (tmux-aware)
 ```
 
-From the tmux picker, `Ctrl-T` creates a detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree to a branch, and `Ctrl-E` opens the existing-branch flow from cached refs first, then refreshes remote branches in the background so large repos feel instant to open.
+From the tmux picker, `Ctrl-T` creates a detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree to a branch, `Ctrl-B` creates a stacked worktree from a picked base branch, and `Ctrl-E` opens the existing-branch flow from cached refs first, then refreshes remote branches in the background so large repos feel instant to open.
 
 | Flag | Description |
 |------|-------------|

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -24,7 +24,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-const tmuxPickerHeader = "^N new ^T detach ^U promote ^B rebase ^E existing ^P PR ^G dispatch ^S sync ^D rm ^X prune"
+const tmuxPickerHeader = "^N new ^T detach ^U promote ^B stack ^E existing ^P PR ^G dispatch ^S sync ^D rm ^X prune"
 
 func tmuxCmd() *cli.Command {
 	return &cli.Command{

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -288,7 +288,7 @@ func TestMoveToFrontWithStack_DetachedOnlyMovesSelectedWorktree(t *testing.T) {
 }
 
 func TestTmuxPickerHeaderActions(t *testing.T) {
-	want := "^N new ^T detach ^U promote ^B rebase ^E existing ^P PR ^G dispatch ^S sync ^D rm ^X prune"
+	want := "^N new ^T detach ^U promote ^B stack ^E existing ^P PR ^G dispatch ^S sync ^D rm ^X prune"
 	if tmuxPickerHeader != want {
 		t.Fatalf("tmux picker header = %q, want %q", tmuxPickerHeader, want)
 	}

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -89,7 +89,7 @@ ww promote scratch-repro feature/repro-fix
 
 Running `ww new -e` without a branch name opens an fzf picker showing all remote branches that don't already have worktrees. Select one to create a worktree for it.
 
-From the tmux picker, `Ctrl-E` opens the same existing-branch flow from cached refs first, then refreshes remote branches in the background so large repos feel instant to open.
+From the tmux picker, `Ctrl-B` creates a stacked worktree from a picked base branch, and `Ctrl-E` opens the same existing-branch flow from cached refs first, then refreshes remote branches in the background so large repos feel instant to open.
 
 #### GitHub PR support
 


### PR DESCRIPTION
## Description of the change
Rename the tmux picker Ctrl-B label from rebase to stack so the header matches the stacked-worktree flow it actually triggers. Update README and website command docs to mention Ctrl-B alongside the existing branch flow.

**Asana ticket:**

## Test plan
Go unit and full regression test suites.

## Loom or screenshots

## Considerations
No keybinding or behavior changes; this is a user-facing label/docs update.