### PR TITLE
:wrench: chore[release]: write brew formula under Formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ brews:
       owner: iamrajjoshi
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
     homepage: https://github.com/iamrajjoshi/willow
     description: A simple, opinionated git worktree manager
     license: MIT


### PR DESCRIPTION
## Description of the change
Configure GoReleaser to publish the Willow Homebrew formula into the tap's `Formula/` directory instead of creating a root-level `willow.rb`. This matches the formula path Homebrew reads for `iamrajjoshi/tap/willow`.

**Asana ticket:**

## Test plan
GoReleaser config validation.

## Loom or screenshots

## Considerations
Also removed the stray root-level `willow.rb` from `iamrajjoshi/homebrew-tap` in a separate tap commit.