### PR TITLE
:bug: fix[shell]: bypass ww function in tab completion

### DIFF
--- a/internal/cli/shellinit.go
+++ b/internal/cli/shellinit.go
@@ -132,12 +132,14 @@ __willow_bash_autocomplete() {
       __willow_init_completion -n "=:" || return
     fi
     words=("${words[@]:0:$cword}")
+    # Always invoke the willow binary directly so the ww shell function
+    # (which captures stdout to cd into a worktree) doesn't swallow completions.
+    local args=("${words[@]:1}")
     if [[ "$cur" == "-"* ]]; then
-      requestComp="${words[*]} ${cur} --generate-shell-completion"
+      opts=$(command willow "${args[@]}" "${cur}" --generate-shell-completion 2>/dev/null)
     else
-      requestComp="${words[*]} --generate-shell-completion"
+      opts=$(command willow "${args[@]}" --generate-shell-completion 2>/dev/null)
     fi
-    opts=$(eval "${requestComp}" 2>/dev/null)
     COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
     return 0
   fi
@@ -256,10 +258,14 @@ _willow() {
   local -a opts
   local current
   current=${words[-1]}
+  # Always invoke the willow binary directly so the ww shell function
+  # (which captures stdout to cd into a worktree) doesn't swallow completions.
+  local -a args
+  args=("${words[2,-2]}")
   if [[ "$current" == "-"* ]]; then
-    opts=("${(@f)$(${words[@]:0:#words[@]-1} ${current} --generate-shell-completion)}")
+    opts=("${(@f)$(command willow "${args[@]}" "${current}" --generate-shell-completion)}")
   else
-    opts=("${(@f)$(${words[@]:0:#words[@]-1} --generate-shell-completion)}")
+    opts=("${(@f)$(command willow "${args[@]}" --generate-shell-completion)}")
   fi
 
   if [[ "${opts[1]}" != "" ]]; then
@@ -384,10 +390,13 @@ end
 function __fish_willow_complete
   set -l tokens (commandline -opc)
   set -l cur (commandline -ct)
+  # Always invoke the willow binary directly so the ww shell function
+  # (which captures stdout to cd into a worktree) doesn't swallow completions.
+  set -l args command willow $tokens[2..]
   if string match -q -- '-*' $cur
-    $tokens $cur --generate-shell-completion 2>/dev/null
+    $args $cur --generate-shell-completion 2>/dev/null
   else
-    $tokens --generate-shell-completion 2>/dev/null
+    $args --generate-shell-completion 2>/dev/null
   end
 end
 

--- a/internal/cli/shellinit_test.go
+++ b/internal/cli/shellinit_test.go
@@ -146,6 +146,73 @@ func TestShellInitScriptsHandlePromoteCd(t *testing.T) {
 	}
 }
 
+func TestShellInitCompletionsBypassWwFunction(t *testing.T) {
+	// The ww shell function captures stdout from `ww sw` / `ww co` / etc. and
+	// passes it to `cd`. If the completion script invokes the function (rather
+	// than the binary), the completion list is fed to `cd` instead of the
+	// completion engine. Make sure each shell's completion section calls the
+	// willow binary directly — checking only the completion block, since the
+	// rest of the script also contains `command willow` for unrelated reasons.
+	tests := []struct {
+		name    string
+		script  string
+		marker  string // line that begins the completion section
+		want    []string
+		notWant []string
+	}{
+		{
+			name:   "bash",
+			script: renderBashInitScript(),
+			marker: "__willow_bash_autocomplete()",
+			want:   []string{"command willow"},
+			notWant: []string{
+				`requestComp="${words[*]} ${cur} --generate-shell-completion"`,
+				`requestComp="${words[*]} --generate-shell-completion"`,
+			},
+		},
+		{
+			name:   "zsh",
+			script: renderZshInitScript(),
+			marker: "_willow()",
+			want:   []string{"command willow"},
+			notWant: []string{
+				`${words[@]:0:#words[@]-1} ${current} --generate-shell-completion`,
+				`${words[@]:0:#words[@]-1} --generate-shell-completion`,
+			},
+		},
+		{
+			name:   "fish",
+			script: renderFishInitScript(),
+			marker: "function __fish_willow_complete",
+			want:   []string{"command willow"},
+			notWant: []string{
+				`$tokens $cur --generate-shell-completion`,
+				`$tokens --generate-shell-completion 2>/dev/null`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := strings.Index(tt.script, tt.marker)
+			if idx < 0 {
+				t.Fatalf("completion marker %q not found in script", tt.marker)
+			}
+			section := tt.script[idx:]
+			for _, w := range tt.want {
+				if !strings.Contains(section, w) {
+					t.Fatalf("completion section must contain %q:\n%s", w, section)
+				}
+			}
+			for _, bad := range tt.notWant {
+				if strings.Contains(section, bad) {
+					t.Fatalf("completion section must not invoke the ww shell function via %q:\n%s", bad, section)
+				}
+			}
+		})
+	}
+}
+
 func TestDetectShell(t *testing.T) {
 	tests := []struct {
 		shell string


### PR DESCRIPTION
## Description of the change

The `ww` shell function shipped by `willow shell-init` captures stdout from `ww sw`, `ww co`, `ww new`, etc. and feeds it to `cd`. The completion functions re-invoke `${words[@]}` (which begins with `ww`), so when the user types `ww sw <TAB>` the completion call recurses through the shell function and the worktree list is passed to `cd` instead of the completion engine.

Repro:
```
$ ww sw <TAB>
ww:cd:8: no such file or directory: gk--ai-scoring
gk-ai-scoring
master
```

Fix: in all three shells (bash, zsh, fish), invoke `command willow` with the subcommand args directly, bypassing the `ww` function wrapper.

## Test plan

- Added `TestShellInitCompletionsBypassWwFunction` covering bash/zsh/fish — checks the completion section of each script calls the binary directly and no longer references the previous patterns that re-invoked `${words[@]}` / `$tokens`.
- Manually verified the patched zsh completion against a live `willow` install: `ww sw <TAB>`, `ww <TAB>`, `ww --<TAB>`, and `willow sw <TAB>` all return the expected completions instead of triggering `cd`.


https://github.com/user-attachments/assets/3a544e20-211e-4498-9e50-8ca92a5d38e3

