### PR TITLE
:zap: perf[ls]: cache GitHub merged status

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ ww rm auth-refactor --prune      # also run git worktree prune
 
 ### `ww ls [repo]`
 
-List worktrees with status. Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and merged worktrees at the bottom.
+List worktrees with status. Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and merged worktrees at the bottom. GitHub-backed merged markers use cached data so `ww ls` stays fast in large repos.
 
 ![ww ls](screenshots/demo-ls.gif)
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -2078,16 +2078,6 @@ func TestMergedWorktrees_UsesGitHubMergedPRsAcrossCLI(t *testing.T) {
 	}
 	installMergedStatusGH(t, baseBranch, "feature-merged", strings.TrimSpace(headOID))
 
-	lsOut, err := captureStdout(t, func() error {
-		return runApp("ls", "mergedrepo")
-	})
-	if err != nil {
-		t.Fatalf("ls failed: %v", err)
-	}
-	if !strings.Contains(lsOut, "feature-merged") || !strings.Contains(lsOut, "[merged]") {
-		t.Fatalf("expected ls output to include merged feature worktree, got:\n%s", lsOut)
-	}
-
 	gcOut, err := captureStdout(t, func() error {
 		return runApp("gc")
 	})
@@ -2098,6 +2088,16 @@ func TestMergedWorktrees_UsesGitHubMergedPRsAcrossCLI(t *testing.T) {
 		t.Fatalf("expected gc output to include merged feature worktree, got:\n%s", gcOut)
 	}
 
+	lsOut, err := captureStdout(t, func() error {
+		return runApp("ls", "mergedrepo")
+	})
+	if err != nil {
+		t.Fatalf("ls failed: %v", err)
+	}
+	if !strings.Contains(lsOut, "feature-merged") || !strings.Contains(lsOut, "[merged]") {
+		t.Fatalf("expected ls output to include cached merged feature worktree, got:\n%s", lsOut)
+	}
+
 	wts, err := worktree.List(repoGit)
 	if err != nil {
 		t.Fatalf("list worktrees: %v", err)
@@ -2105,6 +2105,49 @@ func TestMergedWorktrees_UsesGitHubMergedPRsAcrossCLI(t *testing.T) {
 	mergedSet := mergedBranchSetForRepo("mergedrepo", bareDir, filterBareWorktrees(wts))
 	if !mergedSet["feature-merged"] {
 		t.Fatalf("expected sw merged helper to include feature-merged, got %v", mergedSet)
+	}
+}
+
+func TestLSDoesNotRefreshGitHubMergedStatus(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "lsfast"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "lsfast")
+	entries, _ := os.ReadDir(worktreeDir)
+	mainDir := filepath.Join(worktreeDir, entries[0].Name())
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-fast", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	binDir := t.TempDir()
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatalf("find git: %v", err)
+	}
+	if err := os.Symlink(gitPath, filepath.Join(binDir, "git")); err != nil {
+		t.Fatalf("symlink git: %v", err)
+	}
+	logPath := filepath.Join(binDir, "gh.log")
+	ghScript := fmt.Sprintf("#!/bin/sh\nprintf 'gh invoked\\n' >> %q\nexit 1\n", logPath)
+	if err := os.WriteFile(filepath.Join(binDir, "gh"), []byte(ghScript), 0o755); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+	t.Setenv("PATH", binDir)
+
+	if _, err := captureStdout(t, func() error {
+		return runApp("ls", "lsfast")
+	}); err != nil {
+		t.Fatalf("ls failed: %v", err)
+	}
+
+	if lines := readLogLines(t, logPath); len(lines) > 0 {
+		t.Fatalf("ls should not invoke gh, got log lines %v", lines)
 	}
 }
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -224,9 +224,12 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 			branchHeads[wt.Branch] = wt.Head
 		}
 	}
-	done := trace.Span(ctx, "MergedBranchSet")
+	done := trace.Span(ctx, "git.MergedBranchSet")
 	mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
-	for branch := range gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads) {
+	done()
+
+	done = trace.Span(ctx, "gh.CachedMergedWorktreeSet")
+	for branch := range gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads) {
 		mergedSet[branch] = true
 	}
 	done()

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -221,7 +221,7 @@ List worktrees with status.
   old-feature          --      <willow-base>/worktrees/myrepo/old-feature  5m
 ```
 
-Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and merged worktrees at the bottom.
+Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and merged worktrees at the bottom. GitHub-backed merged markers use cached data so `ww ls` does not refresh GitHub on the hot path.
 
 When run outside a willow repo, lists all repos and their worktree counts.
 


### PR DESCRIPTION
## Description of the change
Use cached GitHub merged-worktree data when rendering `ww ls`, while keeping local git merge detection live. This removes the live `gh pr list` call from the hot path and splits trace spans for local git vs cached GitHub work.

Updated README and website command docs to note that GitHub-backed merged markers are cache-based for `ww ls`.

## Test plan
Go test suite plus manual Evergreen trace with the locally built binary.

## Considerations
Codex assisted.