### PR TITLE
:sparkles: feat[dashboard]: show all worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,21 +379,14 @@ Rich view of Claude Code agent status. Shows per-session rows when multiple agen
 
 ### `ww dashboard` (alias: `dash`, `d`)
 
-Live-refreshing TUI showing active Claude Code sessions across all repos. Includes short session IDs, diff stats, unread counts, per-session activity, and a timeline sparkline showing agent status transitions over the last 60 minutes.
+Live-refreshing TUI showing every worktree across all repos. Uses the same stacked-branch tree grouping as the tmux picker, with aggregate agent status, unread counts, merged markers, and worktree paths.
 
 ```bash
 ww dashboard              # default 2s refresh
 ww dash -i 5              # 5s refresh interval
-ww dash --no-timeline     # hide the timeline column
 ```
 
-| Key | Action |
-|-----|--------|
-| `j/k` | Navigate rows |
-| `Enter` | Switch to tmux session |
-| `t` | Toggle timeline column |
-| `r` | Refresh |
-| `q` | Quit |
+Press `Ctrl-C` to quit.
 
 ![ww dashboard](screenshots/demo-dashboard.gif)
 

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -13,7 +13,7 @@ func dashboardCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "dashboard",
 		Aliases: []string{"dash", "d"},
-		Usage:   "Live overview of all Claude Code sessions across repos",
+		Usage:   "Live overview of all worktrees across repos",
 		Flags: []cli.Flag{
 			&cli.IntFlag{
 				Name:    "interval",
@@ -21,17 +21,12 @@ func dashboardCmd() *cli.Command {
 				Usage:   "Refresh interval in seconds",
 				Value:   2,
 			},
-			&cli.BoolFlag{
-				Name:  "no-timeline",
-				Usage: "Hide the timeline column",
-			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			defer trace.Span(ctx, "cli.dashboard")()
 			interval := time.Duration(cmd.Int("interval")) * time.Second
 			return dashboard.Run(ctx, dashboard.Config{
 				RefreshInterval: interval,
-				ShowTimeline:    !cmd.Bool("no-timeline"),
 			})
 		},
 	}

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -6,17 +6,14 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
-	"github.com/iamrajjoshi/willow/internal/git"
-	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -24,78 +21,26 @@ import (
 
 type Config struct {
 	RefreshInterval time.Duration
-	ShowTimeline    bool
 }
 
-type session struct {
-	Repo      string
-	Branch    string
-	SessionID string
-	Status    claude.Status
-	Tool      string
-	DiffStats string
-	Age       string
-	Unread    bool
-	WtDirName string
-	Timeline  string
+type row struct {
+	Repo        string
+	Branch      string
+	Head        string
+	Detached    bool
+	WtDirName   string
+	Path        string
+	Status      claude.Status
+	Unread      bool
+	Merged      bool
+	StackPrefix string
 }
 
 type summary struct {
-	Repos  int
-	Agents int
-	Unread int
-}
-
-type repoData struct {
-	sessions []session
-	agents   int
-	unread   int
-}
-
-type cachedDiff struct {
-	stats string
-	at    time.Time
-}
-
-var (
-	diffCache    = map[string]cachedDiff{}
-	diffCacheMu  sync.Mutex
-	diffCacheTTL = 10 * time.Second
-)
-
-func readKey(tty *os.File) chan byte {
-	ch := make(chan byte, 1)
-	go func() {
-		buf := make([]byte, 3)
-		for {
-			n, err := tty.Read(buf)
-			if err != nil {
-				return
-			}
-			if n == 1 {
-				ch <- buf[0]
-			} else if n == 3 && buf[0] == 27 && buf[1] == 91 {
-				// Arrow keys: ESC [ A/B
-				ch <- buf[2]
-			}
-		}
-	}()
-	return ch
-}
-
-func setRawMode(tty *os.File) {
-	// Use -icanon instead of raw so output post-processing (ONLCR) stays enabled.
-	// stty raw also sets -opost which turns \n into bare LF, breaking ANSI cursor
-	// positioning that relies on \n returning the cursor to column 0.
-	cmd := exec.Command("stty", "-echo", "-icanon", "min", "1", "time", "0")
-	cmd.Stdin = tty
-	cmd.Run()
-}
-
-func restoreMode(tty *os.File) {
-	cmd := exec.Command("stty", "echo", "icanon")
-	cmd.Stdin = tty
-	cmd.Run()
+	Repos     int
+	Worktrees int
+	Active    int
+	Unread    int
 }
 
 func Run(ctx context.Context, cfg Config) error {
@@ -105,18 +50,8 @@ func Run(ctx context.Context, cfg Config) error {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
-	tty, err := os.Open("/dev/tty")
-	if err != nil {
-		return fmt.Errorf("open /dev/tty: %w", err)
-	}
-	defer tty.Close()
-
-	setRawMode(tty)
-	defer restoreMode(tty)
-
 	fmt.Print(ui.AltScreenOn())
 	fmt.Print(ui.HideCursor())
-
 	defer func() {
 		fmt.Print(ui.ShowCursor())
 		fmt.Print(ui.AltScreenOff())
@@ -126,20 +61,20 @@ func Run(ctx context.Context, cfg Config) error {
 	signal.Notify(winchCh, syscall.SIGWINCH)
 
 	cols := termWidth()
-	ticker := time.NewTicker(cfg.RefreshInterval)
+	interval := cfg.RefreshInterval
+	if interval <= 0 {
+		interval = 2 * time.Second
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
-
-	selectedIdx := 0
-	showTimeline := cfg.ShowTimeline
-	keyCh := readKey(tty)
 
 	frame := 0
 	prevStatus := map[string]claude.Status{}
 	flashUntil := map[string]time.Time{}
 
-	sessions, sum := collectData()
-	updateFlashes(sessions, prevStatus, flashUntil)
-	output := render(sessions, sum, cols, selectedIdx, showTimeline, frame, flashUntil)
+	rows, sum := collectData(ctx)
+	updateFlashes(rows, prevStatus, flashUntil)
+	output := render(rows, sum, cols, frame, flashUntil)
 	fmt.Print(ui.CursorHome())
 	fmt.Print(output)
 	fmt.Print(ui.ClearToEnd())
@@ -154,47 +89,9 @@ func Run(ctx context.Context, cfg Config) error {
 			cols = termWidth()
 		case <-ticker.C:
 			frame++
-			sessions, sum = collectData()
-			updateFlashes(sessions, prevStatus, flashUntil)
-			if selectedIdx >= len(sessions) && len(sessions) > 0 {
-				selectedIdx = len(sessions) - 1
-			}
-			output = render(sessions, sum, cols, selectedIdx, showTimeline, frame, flashUntil)
-			fmt.Print(ui.CursorHome())
-			fmt.Print(output)
-			fmt.Print(ui.ClearToEnd())
-		case key := <-keyCh:
-			switch key {
-			case 'j', 'B': // down: j or arrow-down (ESC[B)
-				if selectedIdx < len(sessions)-1 {
-					selectedIdx++
-				}
-			case 'k', 'A': // up: k or arrow-up (ESC[A)
-				if selectedIdx > 0 {
-					selectedIdx--
-				}
-			case 'q', 3: // q or Ctrl+C
-				return nil
-			case 'r': // refresh
-				sessions, sum = collectData()
-				updateFlashes(sessions, prevStatus, flashUntil)
-				if selectedIdx >= len(sessions) && len(sessions) > 0 {
-					selectedIdx = len(sessions) - 1
-				}
-			case 't': // toggle timeline
-				showTimeline = !showTimeline
-			case 13: // Enter — switch to tmux session
-				if selectedIdx < len(sessions) {
-					s := sessions[selectedIdx]
-					sessionName := tmux.SessionNameForWorktree(s.Repo, s.WtDirName)
-					restoreMode(tty)
-					fmt.Print(ui.ShowCursor())
-					fmt.Print(ui.AltScreenOff())
-					tmux.SwitchClient(sessionName)
-					return nil
-				}
-			}
-			output = render(sessions, sum, cols, selectedIdx, showTimeline, frame, flashUntil)
+			rows, sum = collectData(ctx)
+			updateFlashes(rows, prevStatus, flashUntil)
+			output = render(rows, sum, cols, frame, flashUntil)
 			fmt.Print(ui.CursorHome())
 			fmt.Print(output)
 			fmt.Print(ui.ClearToEnd())
@@ -202,28 +99,20 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 }
 
-// sessionKey uniquely identifies a dashboard row across refreshes. Sessions
-// without an ID (bare worktree status) key by repo+worktree so they still
-// participate in transition tracking.
-func sessionKey(s session) string {
-	if s.SessionID != "" {
-		return s.Repo + "/" + s.WtDirName + "/" + s.SessionID
-	}
-	return s.Repo + "/" + s.WtDirName
+func rowKey(r row) string {
+	return r.Repo + "/" + r.WtDirName
 }
 
-// updateFlashes records a 2-second flash whenever a session transitions from
-// BUSY → DONE, so the row visibly highlights on the next render.
-func updateFlashes(sessions []session, prev map[string]claude.Status, flashUntil map[string]time.Time) {
+func updateFlashes(rows []row, prev map[string]claude.Status, flashUntil map[string]time.Time) {
 	seen := map[string]struct{}{}
 	now := time.Now()
-	for _, s := range sessions {
-		key := sessionKey(s)
+	for _, r := range rows {
+		key := rowKey(r)
 		seen[key] = struct{}{}
-		if p, ok := prev[key]; ok && p == claude.StatusBusy && s.Status == claude.StatusDone {
+		if p, ok := prev[key]; ok && p == claude.StatusBusy && r.Status == claude.StatusDone {
 			flashUntil[key] = now.Add(2 * time.Second)
 		}
-		prev[key] = s.Status
+		prev[key] = r.Status
 	}
 	for key := range prev {
 		if _, ok := seen[key]; !ok {
@@ -238,112 +127,53 @@ func updateFlashes(sessions []session, prev map[string]claude.Status, flashUntil
 	}
 }
 
-func collectData() ([]session, summary) {
+func collectData(ctx context.Context) ([]row, summary) {
 	repos, err := config.ListRepos()
 	if err != nil {
 		return nil, summary{}
 	}
 
 	sum := summary{Repos: len(repos)}
-	results := parallel.Map(repos, func(_ int, repoName string) repoData {
-		return collectRepoData(repoName)
-	})
-
-	var sessions []session
-	for _, result := range results {
-		sessions = append(sessions, result.sessions...)
-		sum.Agents += result.agents
-		sum.Unread += result.unread
-	}
-
-	return sessions, sum
-}
-
-func collectRepoData(repoName string) repoData {
-	bareDir, err := config.ResolveRepo(repoName)
+	items, err := tmux.BuildPickerItemsWithOptions(ctx, "", tmux.PickerBuildOptions{RefreshGitHubMerged: false})
 	if err != nil {
-		return repoData{}
+		return nil, sum
 	}
 
-	repoGit := &git.Git{Dir: bareDir}
-	wts, err := worktree.List(repoGit)
-	if err != nil {
-		return repoData{}
-	}
-
-	cfg := config.Load(bareDir)
-	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
-	timelineSince := time.Now().Add(-60 * time.Minute)
-	var result repoData
-
-	for _, wt := range wts {
-		if wt.IsBare {
-			continue
+	rows := make([]row, 0, len(items))
+	for _, item := range items {
+		unread := claude.CountUnreadIn(item.RepoName, item.WtDirName, item.Sessions) > 0
+		r := row{
+			Repo:        item.RepoName,
+			Branch:      item.Branch,
+			Head:        item.Head,
+			Detached:    item.Detached,
+			WtDirName:   item.WtDirName,
+			Path:        item.WtPath,
+			Status:      item.Status,
+			Unread:      unread,
+			Merged:      item.Merged,
+			StackPrefix: item.StackPrefix,
 		}
-		wtDir := filepath.Base(wt.Path)
-		allSessions := claude.ReadAllSessions(repoName, wtDir)
-		unread := claude.CountUnreadIn(repoName, wtDir, allSessions) > 0
-
+		rows = append(rows, r)
+		sum.Worktrees++
+		if claude.IsActive(item.Status) {
+			sum.Active++
+		}
 		if unread {
-			result.unread++
-		}
-
-		diff := getDiffStats(wt.Path, baseBranch)
-
-		if len(allSessions) > 0 {
-			for _, ss := range allSessions {
-				effective := claude.EffectiveStatus(ss.Status, ss.Timestamp)
-				if effective == claude.StatusIdle || effective == claude.StatusOffline {
-					continue
-				}
-				timeline, _ := claude.ReadTimeline(repoName, wtDir, ss.SessionID, timelineSince)
-				s := session{
-					Repo:      repoName,
-					Branch:    wt.DisplayName(),
-					SessionID: ss.SessionID,
-					Status:    effective,
-					Tool:      ss.Tool,
-					DiffStats: diff,
-					Age:       claude.TimeSince(ss.Timestamp),
-					Unread:    effective == claude.StatusDone && unread,
-					WtDirName: wtDir,
-					Timeline:  claude.Sparkline(timeline, 30, 60*time.Minute),
-				}
-				result.sessions = append(result.sessions, s)
-				if claude.IsActive(effective) {
-					result.agents++
-				}
-			}
-		} else {
-			ws := claude.AggregateStatus(allSessions)
-			if ws.Status == claude.StatusOffline || ws.Status == claude.StatusIdle {
-				continue
-			}
-			s := session{
-				Repo:      repoName,
-				Branch:    wt.DisplayName(),
-				Status:    ws.Status,
-				DiffStats: diff,
-				Age:       claude.TimeSince(ws.Timestamp),
-				Unread:    ws.Status == claude.StatusDone && unread,
-				WtDirName: wtDir,
-				Timeline:  strings.Repeat("\033[2m\u00b7\033[0m", 30),
-			}
-			result.sessions = append(result.sessions, s)
-			result.agents++
+			sum.Unread++
 		}
 	}
 
-	return result
+	return rows, sum
 }
 
-func render(sessions []session, sum summary, width int, selectedIdx int, showTimeline bool, frame int, flashUntil map[string]time.Time) string {
+func render(rows []row, sum summary, width int, frame int, flashUntil map[string]time.Time) string {
 	var b strings.Builder
 	u := &ui.UI{}
 
-	if len(sessions) == 0 {
+	if len(rows) == 0 {
 		title := "willow dashboard"
-		stats := fmt.Sprintf("%d repos | %d agents | %d unread", sum.Repos, sum.Agents, sum.Unread)
+		stats := fmt.Sprintf("%d repos | %d worktrees | %d active | %d unread", sum.Repos, sum.Worktrees, sum.Active, sum.Unread)
 		headerText := title + "  " + stats
 		pad := 0
 		if width > len(headerText) {
@@ -352,59 +182,54 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 		b.WriteString(strings.Repeat(" ", pad))
 		b.WriteString(u.Bold(headerText))
 		b.WriteString("\n\n")
-		b.WriteString(u.Dim("  no active sessions yet"))
+		b.WriteString(u.Dim("  no worktrees yet"))
 		b.WriteString("\n\n")
-		b.WriteString("  start one with  ")
+		b.WriteString("  create one with  ")
 		b.WriteString(u.Cyan("willow new <branch>"))
 		b.WriteString("\n")
 		return b.String()
 	}
 
-	type rowLabel struct {
-		status  string
-		session string
+	multiRepo := hasMultipleRepos(rows)
+	home, _ := os.UserHomeDir()
+
+	type labels struct {
+		status string
+		name   string
+		path   string
 	}
-	labels := make([]rowLabel, len(sessions))
+	rowLabels := make([]labels, len(rows))
 	statusW := len("STATUS")
-	repoW := len("REPO")
-	branchW := len("BRANCH")
-	sessionW := len("SESSION")
-	diffW := len("DIFF")
-	for i, s := range sessions {
-		statusText := string(s.Status)
-		if s.Unread {
-			statusText += "\u25CF"
+	nameW := len("WORKTREE")
+	pathW := len("PATH")
+
+	for i, r := range rows {
+		statusText := string(r.Status)
+		if r.Unread {
+			statusText += " \u25cf"
 		}
-		if s.Status == claude.StatusBusy && s.Tool != "" {
-			statusText += " (" + s.Tool + ")"
+		name := displayName(r, multiRepo)
+		namePlain := name
+		if r.Merged {
+			namePlain += " [merged]"
 		}
-		sessionText := claude.ShortSessionID(s.SessionID)
-		labels[i] = rowLabel{status: statusText, session: sessionText}
-		if len(statusText) > statusW {
-			statusW = len(statusText)
+		path := shortenPathWithHome(r.Path, home)
+		rowLabels[i] = labels{status: statusText, name: name, path: path}
+
+		if utf8.RuneCountInString(statusText) > statusW {
+			statusW = utf8.RuneCountInString(statusText)
 		}
-		if len(s.Repo) > repoW {
-			repoW = len(s.Repo)
+		if utf8.RuneCountInString(namePlain) > nameW {
+			nameW = utf8.RuneCountInString(namePlain)
 		}
-		if len(s.Branch) > branchW {
-			branchW = len(s.Branch)
-		}
-		if len(sessionText) > sessionW {
-			sessionW = len(sessionText)
-		}
-		if len(s.DiffStats) > diffW {
-			diffW = len(s.DiffStats)
+		if utf8.RuneCountInString(path) > pathW {
+			pathW = utf8.RuneCountInString(path)
 		}
 	}
 
-	timelineW := 30
-	tableW := 2 + 2 + 1 + statusW + 2 + repoW + 2 + branchW + 2 + sessionW + 2 + diffW + 2 + 8
-	if showTimeline {
-		tableW += 2 + timelineW // 2 for gap + column width
-	}
-
+	tableW := 2 + 2 + 1 + statusW + 2 + nameW + 2 + pathW
 	title := "willow dashboard"
-	stats := fmt.Sprintf("%d repos | %d agents | %d unread", sum.Repos, sum.Agents, sum.Unread)
+	stats := fmt.Sprintf("%d repos | %d worktrees | %d active | %d unread", sum.Repos, sum.Worktrees, sum.Active, sum.Unread)
 	headerText := title + "  " + stats
 	pad := 0
 	if tableW > len(headerText) {
@@ -414,12 +239,8 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	b.WriteString(u.Bold(headerText))
 	b.WriteString("\n\n")
 
-	headerLine := fmt.Sprintf("  %-2s %-*s  %-*s  %-*s  %-*s  %-*s",
-		"", statusW, "STATUS", repoW, "REPO", branchW, "BRANCH", sessionW, "SESSION", diffW, "DIFF")
-	headerLine += "  AGE"
-	if showTimeline {
-		headerLine += fmt.Sprintf("  %-*s", timelineW, "TIMELINE")
-	}
+	headerLine := fmt.Sprintf("  %-2s %-*s  %-*s  %-*s",
+		"", statusW, "STATUS", nameW, "WORKTREE", pathW, "PATH")
 	b.WriteString(u.Bold(headerLine))
 	b.WriteString("\n")
 
@@ -432,70 +253,94 @@ func render(sessions []session, sum summary, width int, selectedIdx int, showTim
 	b.WriteString("\n")
 
 	now := time.Now()
-	for i, s := range sessions {
-		icon := claude.StatusIcon(s.Status)
-		if s.Status == claude.StatusBusy {
+	for i, r := range rows {
+		icon := claude.StatusIcon(r.Status)
+		if r.Status == claude.StatusBusy {
 			icon = u.Cyan(u.SpinnerFrame(frame))
 		}
-		line := fmt.Sprintf("  %s %-*s  %-*s  %-*s  %-*s  %-*s",
-			icon, statusW, labels[i].status,
-			repoW, s.Repo,
-			branchW, s.Branch,
-			sessionW, labels[i].session,
-			diffW, s.DiffStats)
-		line += "  " + u.Dim(s.Age)
-		if showTimeline {
-			line += "  " + s.Timeline
-		}
 
-		flashing := false
-		if until, ok := flashUntil[sessionKey(s)]; ok && now.Before(until) {
-			flashing = true
-		}
+		statusCol := fmt.Sprintf("%-*s", statusW, rowLabels[i].status)
+		statusCol = colorStatus(u, r.Status, statusCol)
 
-		switch {
-		case i == selectedIdx:
-			b.WriteString("\033[7m") // inverse video
+		nameDisplay := rowLabels[i].name
+		namePlain := nameDisplay
+		if r.Merged {
+			namePlain += " [merged]"
+			nameDisplay += " " + u.Dim("[merged]")
+		}
+		namePadding := nameW - utf8.RuneCountInString(namePlain)
+		if namePadding < 0 {
+			namePadding = 0
+		}
+		nameCol := nameDisplay + strings.Repeat(" ", namePadding)
+
+		pathCol := fmt.Sprintf("%-*s", pathW, rowLabels[i].path)
+		line := fmt.Sprintf("  %s %s  %s  %s", icon, statusCol, nameCol, u.Dim(pathCol))
+
+		if until, ok := flashUntil[rowKey(r)]; ok && now.Before(until) {
+			b.WriteString("\033[48;5;30m")
 			b.WriteString(line)
 			b.WriteString("\033[0m")
-		case flashing:
-			b.WriteString("\033[48;5;30m") // teal background
-			b.WriteString(line)
-			b.WriteString("\033[0m")
-		default:
+		} else {
 			b.WriteString(line)
 		}
 		b.WriteString("\n")
 	}
 
-	b.WriteString("\n")
-	b.WriteString(u.Dim("  j/k: navigate | Enter: switch | t: timeline | r: refresh | q: quit"))
-	b.WriteString("\n")
-
 	return b.String()
 }
 
-func getDiffStats(wtPath, baseBranch string) string {
-	diffCacheMu.Lock()
-	if cached, ok := diffCache[wtPath]; ok && time.Since(cached.at) < diffCacheTTL {
-		diffCacheMu.Unlock()
-		return cached.stats
+func displayName(r row, multiRepo bool) string {
+	name := r.Branch
+	if r.Detached {
+		if r.Head == "" {
+			name = fmt.Sprintf("%s [detached]", r.WtDirName)
+		} else {
+			name = fmt.Sprintf("%s [detached %s]", r.WtDirName, worktree.ShortHead(r.Head))
+		}
 	}
-	diffCacheMu.Unlock()
-
-	g := &git.Git{Dir: wtPath}
-	out, err := g.Run("diff", "--shortstat", fmt.Sprintf("origin/%s...HEAD", baseBranch))
-	if err != nil {
-		return "--"
+	if multiRepo {
+		name = r.Repo + "/" + name
 	}
+	if r.StackPrefix != "" && !r.Detached {
+		name = r.StackPrefix + name
+	}
+	return name
+}
 
-	stats := git.ParseShortstat(out)
+func hasMultipleRepos(rows []row) bool {
+	if len(rows) <= 1 {
+		return false
+	}
+	first := rows[0].Repo
+	for _, r := range rows[1:] {
+		if r.Repo != first {
+			return true
+		}
+	}
+	return false
+}
 
-	diffCacheMu.Lock()
-	diffCache[wtPath] = cachedDiff{stats: stats, at: time.Now()}
-	diffCacheMu.Unlock()
+func colorStatus(u *ui.UI, status claude.Status, text string) string {
+	switch status {
+	case claude.StatusBusy:
+		return u.Green(text)
+	case claude.StatusWait:
+		return u.Red(text)
+	case claude.StatusDone:
+		return u.Cyan(text)
+	case claude.StatusIdle:
+		return u.Yellow(text)
+	default:
+		return u.Dim(text)
+	}
+}
 
-	return stats
+func shortenPathWithHome(path, home string) string {
+	if home != "" && strings.HasPrefix(path, home) {
+		return "~" + path[len(home):]
+	}
+	return path
 }
 
 func termWidth() int {

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -11,224 +12,112 @@ import (
 
 	"github.com/iamrajjoshi/willow/internal/claude"
 	"github.com/iamrajjoshi/willow/internal/config"
-	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
 )
 
-func TestParseShortstatFromGit(t *testing.T) {
-	tests := []struct {
-		name string
-		out  string
-		want string
-	}{
-		{
-			name: "full output",
-			out:  " 3 files changed, 42 insertions(+), 12 deletions(-)",
-			want: "3f +42 -12",
-		},
-		{
-			name: "insertions only",
-			out:  " 1 file changed, 10 insertions(+)",
-			want: "1f +10",
-		},
-		{
-			name: "deletions only",
-			out:  " 2 files changed, 5 deletions(-)",
-			want: "2f -5",
-		},
-		{
-			name: "empty string",
-			out:  "",
-			want: "--",
-		},
-		{
-			name: "single file single insertion and deletion",
-			out:  " 1 file changed, 1 insertion(+), 1 deletion(-)",
-			want: "1f +1 -1",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := git.ParseShortstat(tt.out)
-			if got != tt.want {
-				t.Errorf("git.ParseShortstat(%q) = %q, want %q", tt.out, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestRenderNoSessions(t *testing.T) {
-	out := render(nil, summary{Repos: 2, Agents: 0, Unread: 0}, 120, 0, false, 0, nil)
-	if !strings.Contains(out, "no active sessions") {
-		t.Errorf("expected 'no active sessions' empty-state copy, got:\n%s", out)
+func TestRenderNoWorktrees(t *testing.T) {
+	out := render(nil, summary{Repos: 2, Worktrees: 0, Active: 0, Unread: 0}, 120, 0, nil)
+	if !strings.Contains(out, "no worktrees yet") {
+		t.Errorf("expected 'no worktrees yet' empty-state copy, got:\n%s", out)
 	}
 	if !strings.Contains(out, "willow new") {
 		t.Errorf("expected 'willow new' hint in empty state, got:\n%s", out)
 	}
 }
 
-func TestRenderSingleSession(t *testing.T) {
-	sessions := []session{
+func TestRenderWorktreeRows(t *testing.T) {
+	rows := []row{
 		{
 			Repo:      "myrepo",
 			Branch:    "feat--thing",
-			SessionID: "abc12345rest",
 			Status:    claude.StatusBusy,
-			Tool:      "",
-			DiffStats: "2f +10 -3",
-			Age:       "5m",
-			Unread:    false,
+			Path:      "/tmp/worktrees/myrepo/feat--thing",
 			WtDirName: "feat--thing",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false, 0, nil)
+	out := render(rows, summary{Repos: 1, Worktrees: 1, Active: 1, Unread: 0}, 120, 0, nil)
 
-	if !strings.Contains(out, "myrepo") {
-		t.Errorf("expected 'myrepo' in output, got:\n%s", out)
+	for _, want := range []string{"WORKTREE", "PATH", "myrepo", "feat--thing", "/tmp/worktrees/myrepo/feat--thing"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
 	}
-	if !strings.Contains(out, "feat--thing") {
-		t.Errorf("expected 'feat--thing' in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "2f +10 -3") {
-		t.Errorf("expected diff stats in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "SESSION") {
-		t.Errorf("expected SESSION column header, got:\n%s", out)
-	}
-	if !strings.Contains(out, "abc12345") {
-		t.Errorf("expected shortened session id in output, got:\n%s", out)
+	for _, removed := range []string{"SESSION", "DIFF", "TIMELINE", "j/k: navigate"} {
+		if strings.Contains(out, removed) {
+			t.Errorf("did not expect %q in passive dashboard output, got:\n%s", removed, out)
+		}
 	}
 }
 
 func TestRenderUnreadMarker(t *testing.T) {
-	sessions := []session{
+	rows := []row{
 		{
 			Repo:      "myrepo",
 			Branch:    "feat--done",
-			SessionID: "abc123",
 			Status:    claude.StatusDone,
-			DiffStats: "--",
-			Age:       "2m",
 			Unread:    true,
+			Path:      "/tmp/worktrees/myrepo/feat--done",
 			WtDirName: "feat--done",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 1}, 120, 0, false, 0, nil)
+	out := render(rows, summary{Repos: 1, Worktrees: 1, Active: 1, Unread: 1}, 120, 0, nil)
 
-	if !strings.Contains(out, "\u25CF") {
-		t.Errorf("expected unread marker (bullet) in output, got:\n%s", out)
+	if !strings.Contains(out, "DONE \u25cf") {
+		t.Errorf("expected spaced unread marker in output, got:\n%s", out)
 	}
 }
 
-func TestRenderBusyWithTool(t *testing.T) {
-	sessions := []session{
+func TestRenderStackPrefixAndMergedMarker(t *testing.T) {
+	rows := []row{
 		{
-			Repo:      "myrepo",
-			Branch:    "feat--edit",
-			SessionID: "abc123",
-			Status:    claude.StatusBusy,
-			Tool:      "Edit",
-			DiffStats: "1f +5",
-			Age:       "1m",
-			Unread:    false,
-			WtDirName: "feat--edit",
+			Repo:      "repo",
+			Branch:    "parent",
+			Status:    claude.StatusIdle,
+			Path:      "/tmp/worktrees/repo/parent",
+			WtDirName: "parent",
+		},
+		{
+			Repo:        "repo",
+			Branch:      "child",
+			Status:      claude.StatusDone,
+			Path:        "/tmp/worktrees/repo/child",
+			WtDirName:   "child",
+			Merged:      true,
+			StackPrefix: "\u2514\u2500 ",
 		},
 	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false, 0, nil)
+	out := render(rows, summary{Repos: 1, Worktrees: 2, Active: 1, Unread: 0}, 120, 0, nil)
 
-	if !strings.Contains(out, "(Edit)") {
-		t.Errorf("expected '(Edit)' tool label in output, got:\n%s", out)
+	if !strings.Contains(out, "\u2514\u2500 child") {
+		t.Errorf("expected stack prefix before child branch, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[merged]") {
+		t.Errorf("expected merged marker in output, got:\n%s", out)
 	}
 }
 
-func TestRenderSelectedRow(t *testing.T) {
-	sessions := []session{
+func TestRenderMultiRepoStackNameMatchesPickerStyle(t *testing.T) {
+	rows := []row{
 		{
 			Repo:      "repo-a",
-			Branch:    "branch-a",
-			Status:    claude.StatusBusy,
-			DiffStats: "--",
-			Age:       "3m",
-			WtDirName: "branch-a",
-		},
-		{
-			Repo:      "repo-b",
-			Branch:    "branch-b",
-			Status:    claude.StatusDone,
-			DiffStats: "1f +2",
-			Age:       "8m",
-			WtDirName: "branch-b",
-		},
-	}
-	out := render(sessions, summary{Repos: 2, Agents: 2, Unread: 0}, 120, 1, false, 0, nil)
-
-	if !strings.Contains(out, "\033[7m") {
-		t.Errorf("expected inverse video escape sequence for selected row, got:\n%s", out)
-	}
-}
-
-func TestRenderKeybindingHint(t *testing.T) {
-	sessions := []session{
-		{
-			Repo:      "myrepo",
 			Branch:    "main",
-			Status:    claude.StatusBusy,
-			DiffStats: "--",
-			Age:       "1m",
+			Status:    claude.StatusOffline,
+			Path:      "/tmp/worktrees/repo-a/main",
 			WtDirName: "main",
 		},
-	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, false, 0, nil)
-
-	if !strings.Contains(out, "j/k: navigate") {
-		t.Errorf("expected keybinding hint 'j/k: navigate' in output, got:\n%s", out)
-	}
-}
-
-func TestRenderTimelineColumn(t *testing.T) {
-	sparkline := strings.Repeat("\033[32m\u2588\033[0m", 30)
-	sessions := []session{
 		{
-			Repo:      "myrepo",
-			Branch:    "feat--thing",
-			Status:    claude.StatusBusy,
-			DiffStats: "--",
-			Age:       "2m",
-			WtDirName: "feat--thing",
-			Timeline:  sparkline,
+			Repo:        "repo-b",
+			Branch:      "stack-child",
+			Status:      claude.StatusWait,
+			Path:        "/tmp/worktrees/repo-b/stack-child",
+			WtDirName:   "stack-child",
+			StackPrefix: "\u2514\u2500 ",
 		},
 	}
+	out := render(rows, summary{Repos: 2, Worktrees: 2, Active: 1, Unread: 0}, 120, 0, nil)
 
-	// With timeline enabled
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 200, 0, true, 0, nil)
-	if !strings.Contains(out, "TIMELINE") {
-		t.Errorf("expected 'TIMELINE' header when showTimeline=true, got:\n%s", out)
-	}
-	if !strings.Contains(out, "\u2588") {
-		t.Errorf("expected sparkline blocks in output when showTimeline=true")
-	}
-
-	// With timeline disabled
-	out = render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 200, 0, false, 0, nil)
-	if strings.Contains(out, "TIMELINE") {
-		t.Errorf("expected no 'TIMELINE' header when showTimeline=false, got:\n%s", out)
-	}
-}
-
-func TestRenderTimelineKeybindingHint(t *testing.T) {
-	sessions := []session{
-		{
-			Repo:      "myrepo",
-			Branch:    "main",
-			Status:    claude.StatusBusy,
-			DiffStats: "--",
-			Age:       "1m",
-			WtDirName: "main",
-		},
-	}
-	out := render(sessions, summary{Repos: 1, Agents: 1, Unread: 0}, 120, 0, true, 0, nil)
-	if !strings.Contains(out, "t: timeline") {
-		t.Errorf("expected 't: timeline' in keybinding hint, got:\n%s", out)
+	if !strings.Contains(out, "\u2514\u2500 repo-b/stack-child") {
+		t.Errorf("expected multi-repo stack label to match picker style, got:\n%s", out)
 	}
 }
 
@@ -281,6 +170,15 @@ func setupDashboardRepo(t *testing.T) string {
 	return wtPath
 }
 
+func addDashboardWorktree(t *testing.T, bareDir, branch, base string) string {
+	t.Helper()
+
+	wtPath := filepath.Join(config.WorktreesDir(), "dashrepo", branch)
+	runDashboardGit(t, bareDir, "branch", branch, base)
+	runDashboardGit(t, bareDir, "worktree", "add", wtPath, branch)
+	return wtPath
+}
+
 func writeDashboardSession(t *testing.T, repo, wtDir, sessionID string, status claude.Status, tool string, ts time.Time) {
 	t.Helper()
 
@@ -302,98 +200,85 @@ func writeDashboardSession(t *testing.T, repo, wtDir, sessionID string, status c
 	}
 }
 
-func resetDiffCache() {
-	diffCacheMu.Lock()
-	defer diffCacheMu.Unlock()
-	diffCache = map[string]cachedDiff{}
-}
+func TestCollectDataIncludesAllWorktreesUnreadAndStackPrefixes(t *testing.T) {
+	setupDashboardRepo(t)
+	bareDir := filepath.Join(config.ReposDir(), "dashrepo.git")
+	addDashboardWorktree(t, bareDir, "feature-a", "main")
+	addDashboardWorktree(t, bareDir, "feature-b", "feature-a")
 
-func TestCollectDataIncludesActiveSessionsUnreadAndDiffStats(t *testing.T) {
-	resetDiffCache()
-	wtPath := setupDashboardRepo(t)
-	if err := os.WriteFile(filepath.Join(wtPath, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
-		t.Fatalf("write feature: %v", err)
+	st := &stack.Stack{Parents: map[string]string{
+		"feature-a": "main",
+		"feature-b": "feature-a",
+	}}
+	if err := st.Save(bareDir); err != nil {
+		t.Fatalf("save stack: %v", err)
 	}
-	runDashboardGit(t, wtPath, "add", "feature.txt")
-	runDashboardGit(t, wtPath, "commit", "-m", "feature")
 
 	now := time.Now()
-	writeDashboardSession(t, "dashrepo", "main", "busy-session", claude.StatusBusy, "Edit", now)
-	writeDashboardSession(t, "dashrepo", "main", "done-session", claude.StatusDone, "", now)
+	writeDashboardSession(t, "dashrepo", "feature-a", "done-session", claude.StatusDone, "", now)
+	writeDashboardSession(t, "dashrepo", "feature-b", "busy-session", claude.StatusBusy, "Edit", now)
+	writeDashboardSession(t, "dashrepo", "feature-b", "done-session", claude.StatusDone, "", now)
 
-	sessions, sum := collectData()
+	rows, sum := collectData(context.Background())
 	if sum.Repos != 1 {
 		t.Fatalf("Repos = %d, want 1", sum.Repos)
 	}
-	if sum.Agents != 2 {
-		t.Fatalf("Agents = %d, want 2 active busy/done sessions", sum.Agents)
+	if sum.Worktrees != 3 {
+		t.Fatalf("Worktrees = %d, want 3", sum.Worktrees)
 	}
-	if sum.Unread != 1 {
-		t.Fatalf("Unread = %d, want 1 done unread session", sum.Unread)
+	if sum.Active != 2 {
+		t.Fatalf("Active = %d, want 2", sum.Active)
 	}
-	if len(sessions) != 2 {
-		t.Fatalf("len(sessions) = %d, want 2", len(sessions))
+	if sum.Unread != 2 {
+		t.Fatalf("Unread = %d, want 2", sum.Unread)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("len(rows) = %d, want 3: %+v", len(rows), rows)
 	}
 
-	var sawBusy, sawDone bool
-	for _, s := range sessions {
-		if s.Repo != "dashrepo" || s.Branch != "main" || s.WtDirName != "main" {
-			t.Fatalf("unexpected session row: %+v", s)
-		}
-		if s.DiffStats != "1f +1" {
-			t.Fatalf("DiffStats = %q, want 1f +1", s.DiffStats)
-		}
-		if s.Status == claude.StatusBusy && s.Tool == "Edit" {
-			sawBusy = true
-		}
-		if s.Status == claude.StatusDone && s.Unread {
-			sawDone = true
+	var sawMain, sawFeatureA, sawFeatureB bool
+	for _, r := range rows {
+		switch r.Branch {
+		case "main":
+			sawMain = true
+			if r.Status != claude.StatusOffline {
+				t.Fatalf("main status = %s, want offline", r.Status)
+			}
+		case "feature-a":
+			sawFeatureA = true
+			if !r.Unread {
+				t.Fatalf("feature-a should carry unread marker: %+v", r)
+			}
+		case "feature-b":
+			sawFeatureB = true
+			if r.Status != claude.StatusBusy {
+				t.Fatalf("feature-b status = %s, want BUSY", r.Status)
+			}
+			if !r.Unread {
+				t.Fatalf("feature-b should show unread marker despite BUSY aggregate status: %+v", r)
+			}
+			if r.StackPrefix == "" {
+				t.Fatalf("feature-b should have stack prefix: %+v", r)
+			}
 		}
 	}
-	if !sawBusy || !sawDone {
-		t.Fatalf("expected busy and unread done rows, got %+v", sessions)
+	if !sawMain || !sawFeatureA || !sawFeatureB {
+		t.Fatalf("missing expected rows: %+v", rows)
 	}
 }
 
-func TestGetDiffStatsCachesByWorktreePath(t *testing.T) {
-	resetDiffCache()
-	wtPath := setupDashboardRepo(t)
-	if err := os.WriteFile(filepath.Join(wtPath, "first.txt"), []byte("first\n"), 0o644); err != nil {
-		t.Fatalf("write first: %v", err)
-	}
-	runDashboardGit(t, wtPath, "add", "first.txt")
-	runDashboardGit(t, wtPath, "commit", "-m", "first")
-
-	first := getDiffStats(wtPath, "main")
-	if first != "1f +1" {
-		t.Fatalf("first diff stats = %q, want 1f +1", first)
-	}
-
-	if err := os.WriteFile(filepath.Join(wtPath, "second.txt"), []byte("second\n"), 0o644); err != nil {
-		t.Fatalf("write second: %v", err)
-	}
-	runDashboardGit(t, wtPath, "add", "second.txt")
-	runDashboardGit(t, wtPath, "commit", "-m", "second")
-
-	second := getDiffStats(wtPath, "main")
-	if second != first {
-		t.Fatalf("cached diff stats changed before TTL expiry: got %q, want %q", second, first)
-	}
-}
-
-func TestUpdateFlashesRecordsBusyToDoneAndPrunesMissingSessions(t *testing.T) {
-	doneSession := session{
+func TestUpdateFlashesRecordsBusyToDoneAndPrunesMissingRows(t *testing.T) {
+	doneRow := row{
 		Repo:      "repo",
 		Branch:    "feature",
-		SessionID: "s1",
 		Status:    claude.StatusDone,
 		WtDirName: "feature",
 	}
-	key := sessionKey(doneSession)
+	key := rowKey(doneRow)
 	prev := map[string]claude.Status{key: claude.StatusBusy}
 	flashUntil := map[string]time.Time{}
 
-	updateFlashes([]session{doneSession}, prev, flashUntil)
+	updateFlashes([]row{doneRow}, prev, flashUntil)
 	if prev[key] != claude.StatusDone {
 		t.Fatalf("prev[%q] = %s, want DONE", key, prev[key])
 	}
@@ -403,10 +288,10 @@ func TestUpdateFlashesRecordsBusyToDoneAndPrunesMissingSessions(t *testing.T) {
 
 	updateFlashes(nil, prev, flashUntil)
 	if _, ok := prev[key]; ok {
-		t.Fatalf("expected missing session to be pruned from prev: %v", prev)
+		t.Fatalf("expected missing row to be pruned from prev: %v", prev)
 	}
 	if _, ok := flashUntil[key]; ok {
-		t.Fatalf("expected missing session to be pruned from flashUntil: %v", flashUntil)
+		t.Fatalf("expected missing row to be pruned from flashUntil: %v", flashUntil)
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -45,6 +45,48 @@ func setupRemoteAndClone(t *testing.T, defaultBranch string) string {
 	return work
 }
 
+func TestParseShortstat(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{
+			name: "full output",
+			out:  " 3 files changed, 42 insertions(+), 12 deletions(-)",
+			want: "3f +42 -12",
+		},
+		{
+			name: "insertions only",
+			out:  " 1 file changed, 10 insertions(+)",
+			want: "1f +10",
+		},
+		{
+			name: "deletions only",
+			out:  " 2 files changed, 5 deletions(-)",
+			want: "2f -5",
+		},
+		{
+			name: "empty string",
+			out:  "",
+			want: "--",
+		},
+		{
+			name: "single file single insertion and deletion",
+			out:  " 1 file changed, 1 insertion(+), 1 deletion(-)",
+			want: "1f +1 -1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseShortstat(tt.out); got != tt.want {
+				t.Errorf("ParseShortstat(%q) = %q, want %q", tt.out, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveBaseBranch(t *testing.T) {
 	work := setupRemoteAndClone(t, "master")
 	g := &Git{Dir: work}

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -358,12 +358,11 @@ The `●` indicator marks completed sessions you haven't reviewed yet. Switching
 
 ### `ww dashboard` (alias: `dash`, `d`)
 
-Live-refreshing TUI showing active Claude Code sessions across all repos. Renders in an alternate screen buffer with no flicker. Includes short session IDs and a timeline sparkline showing BUSY/WAIT/DONE transitions over the last 60 minutes.
+Live-refreshing TUI showing every worktree across all repos. Renders in an alternate screen buffer with no flicker. Uses the same stacked-branch tree grouping as the tmux picker, with aggregate agent status, unread counts, merged markers, and worktree paths.
 
 ```bash
 ww dashboard              # default 2s refresh
 ww dash -i 5              # 5s refresh interval
-ww dash --no-timeline     # hide the timeline column
 ```
 
 ![ww dashboard](/demo-dashboard.gif)
@@ -371,17 +370,8 @@ ww dash --no-timeline     # hide the timeline column
 | Flag | Description |
 |------|-------------|
 | `-i, --interval` | Refresh interval in seconds (default: 2) |
-| `--no-timeline` | Hide the timeline sparkline column |
 
-| Key | Action |
-|-----|--------|
-| `j/k` | Navigate rows |
-| `Enter` | Switch to tmux session |
-| `t` | Toggle timeline column |
-| `r` | Refresh |
-| `q` / `Ctrl-C` | Quit |
-
-The timeline requires `ww cc-setup` to be re-run to install the updated hook that records status transitions.
+Press `Ctrl-C` to quit.
 
 ### `ww log`
 


### PR DESCRIPTION
## Description of the change
Revamps `ww dashboard` into a passive auto-refresh view of all Willow worktrees. The dashboard now reuses the tmux picker stacked-branch ordering, removes interactive navigation/session/diff/timeline UI, and keeps aggregate status plus unread markers visible per worktree.

**Asana ticket:**

## Test plan
Unit and integration tests with the full Go test suite.

## Loom or screenshots

## Considerations
The existing dashboard GIF is intentionally left unchanged for now.
