### PR TITLE
:bug: fix[tmux]: use PR state for merged tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ go install github.com/iamrajjoshi/willow/cmd/willow@latest
 
 - [git](https://git-scm.com/)
 - [tmux](https://github.com/tmux/tmux) — optional, for the `ww tmux` picker popup
-- [gh](https://cli.github.com/) — optional, required for `ww new --pr`, `ww stack status`, `ww pr create`, and GitHub-aware merged worktree detection
+- [gh](https://cli.github.com/) — optional, required for `ww new --pr`, `ww stack status`, `ww pr create`, and PR-state merged worktree detection
 
 ## Setup
 
@@ -236,7 +236,7 @@ Willow refuses to overwrite existing branches, worktree paths, status directorie
 
 ### `ww checkout <branch-or-pr-url>` (alias: `co`)
 
-Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree. Merged worktrees show a `[merged]` indicator in `ww ls` and the tmux picker. When `gh` is installed, willow also marks branches whose latest PR was merged on GitHub via squash/rebase, even if the branch tip is not an ancestor of the base branch. The tmux picker uses cached GitHub merge results on open so slow PR lookups don't block rendering.
+Smart switch-or-create. If a worktree exists for the branch, switch to it. If the branch exists on the remote, create a worktree for it. Otherwise, create a new branch and worktree. Worktrees whose exact current-head PR is merged show a `[merged]` indicator in `ww ls` and the tmux picker. The tmux picker uses cached GitHub PR-state results on open so slow PR lookups don't block rendering.
 
 ```bash
 ww checkout auth-refactor                # switch if exists, create if not
@@ -358,7 +358,7 @@ ww rm auth-refactor --prune      # also run git worktree prune
 
 ### `ww ls [repo]`
 
-List worktrees with status. Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and merged worktrees at the bottom. GitHub-backed merged markers use cached data so `ww ls` stays fast in large repos.
+List worktrees with status. Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and PR-merged worktrees at the bottom. GitHub-backed merged markers use cached exact PR-state data so `ww ls` stays fast in large repos.
 
 ![ww ls](screenshots/demo-ls.gif)
 

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -85,9 +86,10 @@ func gcCmd() *cli.Command {
 				}
 
 				baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
-				branches := make([]string, 0, len(wts))
 				branchHeads := make(map[string]string, len(wts))
+				branchBases := make(map[string]string, len(wts))
 				repoDir := ""
+				st := stack.Load(bareDir)
 				for _, wt := range wts {
 					if wt.IsBare || wt.Detached || wt.Branch == "" {
 						continue
@@ -95,14 +97,13 @@ func gcCmd() *cli.Command {
 					if repoDir == "" {
 						repoDir = wt.Path
 					}
-					branches = append(branches, wt.Branch)
 					branchHeads[wt.Branch] = wt.Head
+					if parent := st.Parent(wt.Branch); parent != "" {
+						branchBases[wt.Branch] = parent
+					}
 				}
 
-				mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
-				for branch := range gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads) {
-					mergedSet[branch] = true
-				}
+				mergedSet := gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
 				if len(mergedSet) == 0 {
 					continue
 				}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -343,7 +343,16 @@ func captureStderr(t *testing.T, fn func() error) (string, error) {
 }
 
 func installMergedStatusGH(t *testing.T, baseBranch, branch, headOID string) string {
+	return installPRStatusGH(t, baseBranch, branch, headOID, "MERGED")
+}
+
+func installPRStatusGH(t *testing.T, baseBranch, branch, headOID, state string) string {
 	t.Helper()
+
+	mergedAt := ""
+	if state == "MERGED" {
+		mergedAt = "2026-04-21T18:08:47Z"
+	}
 
 	script := fmt.Sprintf(`#!/bin/sh
 set -eu
@@ -368,7 +377,7 @@ if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
 
   case "$search" in
     *"head:%s"*)
-      printf '[{"number":42,"title":"Merged PR","headRefName":"%s","headRefOid":"%s","baseRefName":"%s","state":"MERGED","mergedAt":"2026-04-21T18:08:47Z","reviewDecision":"","mergeable":"MERGEABLE","additions":0,"deletions":0,"url":"https://github.com/test/repo/pull/42","statusCheckRollup":[]}]\n'
+      printf '[{"number":42,"title":"Test PR","headRefName":"%s","headRefOid":"%s","baseRefName":"%s","state":"%s","mergedAt":"%s","reviewDecision":"","mergeable":"MERGEABLE","additions":0,"deletions":0,"url":"https://github.com/test/repo/pull/42","statusCheckRollup":[]}]\n'
       ;;
     *)
       printf '[]\n'
@@ -379,7 +388,7 @@ fi
 
 printf 'unsupported gh invocation: %%s\n' "$*" >&2
 exit 1
-`, branch, branch, headOID, baseBranch)
+`, branch, branch, headOID, baseBranch, state, mergedAt)
 
 	_, logPath := installTestCLIPath(t, script)
 	return logPath
@@ -2105,6 +2114,101 @@ func TestMergedWorktrees_UsesGitHubMergedPRsAcrossCLI(t *testing.T) {
 	mergedSet := mergedBranchSetForRepo("mergedrepo", bareDir, filterBareWorktrees(wts))
 	if !mergedSet["feature-merged"] {
 		t.Fatalf("expected sw merged helper to include feature-merged, got %v", mergedSet)
+	}
+}
+
+func TestMergedWorktrees_OpenPRDoesNotMarkMergedAcrossCLI(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "openprrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "openprrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	baseBranch := entries[0].Name()
+	mainDir := filepath.Join(worktreeDir, baseBranch)
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "feature-open", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "feature-open")
+	commitFile(t, featureDir, "feature.txt", "feature\n", "add feature")
+
+	headOID, err := (&git.Git{Dir: featureDir}).Run("rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	installPRStatusGH(t, baseBranch, "feature-open", strings.TrimSpace(headOID), "OPEN")
+
+	gcOut, err := captureStdout(t, func() error {
+		return runApp("gc")
+	})
+	if err != nil {
+		t.Fatalf("gc failed: %v", err)
+	}
+	if strings.Contains(gcOut, "feature-open (repo: openprrepo)") {
+		t.Fatalf("open PR worktree should not be offered as merged, got:\n%s", gcOut)
+	}
+
+	bareDir := filepath.Join(home, ".willow", "repos", "openprrepo.git")
+	wts, err := worktree.List(&git.Git{Dir: bareDir})
+	if err != nil {
+		t.Fatalf("list worktrees: %v", err)
+	}
+	mergedSet := mergedBranchSetForRepo("openprrepo", bareDir, filterBareWorktrees(wts))
+	if mergedSet["feature-open"] {
+		t.Fatalf("open PR worktree should not be merged, got %v", mergedSet)
+	}
+}
+
+func TestMergedWorktrees_GitMergedBranchWithoutPRIsNotMerged(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "gitmergedrepo"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	worktreeDir := filepath.Join(home, ".willow", "worktrees", "gitmergedrepo")
+	entries, _ := os.ReadDir(worktreeDir)
+	baseBranch := entries[0].Name()
+	mainDir := filepath.Join(worktreeDir, baseBranch)
+	os.Chdir(mainDir)
+
+	if err := runApp("new", "manual-merged", "--no-fetch"); err != nil {
+		t.Fatalf("new failed: %v", err)
+	}
+
+	featureDir := filepath.Join(worktreeDir, "manual-merged")
+	commitFile(t, featureDir, "feature.txt", "feature\n", "add feature")
+	os.Chdir(mainDir)
+	if _, err := (&git.Git{Dir: mainDir}).Run("merge", "--no-ff", "manual-merged", "-m", "merge manual"); err != nil {
+		t.Fatalf("merge manual-merged: %v", err)
+	}
+	if _, err := (&git.Git{Dir: mainDir}).Run("push", "origin", baseBranch); err != nil {
+		t.Fatalf("push merged base: %v", err)
+	}
+
+	bareDir := filepath.Join(home, ".willow", "repos", "gitmergedrepo.git")
+	repoGit := &git.Git{Dir: bareDir}
+	gitMerged := repoGit.MergedBranchSet(baseBranch, []string{"manual-merged"})
+	if !gitMerged["manual-merged"] {
+		t.Fatalf("manual-merged should be git-merged in this regression setup, got %v", gitMerged)
+	}
+
+	installTestCLIPath(t, "")
+	gcOut, err := captureStdout(t, func() error {
+		return runApp("gc")
+	})
+	if err != nil {
+		t.Fatalf("gc failed: %v", err)
+	}
+	if strings.Contains(gcOut, "manual-merged (repo: gitmergedrepo)") {
+		t.Fatalf("git-only merged worktree should not be offered as PR-merged, got:\n%s", gcOut)
 	}
 }
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -212,26 +212,22 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
 
 	st := stack.Load(repoGit.Dir)
-	branches := make([]string, 0, len(worktrees))
 	branchHeads := make(map[string]string, len(worktrees))
+	branchBases := make(map[string]string, len(worktrees))
 	repoDir := ""
 	for _, wt := range worktrees {
 		if repoDir == "" {
 			repoDir = wt.Path
 		}
 		if wt.Branch != "" && !wt.Detached {
-			branches = append(branches, wt.Branch)
 			branchHeads[wt.Branch] = wt.Head
+			if parent := st.Parent(wt.Branch); parent != "" {
+				branchBases[wt.Branch] = parent
+			}
 		}
 	}
-	done := trace.Span(ctx, "git.MergedBranchSet")
-	mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
-	done()
-
-	done = trace.Span(ctx, "gh.CachedMergedWorktreeSet")
-	for branch := range gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads) {
-		mergedSet[branch] = true
-	}
+	done := trace.Span(ctx, "gh.CachedMergedWorktreeSet")
+	mergedSet := gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
 	done()
 
 	var rows []lsRow

--- a/internal/cli/sw.go
+++ b/internal/cli/sw.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/parallel"
+	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -265,30 +266,29 @@ func mergedBranchSetForRepo(repoName, bareDir string, worktrees []worktree.Workt
 		bareDir = resolved
 	}
 
-	branches := make([]string, 0, len(worktrees))
 	branchHeads := make(map[string]string, len(worktrees))
+	branchBases := make(map[string]string, len(worktrees))
 	repoDir := ""
+	st := stack.Load(bareDir)
 	for _, wt := range worktrees {
 		if wt.Branch != "" && !wt.Detached {
 			if repoDir == "" {
 				repoDir = wt.Path
 			}
-			branches = append(branches, wt.Branch)
 			branchHeads[wt.Branch] = wt.Head
+			if parent := st.Parent(wt.Branch); parent != "" {
+				branchBases[wt.Branch] = parent
+			}
 		}
 	}
-	if len(branches) == 0 {
+	if len(branchHeads) == 0 {
 		return map[string]bool{}
 	}
 
 	repoGit := &git.Git{Dir: bareDir}
 	cfg := config.Load(bareDir)
 	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
-	mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
-	for branch := range gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads) {
-		mergedSet[branch] = true
-	}
-	return mergedSet
+	return gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
 }
 
 func fzfPickWorktree(worktrees []worktree.Worktree, repoName string) (string, error) {

--- a/internal/gh/merged.go
+++ b/internal/gh/merged.go
@@ -15,11 +15,12 @@ import (
 )
 
 const (
-	mergedWorktreeCacheTTL  = 30 * time.Second
-	mergedWorktreeBatchSize = 20
-	mergedWorktreeCacheDir  = "merged-worktrees"
-	mergedWorktreeSearchCap = 100
-	detachedBranchName      = "(detached)"
+	mergedWorktreeCacheVersion = 2
+	mergedWorktreeCacheTTL     = 30 * time.Second
+	mergedWorktreeBatchSize    = 20
+	mergedWorktreeCacheDir     = "merged-worktrees"
+	mergedWorktreeSearchCap    = 100
+	detachedBranchName         = "(detached)"
 )
 
 type mergedWorktreeCacheEntry struct {
@@ -33,7 +34,14 @@ type mergedWorktreeCacheEntry struct {
 }
 
 type mergedWorktreeCache struct {
+	Version int                                 `json:"version"`
 	Entries map[string]mergedWorktreeCacheEntry `json:"entries"`
+}
+
+type mergeCandidate struct {
+	branch string
+	head   string
+	base   string
 }
 
 var (
@@ -46,139 +54,160 @@ var (
 	mergedWorktreeRepoKey   = repoCacheKey
 )
 
-// MergedWorktreeSet returns branches whose worktrees are safe to treat as
-// merged based on GitHub PR state. It is designed to augment git ancestry-
-// based merged detection and silently falls back to an empty set when `gh`
-// is unavailable or GitHub lookup fails.
-func MergedWorktreeSet(dir, base string, branchHeads map[string]string) map[string]bool {
+// MergedWorktreeSet returns branches whose current worktree heads have exact
+// merged PRs on GitHub. It deliberately does not use git ancestry: in Willow,
+// `[merged]` is a PR lifecycle signal, not a reachability signal.
+func MergedWorktreeSet(dir, defaultBase string, branchHeads, branchBases map[string]string) map[string]bool {
+	return mergedWorktreeSet(dir, defaultBase, branchHeads, branchBases, true)
+}
+
+// CachedMergedWorktreeSet returns fresh merged branches from the on-disk
+// GitHub lookup cache only. It never shells out to gh, so interactive pickers
+// can use it without putting network-backed PR lookups on their initial render
+// path. Stale positives are ignored rather than risk showing a false
+// `[merged]` tag for a reused branch.
+func CachedMergedWorktreeSet(dir, defaultBase string, branchHeads, branchBases map[string]string) map[string]bool {
+	return mergedWorktreeSet(dir, defaultBase, branchHeads, branchBases, false)
+}
+
+func mergedWorktreeSet(dir, defaultBase string, branchHeads, branchBases map[string]string, refresh bool) map[string]bool {
 	set := make(map[string]bool)
-	if dir == "" || len(branchHeads) == 0 || !mergedWorktreeCLI() {
+	candidates := mergedCandidates(defaultBase, branchHeads, branchBases)
+	if dir == "" || len(candidates) == 0 {
 		return set
 	}
 
 	now := mergedWorktreeNow()
-	cachePath := mergedWorktreeCachePath(dir, base)
+	cachePath := mergedWorktreeCachePath(dir, defaultBase)
 	cache := loadMergedWorktreeCache(cachePath)
 
-	eligibleHeads := make(map[string]string, len(branchHeads))
-	var pending []string
-	for branch, head := range branchHeads {
-		if branch == "" || branch == base || branch == detachedBranchName || head == "" {
-			continue
-		}
-
-		eligibleHeads[branch] = head
-		entry, ok := cache.Entries[branch]
-		if ok && now.Sub(entry.CheckedAt) < mergedWorktreeCacheTTL {
-			if entry.isMerged(base, head) {
-				set[branch] = true
+	var pending []mergeCandidate
+	for _, candidate := range candidates {
+		entry, ok := cache.Entries[candidate.branch]
+		if ok && entry.isFreshFor(candidate, now) {
+			if entry.isMerged(candidate) {
+				set[candidate.branch] = true
 			}
 			continue
 		}
 
-		pending = append(pending, branch)
+		pending = append(pending, candidate)
 	}
 
-	if len(pending) == 0 {
+	if !refresh || len(pending) == 0 || !mergedWorktreeCLI() {
 		return set
 	}
 
-	sort.Strings(pending)
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].branch < pending[j].branch
+	})
 	updated, _ := refreshMergedWorktreeCache(cache, dir, pending, now)
 	_ = saveMergedWorktreeCache(cachePath, updated)
 
-	for branch, head := range eligibleHeads {
-		entry, ok := updated.Entries[branch]
-		if !ok || now.Sub(entry.CheckedAt) >= mergedWorktreeCacheTTL {
+	for _, candidate := range candidates {
+		entry, ok := updated.Entries[candidate.branch]
+		if !ok || !entry.isFreshFor(candidate, now) {
 			continue
 		}
-		if entry.isMerged(base, head) {
-			set[branch] = true
+		if entry.isMerged(candidate) {
+			set[candidate.branch] = true
 		}
 	}
 
 	return set
 }
 
-// CachedMergedWorktreeSet returns merged branches from the on-disk GitHub
-// lookup cache only. It never shells out to gh, so interactive pickers can use
-// it without putting network-backed PR lookups on their initial render path.
-func CachedMergedWorktreeSet(dir, base string, branchHeads map[string]string) map[string]bool {
-	set := make(map[string]bool)
-	if dir == "" || len(branchHeads) == 0 {
-		return set
-	}
-
-	cache := loadMergedWorktreeCache(mergedWorktreeCachePath(dir, base))
+func mergedCandidates(defaultBase string, branchHeads, branchBases map[string]string) []mergeCandidate {
+	candidates := make([]mergeCandidate, 0, len(branchHeads))
 	for branch, head := range branchHeads {
-		if branch == "" || branch == base || branch == detachedBranchName || head == "" {
+		base := defaultBase
+		if branchBases != nil && branchBases[branch] != "" {
+			base = branchBases[branch]
+		}
+		if branch == "" || branch == base || branch == detachedBranchName || head == "" || base == "" {
 			continue
 		}
-		entry, ok := cache.Entries[branch]
-		if ok && entry.isMerged(base, head) {
-			set[branch] = true
-		}
+		candidates = append(candidates, mergeCandidate{branch: branch, head: head, base: base})
 	}
-	return set
+	return candidates
 }
 
-func (e mergedWorktreeCacheEntry) isMerged(base, head string) bool {
+func (e mergedWorktreeCacheEntry) isFreshFor(candidate mergeCandidate, now time.Time) bool {
+	return now.Sub(e.CheckedAt) < mergedWorktreeCacheTTL &&
+		e.BaseRefName == candidate.base &&
+		e.HeadRefOID == candidate.head
+}
+
+func (e mergedWorktreeCacheEntry) isMerged(candidate mergeCandidate) bool {
 	return e.Found &&
 		e.State == "MERGED" &&
-		e.BaseRefName == base &&
-		e.HeadRefOID == head
+		e.BaseRefName == candidate.base &&
+		e.HeadRefOID == candidate.head
 }
 
-func refreshMergedWorktreeCache(cache mergedWorktreeCache, dir string, branches []string, now time.Time) (mergedWorktreeCache, error) {
+func refreshMergedWorktreeCache(cache mergedWorktreeCache, dir string, candidates []mergeCandidate, now time.Time) (mergedWorktreeCache, error) {
 	updated := cache.clone()
 
-	for start := 0; start < len(branches); start += mergedWorktreeBatchSize {
+	for start := 0; start < len(candidates); start += mergedWorktreeBatchSize {
 		end := start + mergedWorktreeBatchSize
-		if end > len(branches) {
-			end = len(branches)
+		if end > len(candidates) {
+			end = len(candidates)
 		}
 
-		batch := branches[start:end]
-		prs, err := mergedWorktreeSearchPRs(dir, batch)
+		batch := candidates[start:end]
+		prs, err := mergedWorktreeSearchPRs(dir, candidateBranches(batch))
 		if err != nil {
 			return updated, err
 		}
 
-		latest := latestPRsByBranch(batch, prs)
-		for _, branch := range batch {
-			entry := mergedWorktreeCacheEntry{CheckedAt: now}
-			if pr := latest[branch]; pr != nil {
+		for _, candidate := range batch {
+			entry := mergedWorktreeCacheEntry{
+				CheckedAt:   now,
+				BaseRefName: candidate.base,
+				HeadRefOID:  candidate.head,
+			}
+			if pr := selectExactPR(candidate, prs); pr != nil {
 				entry.Found = true
 				entry.Number = pr.Number
 				entry.State = pr.State
-				entry.BaseRefName = pr.BaseRefName
-				entry.HeadRefOID = pr.HeadRefOID
 				entry.MergedAt = pr.MergedAt
 			}
-			updated.Entries[branch] = entry
+			updated.Entries[candidate.branch] = entry
 		}
 	}
 
 	return updated, nil
 }
 
-func latestPRsByBranch(branches []string, prs []*PRInfo) map[string]*PRInfo {
-	branchSet := make(map[string]bool, len(branches))
-	for _, branch := range branches {
-		branchSet[branch] = true
+func candidateBranches(candidates []mergeCandidate) []string {
+	branches := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		branches = append(branches, candidate.branch)
 	}
+	return branches
+}
 
-	latest := make(map[string]*PRInfo, len(branches))
+func selectExactPR(candidate mergeCandidate, prs []*PRInfo) *PRInfo {
+	var selected *PRInfo
 	for _, pr := range prs {
-		if pr == nil || !branchSet[pr.Branch] {
+		if pr == nil ||
+			pr.Branch != candidate.branch ||
+			pr.HeadRefOID != candidate.head ||
+			pr.BaseRefName != candidate.base {
 			continue
 		}
-		if current := latest[pr.Branch]; current == nil || pr.Number > current.Number {
-			latest[pr.Branch] = pr
+		if betterExactPR(pr, selected) {
+			selected = pr
 		}
 	}
+	return selected
+}
 
-	return latest
+func betterExactPR(candidate, current *PRInfo) bool {
+	if current == nil {
+		return true
+	}
+	return candidate.Number > current.Number
 }
 
 func searchPRsByBranches(dir string, branches []string) ([]*PRInfo, error) {
@@ -234,7 +263,8 @@ func headSearchTerm(branch string) string {
 }
 
 func mergedWorktreeCachePath(dir, base string) string {
-	sum := sha256.Sum256([]byte(mergedWorktreeRepoKey(dir) + "\x00" + base))
+	key := fmt.Sprintf("v%d\x00%s\x00%s", mergedWorktreeCacheVersion, mergedWorktreeRepoKey(dir), base)
+	sum := sha256.Sum256([]byte(key))
 	return filepath.Join(config.WillowHome(), "cache", mergedWorktreeCacheDir, fmt.Sprintf("%x.json", sum[:]))
 }
 
@@ -259,12 +289,15 @@ func repoCacheKey(dir string) string {
 func loadMergedWorktreeCache(path string) mergedWorktreeCache {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return mergedWorktreeCache{Entries: make(map[string]mergedWorktreeCacheEntry)}
+		return emptyMergedWorktreeCache()
 	}
 
 	var cache mergedWorktreeCache
 	if err := json.Unmarshal(data, &cache); err != nil {
-		return mergedWorktreeCache{Entries: make(map[string]mergedWorktreeCacheEntry)}
+		return emptyMergedWorktreeCache()
+	}
+	if cache.Version != mergedWorktreeCacheVersion {
+		return emptyMergedWorktreeCache()
 	}
 	if cache.Entries == nil {
 		cache.Entries = make(map[string]mergedWorktreeCacheEntry)
@@ -277,6 +310,7 @@ func saveMergedWorktreeCache(path string, cache mergedWorktreeCache) error {
 		return err
 	}
 
+	cache.Version = mergedWorktreeCacheVersion
 	data, err := json.Marshal(cache)
 	if err != nil {
 		return err
@@ -305,10 +339,18 @@ func saveMergedWorktreeCache(path string, cache mergedWorktreeCache) error {
 
 func (c mergedWorktreeCache) clone() mergedWorktreeCache {
 	cloned := mergedWorktreeCache{
+		Version: mergedWorktreeCacheVersion,
 		Entries: make(map[string]mergedWorktreeCacheEntry, len(c.Entries)),
 	}
 	for branch, entry := range c.Entries {
 		cloned.Entries[branch] = entry
 	}
 	return cloned
+}
+
+func emptyMergedWorktreeCache() mergedWorktreeCache {
+	return mergedWorktreeCache{
+		Version: mergedWorktreeCacheVersion,
+		Entries: make(map[string]mergedWorktreeCacheEntry),
+	}
 }

--- a/internal/gh/merged_test.go
+++ b/internal/gh/merged_test.go
@@ -91,11 +91,129 @@ func TestMergedWorktreeSet_MergeEligibility(t *testing.T) {
 
 			got := MergedWorktreeSet("/fake/repo", tt.base, map[string]string{
 				tt.branch: tt.head,
-			})
+			}, nil)
 			if got[tt.branch] != tt.wantMerged {
 				t.Fatalf("MergedWorktreeSet()[%q] = %v, want %v", tt.branch, got[tt.branch], tt.wantMerged)
 			}
 		})
+	}
+}
+
+func TestMergedWorktreeSet_ExactOpenPRBeatsOlderMergedPR(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+
+	prepareMergedWorktreeTestEnv(t, now, func(_ string, branches []string) ([]*PRInfo, error) {
+		if len(branches) != 1 || branches[0] != "feature" {
+			t.Fatalf("search branches = %v, want [feature]", branches)
+		}
+		return []*PRInfo{
+			{
+				Number:      101,
+				Branch:      "feature",
+				HeadRefOID:  "abc123",
+				BaseRefName: "master",
+				State:       "MERGED",
+				MergedAt:    "2026-04-21T18:08:47Z",
+			},
+			{
+				Number:      102,
+				Branch:      "feature",
+				HeadRefOID:  "def456",
+				BaseRefName: "master",
+				State:       "OPEN",
+			},
+		}, nil
+	})
+
+	got := MergedWorktreeSet("/fake/repo", "master", map[string]string{
+		"feature": "def456",
+	}, nil)
+	if got["feature"] {
+		t.Fatalf("open current-head PR should not be marked merged, got %v", got)
+	}
+}
+
+func TestMergedWorktreeSet_ExactNonMergedPRBeatsSameHeadMergedPR(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+
+	prepareMergedWorktreeTestEnv(t, now, func(_ string, _ []string) ([]*PRInfo, error) {
+		return []*PRInfo{
+			{
+				Number:      101,
+				Branch:      "feature",
+				HeadRefOID:  "abc123",
+				BaseRefName: "master",
+				State:       "MERGED",
+				MergedAt:    "2026-04-21T18:08:47Z",
+			},
+			{
+				Number:      102,
+				Branch:      "feature",
+				HeadRefOID:  "abc123",
+				BaseRefName: "master",
+				State:       "OPEN",
+			},
+		}, nil
+	})
+
+	got := MergedWorktreeSet("/fake/repo", "master", map[string]string{
+		"feature": "abc123",
+	}, nil)
+	if got["feature"] {
+		t.Fatalf("exact non-merged PR should win over older merged PR, got %v", got)
+	}
+}
+
+func TestMergedWorktreeSet_NewerMergedPRBeatsOlderClosedPR(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+
+	prepareMergedWorktreeTestEnv(t, now, func(_ string, _ []string) ([]*PRInfo, error) {
+		return []*PRInfo{
+			{
+				Number:      101,
+				Branch:      "feature",
+				HeadRefOID:  "abc123",
+				BaseRefName: "master",
+				State:       "CLOSED",
+			},
+			{
+				Number:      102,
+				Branch:      "feature",
+				HeadRefOID:  "abc123",
+				BaseRefName: "master",
+				State:       "MERGED",
+				MergedAt:    "2026-04-21T18:08:47Z",
+			},
+		}, nil
+	})
+
+	got := MergedWorktreeSet("/fake/repo", "master", map[string]string{
+		"feature": "abc123",
+	}, nil)
+	if !got["feature"] {
+		t.Fatalf("newer exact merged PR should win over older closed PR, got %v", got)
+	}
+}
+
+func TestMergedWorktreeSet_UsesBranchSpecificBase(t *testing.T) {
+	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
+
+	prepareMergedWorktreeTestEnv(t, now, func(_ string, _ []string) ([]*PRInfo, error) {
+		return []*PRInfo{{
+			Number:      101,
+			Branch:      "feature-b",
+			HeadRefOID:  "sha-b",
+			BaseRefName: "feature-a",
+			State:       "MERGED",
+			MergedAt:    "2026-04-21T18:08:47Z",
+		}}, nil
+	})
+
+	got := MergedWorktreeSet("/fake/repo", "master", map[string]string{
+		"feature-b": "sha-b",
+	}, map[string]string{"feature-b": "feature-a"})
+	if !got["feature-b"] {
+		t.Fatalf("expected branch-specific base to match merged PR, got %v", got)
 	}
 }
 
@@ -112,8 +230,8 @@ func TestMergedWorktreeSet_NegativeResultsAreCached(t *testing.T) {
 	})
 
 	heads := map[string]string{"feature": "abc123"}
-	first := MergedWorktreeSet("/fake/repo", "master", heads)
-	second := MergedWorktreeSet("/fake/repo", "master", heads)
+	first := MergedWorktreeSet("/fake/repo", "master", heads, nil)
+	second := MergedWorktreeSet("/fake/repo", "master", heads, nil)
 
 	if len(first) != 0 || len(second) != 0 {
 		t.Fatalf("expected no merged branches, got first=%v second=%v", first, second)
@@ -141,7 +259,7 @@ func TestMergedWorktreeSet_FreshCacheIsReused(t *testing.T) {
 
 	heads := map[string]string{"feature": "abc123"}
 	for i := 0; i < 2; i++ {
-		got := MergedWorktreeSet("/fake/repo", "master", heads)
+		got := MergedWorktreeSet("/fake/repo", "master", heads, nil)
 		if !got["feature"] {
 			t.Fatalf("call %d: expected feature to be merged, got %v", i+1, got)
 		}
@@ -175,12 +293,12 @@ func TestMergedWorktreeSet_StaleCacheRefreshes(t *testing.T) {
 	mergedWorktreeNow = func() time.Time { return current }
 	heads := map[string]string{"feature": "abc123"}
 
-	if got := MergedWorktreeSet("/fake/repo", "master", heads); got["feature"] {
+	if got := MergedWorktreeSet("/fake/repo", "master", heads, nil); got["feature"] {
 		t.Fatalf("first call unexpectedly marked feature merged: %v", got)
 	}
 
 	current = start.Add(mergedWorktreeCacheTTL + time.Second)
-	got := MergedWorktreeSet("/fake/repo", "master", heads)
+	got := MergedWorktreeSet("/fake/repo", "master", heads, nil)
 	if !got["feature"] {
 		t.Fatalf("expected stale cache refresh to mark feature merged, got %v", got)
 	}
@@ -229,7 +347,7 @@ func TestMergedWorktreeSet_MissingBranchEntriesRefreshIndividually(t *testing.T)
 
 	first := MergedWorktreeSet("/fake/repo", "master", map[string]string{
 		"feature-a": "sha-a",
-	})
+	}, nil)
 	if !first["feature-a"] {
 		t.Fatalf("expected feature-a to be merged, got %v", first)
 	}
@@ -237,7 +355,7 @@ func TestMergedWorktreeSet_MissingBranchEntriesRefreshIndividually(t *testing.T)
 	second := MergedWorktreeSet("/fake/repo", "master", map[string]string{
 		"feature-a": "sha-a",
 		"feature-b": "sha-b",
-	})
+	}, nil)
 	if !second["feature-a"] || !second["feature-b"] {
 		t.Fatalf("expected both branches merged after refresh, got %v", second)
 	}
@@ -246,7 +364,7 @@ func TestMergedWorktreeSet_MissingBranchEntriesRefreshIndividually(t *testing.T)
 	}
 }
 
-func TestCachedMergedWorktreeSet_UsesStalePositiveCacheWithoutRefreshing(t *testing.T) {
+func TestCachedMergedWorktreeSet_IgnoresStalePositiveCacheWithoutRefreshing(t *testing.T) {
 	now := time.Date(2026, 4, 21, 18, 30, 0, 0, time.UTC)
 	calls := 0
 
@@ -272,9 +390,9 @@ func TestCachedMergedWorktreeSet_UsesStalePositiveCacheWithoutRefreshing(t *test
 		t.Fatalf("save cache: %v", err)
 	}
 
-	got := CachedMergedWorktreeSet("/fake/repo", "master", map[string]string{"feature": "abc123"})
-	if !got["feature"] {
-		t.Fatalf("expected cached merged branch, got %v", got)
+	got := CachedMergedWorktreeSet("/fake/repo", "master", map[string]string{"feature": "abc123"}, nil)
+	if got["feature"] {
+		t.Fatalf("stale cached merged branch should be ignored, got %v", got)
 	}
 	if calls != 0 {
 		t.Fatalf("search calls = %d, want 0", calls)

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -122,31 +122,27 @@ func buildPickerItemsForRepo(ctx context.Context, repoName string, sessionSet ma
 
 	cfg := config.Load(bareDir)
 	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
-	branches := make([]string, 0, len(wts))
 	branchHeads := make(map[string]string, len(wts))
+	branchBases := make(map[string]string, len(wts))
 	repoDir := ""
 	for _, wt := range wts {
 		if !wt.IsBare && !wt.Detached && wt.Branch != "" {
 			if repoDir == "" {
 				repoDir = wt.Path
 			}
-			branches = append(branches, wt.Branch)
 			branchHeads[wt.Branch] = wt.Head
+			if parent := result.stack.Parent(wt.Branch); parent != "" {
+				branchBases[wt.Branch] = parent
+			}
 		}
 	}
-	done = trace.Span(ctx, "git.MergedBranchSet/"+repoName)
-	mergedSet := repoGit.MergedBranchSet(baseBranch, branches)
-	done()
 
 	done = trace.Span(ctx, "gh.MergedWorktreeSet/"+repoName)
-	var githubMerged map[string]bool
+	var mergedSet map[string]bool
 	if opts.RefreshGitHubMerged {
-		githubMerged = gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads)
+		mergedSet = gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
 	} else {
-		githubMerged = gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads)
-	}
-	for branch := range githubMerged {
-		mergedSet[branch] = true
+		mergedSet = gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
 	}
 	done()
 

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -221,7 +221,7 @@ List worktrees with status.
   old-feature          --      <willow-base>/worktrees/myrepo/old-feature  5m
 ```
 
-Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and merged worktrees at the bottom. GitHub-backed merged markers use cached data so `ww ls` does not refresh GitHub on the hot path.
+Uses the same urgency ordering as `ww sw`, while keeping stacked branches together and PR-merged worktrees at the bottom. GitHub-backed merged markers use cached exact PR-state data so `ww ls` does not refresh GitHub on the hot path.
 
 When run outside a willow repo, lists all repos and their worktree counts.
 
@@ -405,10 +405,10 @@ ww log --json                   # raw JSON output
 
 ### `ww gc`
 
-Clean up leftover trash from removed worktrees and, optionally, prune worktrees whose branches have been merged into the base branch.
+Clean up leftover trash from removed worktrees and, optionally, prune worktrees whose exact current-head PRs are merged.
 
 ```bash
-ww gc                    # empty <willow-base>/trash/ and list merged worktrees
+ww gc                    # empty <willow-base>/trash/ and list PR-merged worktrees
 ww gc --prune            # also interactively remove merged worktrees
 ww gc --dry-run          # preview without touching anything
 ww gc --prune --dry-run  # list what --prune would remove
@@ -419,7 +419,7 @@ ww gc --prune --dry-run  # list what --prune would remove
 | `--prune` | Interactively remove merged worktrees | `false` |
 | `--dry-run` | Show what would be cleaned up without removing anything | `false` |
 
-Without `--prune`, willow only empties the trash directory and prints the commands you'd run to remove each merged worktree. With `--prune`, it checks both Git ancestry and, when `gh` is available, merged GitHub PR state so squash/rebase-merged branches still show up for cleanup. If `gh` is missing or lookup fails, willow falls back to Git-only detection.
+Without `--prune`, willow only empties the trash directory and prints the commands you'd run to remove each merged worktree. With `--prune`, it checks GitHub PR state and only treats a worktree as merged when the PR head branch, head SHA, and expected base branch match the current worktree. If `gh` is missing or lookup fails, willow skips merged detection instead of falling back to Git ancestry.
 
 ## Agents
 

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -78,16 +78,16 @@ Press `Ctrl-E` to open a secondary picker showing all remote branches that don't
 
 ### Merged worktree indicator
 
-Worktrees whose branches have been merged into the base branch show a dim `[merged]` tag. When `gh` is available, this also covers branches whose latest PR was merged on GitHub via squash/rebase. The picker uses cached GitHub merge results on open so slow PR lookups don't block rendering. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session and any merged worktrees with local changes, unpushed commits, or stacked children are skipped), or use `ww gc --prune`.
+Worktrees whose exact current-head PR is merged show a dim `[merged]` tag. Willow matches the PR head branch, head SHA, and expected base branch, using stack parents as the base for stacked branches. The picker uses cached GitHub PR-state results on open so slow PR lookups don't block rendering. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session and any merged worktrees with local changes, unpushed commits, or stacked children are skipped), or use `ww gc --prune`.
 
 ### Features
 
-- **Fast startup** — opens from local git/status files and cached GitHub merge results
+- **Fast startup** — opens from local git/status files and cached GitHub PR-state results
 - **Auto-navigate** — opens with the cursor on your current session
 - **Urgency sort** — current session first, then `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline
 - **Status colors** — BUSY (green), WAIT (red), DONE (blue), IDLE (yellow)
 - **Unread indicator** — `●` marks completed sessions you haven't viewed
-- **Merged indicator** — `[merged]` marks worktrees whose branches are merged, including cached GitHub-merged PRs when `gh` is available
+- **Merged indicator** — `[merged]` marks worktrees whose exact current-head PR is merged when `gh` data is available
 - **Stack-aware ordering** — stacked branches stay grouped together and inherit the most urgent item in the tree
 - **Multi-Claude sub-rows** — when a worktree has multiple active Claude sessions, each is shown as an indented sub-row with its own status and tool info
 - **Embedded fzf** — fzf is compiled into the willow binary, no external `fzf` dependency needed


### PR DESCRIPTION
## Description of the change
Make Willow’s `[merged]` indicator PR-state only. Exact current-head merged PRs now drive the tag across tmux, ls, sw, dashboard, and gc; Git ancestry is no longer used as a fallback. This also versions the merge-status cache and updates docs.

Codex assisted with implementation and validation.

## Test plan
Go test suite and website production build.

- `go test ./... -count=1`
- `pnpm install --frozen-lockfile`
- `pnpm build`
- `git diff --check`

## Considerations
`[merged]` now intentionally omits manually merged branches without matching GitHub PR state.