### PR TITLE
:zap: perf[cli]: reduce willow benchmark latency

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/errors"
@@ -31,6 +33,65 @@ func resolveRepoFromCwd() (string, bool) {
 		return "", false
 	}
 	return config.ResolveRepoFromDir(cwd)
+}
+
+func resolveRepoFromGitMetadataCwd() (bareDir string, isWillow bool, foundGit bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false, false
+	}
+
+	for {
+		if commonDir, ok := commonDirFromGitMetadata(cwd); ok {
+			return commonDir, config.IsWillowRepo(commonDir), true
+		}
+
+		parent := filepath.Dir(cwd)
+		if parent == cwd {
+			return "", false, false
+		}
+		cwd = parent
+	}
+}
+
+func commonDirFromGitMetadata(dir string) (string, bool) {
+	gitPath := filepath.Join(dir, ".git")
+	info, err := os.Stat(gitPath)
+	if err != nil {
+		return "", false
+	}
+
+	gitDir := gitPath
+	if !info.IsDir() {
+		data, err := os.ReadFile(gitPath)
+		if err != nil {
+			return "", false
+		}
+		line := strings.TrimSpace(string(data))
+		rawGitDir, ok := strings.CutPrefix(line, "gitdir:")
+		if !ok {
+			return "", false
+		}
+		gitDir = strings.TrimSpace(rawGitDir)
+		if gitDir == "" {
+			return "", false
+		}
+		if !filepath.IsAbs(gitDir) {
+			gitDir = filepath.Join(dir, gitDir)
+		}
+	}
+
+	commonDir := gitDir
+	if data, err := os.ReadFile(filepath.Join(gitDir, "commondir")); err == nil {
+		value := strings.TrimSpace(string(data))
+		if value != "" {
+			commonDir = value
+			if !filepath.IsAbs(commonDir) {
+				commonDir = filepath.Join(gitDir, commonDir)
+			}
+		}
+	}
+	return filepath.Clean(commonDir), true
 }
 
 var version = "dev"

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveRepoFromGitMetadataCwdWillowWorktree(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("WILLOW_BASE_DIR", baseDir)
+
+	bareDir := filepath.Join(baseDir, "repos", "repo.git")
+	adminDir := filepath.Join(bareDir, "worktrees", "feature")
+	wtDir := filepath.Join(baseDir, "worktrees", "repo", "feature")
+	writeCLITestFile(t, filepath.Join(adminDir, "commondir"), "../..\n")
+	writeCLITestFile(t, filepath.Join(wtDir, ".git"), "gitdir: "+adminDir+"\n")
+	t.Chdir(wtDir)
+
+	got, isWillow, foundGit := resolveRepoFromGitMetadataCwd()
+	if !foundGit || !isWillow {
+		t.Fatalf("resolveRepoFromGitMetadataCwd() foundGit=%v isWillow=%v, want true/true", foundGit, isWillow)
+	}
+	if got != filepath.Clean(bareDir) {
+		t.Fatalf("bareDir = %q, want %q", got, filepath.Clean(bareDir))
+	}
+}
+
+func TestResolveRepoFromGitMetadataCwdNonWillowGitRepo(t *testing.T) {
+	baseDir := t.TempDir()
+	t.Setenv("WILLOW_BASE_DIR", baseDir)
+
+	repoDir := filepath.Join(t.TempDir(), "repo")
+	cwd := filepath.Join(repoDir, "subdir")
+	writeCLITestFile(t, filepath.Join(repoDir, ".git", "HEAD"), "ref: refs/heads/main\n")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir cwd: %v", err)
+	}
+	t.Chdir(cwd)
+
+	_, isWillow, foundGit := resolveRepoFromGitMetadataCwd()
+	if !foundGit || isWillow {
+		t.Fatalf("resolveRepoFromGitMetadataCwd() foundGit=%v isWillow=%v, want true/false", foundGit, isWillow)
+	}
+}
+
+func writeCLITestFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -57,11 +57,19 @@ func lsCmd() *cli.Command {
 				return listWorktrees(ctx, flags, cmd, &git.Git{Dir: bareDir, Verbose: g.Verbose})
 			}
 
-			bareDir, err := g.BareRepoDir()
-			if err == nil && config.IsWillowRepo(bareDir) {
+			if bareDir, ok := resolveRepoFromCwd(); ok {
 				return listWorktrees(ctx, flags, cmd, &git.Git{Dir: bareDir, Verbose: g.Verbose})
 			}
-			if bareDir, ok := resolveRepoFromCwd(); ok {
+			if !g.Verbose {
+				if bareDir, isWillow, foundGit := resolveRepoFromGitMetadataCwd(); isWillow {
+					return listWorktrees(ctx, flags, cmd, &git.Git{Dir: bareDir, Verbose: g.Verbose})
+				} else if foundGit {
+					return printRepoList(flags)
+				}
+			}
+
+			bareDir, err := g.BareRepoDir()
+			if err == nil && config.IsWillowRepo(bareDir) {
 				return listWorktrees(ctx, flags, cmd, &git.Git{Dir: bareDir, Verbose: g.Verbose})
 			}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -38,7 +38,7 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 	for _, wt := range worktrees {
 		wtDir := filepath.Base(wt.Path)
 		sessions := claude.ReadAllSessions(repoName, wtDir)
-		unread := claude.CountUnreadIn(repoName, wtDir, sessions) > 0
+		unread := hasDoneSession(sessions) && claude.CountUnreadIn(repoName, wtDir, sessions) > 0
 		if unread {
 			rs.UnreadCount++
 		}
@@ -84,6 +84,15 @@ func collectRepoStatus(repoName string, worktrees []worktree.Worktree) repoStatu
 		}
 	}
 	return rs
+}
+
+func hasDoneSession(sessions []*claude.SessionStatus) bool {
+	for _, ss := range sessions {
+		if ss.Status == claude.StatusDone {
+			return true
+		}
+	}
+	return false
 }
 
 func collectRepoStatuses(repos []repoInfo, verbose bool) []repoStatus {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -103,7 +103,7 @@ func collectRepoStatuses(repos []repoInfo, verbose bool) []repoStatus {
 
 	results := parallel.Map(repos, func(_ int, r repoInfo) result {
 		repoGit := &git.Git{Dir: r.BareDir, Verbose: verbose}
-		wts, err := worktree.List(repoGit)
+		wts, err := worktree.ListWithOptions(repoGit, worktree.ListOptions{ResolveHeads: false})
 		if err != nil {
 			return result{}
 		}

--- a/internal/gh/merged.go
+++ b/internal/gh/merged.go
@@ -269,6 +269,10 @@ func mergedWorktreeCachePath(dir, base string) string {
 }
 
 func repoCacheKey(dir string) string {
+	if key, ok := repoCacheKeyFromGitMetadata(dir); ok {
+		return key
+	}
+
 	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	cmd.Dir = dir
 	out, err := cmd.Output()
@@ -284,6 +288,63 @@ func repoCacheKey(dir string) string {
 		key = filepath.Join(dir, key)
 	}
 	return filepath.Clean(key)
+}
+
+func repoCacheKeyFromGitMetadata(dir string) (string, bool) {
+	dir = filepath.Clean(dir)
+	if isGitDir(dir) {
+		return commonDirFromGitDir(dir)
+	}
+
+	gitPath := filepath.Join(dir, ".git")
+	info, err := os.Stat(gitPath)
+	if err == nil && info.IsDir() {
+		return commonDirFromGitDir(gitPath)
+	}
+
+	data, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(data))
+	gitDir, ok := strings.CutPrefix(line, "gitdir:")
+	if !ok {
+		return "", false
+	}
+	gitDir = strings.TrimSpace(gitDir)
+	if gitDir == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(dir, gitDir)
+	}
+	return commonDirFromGitDir(gitDir)
+}
+
+func commonDirFromGitDir(gitDir string) (string, bool) {
+	gitDir = filepath.Clean(gitDir)
+	data, err := os.ReadFile(filepath.Join(gitDir, "commondir"))
+	if err != nil {
+		return filepath.Clean(gitDir), true
+	}
+	commonDir := strings.TrimSpace(string(data))
+	if commonDir == "" {
+		return filepath.Clean(gitDir), true
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(gitDir, commonDir)
+	}
+	return filepath.Clean(commonDir), true
+}
+
+func isGitDir(dir string) bool {
+	if !strings.HasSuffix(filepath.Base(dir), ".git") {
+		return false
+	}
+	if info, err := os.Stat(filepath.Join(dir, "HEAD")); err != nil || info.IsDir() {
+		return false
+	}
+	return true
 }
 
 func loadMergedWorktreeCache(path string) mergedWorktreeCache {

--- a/internal/gh/merged_test.go
+++ b/internal/gh/merged_test.go
@@ -399,6 +399,52 @@ func TestCachedMergedWorktreeSet_IgnoresStalePositiveCacheWithoutRefreshing(t *t
 	}
 }
 
+func TestRepoCacheKeyFromLinkedWorktreeMetadata(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	root := t.TempDir()
+	bareDir := filepath.Join(root, "repos", "repo.git")
+	gitDir := filepath.Join(bareDir, "worktrees", "feature")
+	wtDir := filepath.Join(root, "worktrees", "repo", "feature")
+
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir git dir: %v", err)
+	}
+	if err := os.MkdirAll(wtDir, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(bareDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("write HEAD: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+		t.Fatalf("write commondir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(wtDir, ".git"), []byte("gitdir: "+gitDir+"\n"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+
+	if got := repoCacheKey(wtDir); got != filepath.Clean(bareDir) {
+		t.Fatalf("repoCacheKey() = %q, want %q", got, filepath.Clean(bareDir))
+	}
+}
+
+func TestRepoCacheKeyFromGitDirectory(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	root := t.TempDir()
+	gitDir := filepath.Join(root, "repo", ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir git dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("write HEAD: %v", err)
+	}
+
+	if got := repoCacheKey(filepath.Dir(gitDir)); got != filepath.Clean(gitDir) {
+		t.Fatalf("repoCacheKey() = %q, want %q", got, filepath.Clean(gitDir))
+	}
+}
+
 func prepareMergedWorktreeTestEnv(t *testing.T, now time.Time, search func(dir string, branches []string) ([]*PRInfo, error)) {
 	t.Helper()
 

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -73,10 +73,8 @@ func BuildPickerItemsWithOptions(ctx context.Context, repoFilter string, opts Pi
 		}
 	}
 
-	sessionSet := ListSessions()
-
 	results := parallel.Map(repoNames, func(_ int, repoName string) pickerRepoResult {
-		return buildPickerItemsForRepo(ctx, repoName, sessionSet, opts)
+		return buildPickerItemsForRepo(ctx, repoName, opts)
 	})
 
 	var items []PickerItem
@@ -104,7 +102,7 @@ type pickerRepoResult struct {
 	stack    *stack.Stack
 }
 
-func buildPickerItemsForRepo(ctx context.Context, repoName string, sessionSet map[string]bool, opts PickerBuildOptions) pickerRepoResult {
+func buildPickerItemsForRepo(ctx context.Context, repoName string, opts PickerBuildOptions) pickerRepoResult {
 	result := pickerRepoResult{repoName: repoName}
 	bareDir, err := config.ResolveRepo(repoName)
 	if err != nil {
@@ -154,19 +152,17 @@ func buildPickerItemsForRepo(ctx context.Context, repoName string, sessionSet ma
 		wtDir := filepath.Base(wt.Path)
 		sessions := claude.ReadAllSessions(repoName, wtDir)
 		ws := claude.AggregateStatus(sessions)
-		sessName := SessionNameForWorktree(repoName, wtDir)
 		result.items = append(result.items, PickerItem{
-			RepoName:   repoName,
-			Branch:     wt.Branch,
-			Head:       wt.Head,
-			Detached:   wt.Detached,
-			WtDirName:  wtDir,
-			WtPath:     wt.Path,
-			Status:     ws.Status,
-			Unread:     ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
-			HasSession: sessionSet[sessName],
-			Sessions:   sessions,
-			Merged:     !wt.Detached && mergedSet[wt.Branch],
+			RepoName:  repoName,
+			Branch:    wt.Branch,
+			Head:      wt.Head,
+			Detached:  wt.Detached,
+			WtDirName: wtDir,
+			WtPath:    wt.Path,
+			Status:    ws.Status,
+			Unread:    ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
+			Sessions:  sessions,
+			Merged:    !wt.Detached && mergedSet[wt.Branch],
 		})
 	}
 	done()

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -1,7 +1,9 @@
 package worktree
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -47,11 +49,137 @@ func ShortHead(head string) string {
 }
 
 func List(g *git.Git) ([]Worktree, error) {
+	if g.Dir != "" && !g.Verbose {
+		if worktrees, ok := listFromGitMetadata(g.Dir); ok {
+			return worktrees, nil
+		}
+	}
+
 	out, err := g.Run("worktree", "list", "--porcelain")
 	if err != nil {
 		return nil, err
 	}
 	return parsePorcelain(out), nil
+}
+
+func listFromGitMetadata(commonDir string) ([]Worktree, bool) {
+	commonDir = filepath.Clean(commonDir)
+	if !isBareCommonDir(commonDir) {
+		return nil, false
+	}
+
+	worktrees := []Worktree{{Path: commonDir, IsBare: true}}
+	entries, err := os.ReadDir(filepath.Join(commonDir, "worktrees"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return worktrees, true
+		}
+		return nil, false
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		wt, ok := readLinkedWorktree(commonDir, filepath.Join(commonDir, "worktrees", entry.Name()))
+		if !ok {
+			return nil, false
+		}
+		worktrees = append(worktrees, wt)
+	}
+	return worktrees, true
+}
+
+func isBareCommonDir(dir string) bool {
+	if info, err := os.Stat(filepath.Join(dir, "HEAD")); err != nil || info.IsDir() {
+		return false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "config"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.EqualFold(line, "bare = true") {
+			return true
+		}
+	}
+	return false
+}
+
+func readLinkedWorktree(commonDir, adminDir string) (Worktree, bool) {
+	gitDirData, err := os.ReadFile(filepath.Join(adminDir, "gitdir"))
+	if err != nil {
+		return Worktree{}, false
+	}
+	gitDir := strings.TrimSpace(string(gitDirData))
+	if gitDir == "" {
+		return Worktree{}, false
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(adminDir, gitDir)
+	}
+
+	wtPath := filepath.Clean(gitDir)
+	if filepath.Base(wtPath) == ".git" {
+		wtPath = filepath.Dir(wtPath)
+	}
+	wt := Worktree{Path: wtPath}
+
+	headData, err := os.ReadFile(filepath.Join(adminDir, "HEAD"))
+	if err != nil {
+		return Worktree{}, false
+	}
+	head := strings.TrimSpace(string(headData))
+	if head == "" {
+		return Worktree{}, false
+	}
+	if ref, ok := strings.CutPrefix(head, "ref:"); ok {
+		ref = strings.TrimSpace(ref)
+		branch, ok := strings.CutPrefix(ref, "refs/heads/")
+		if !ok || branch == "" {
+			return Worktree{}, false
+		}
+		resolved, ok := resolveRef(commonDir, ref)
+		if !ok {
+			return Worktree{}, false
+		}
+		wt.Branch = branch
+		wt.Head = resolved
+		return wt, true
+	}
+
+	wt.Branch = DetachedBranch
+	wt.Head = head
+	wt.Detached = true
+	return wt, true
+}
+
+func resolveRef(commonDir, ref string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(commonDir, filepath.FromSlash(ref)))
+	if err == nil {
+		value := strings.TrimSpace(string(data))
+		return value, value != ""
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", false
+	}
+
+	data, err = os.ReadFile(filepath.Join(commonDir, "packed-refs"))
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {
+			continue
+		}
+		sha, name, ok := strings.Cut(line, " ")
+		if ok && name == ref && sha != "" {
+			return sha, true
+		}
+	}
+	return "", false
 }
 
 func parsePorcelain(output string) []Worktree {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -20,6 +20,10 @@ type Worktree struct {
 	IsBare   bool   `json:"-"`
 }
 
+type ListOptions struct {
+	ResolveHeads bool
+}
+
 func (wt Worktree) DirName() string {
 	return filepath.Base(wt.Path)
 }
@@ -49,8 +53,12 @@ func ShortHead(head string) string {
 }
 
 func List(g *git.Git) ([]Worktree, error) {
+	return ListWithOptions(g, ListOptions{ResolveHeads: true})
+}
+
+func ListWithOptions(g *git.Git, opts ListOptions) ([]Worktree, error) {
 	if g.Dir != "" && !g.Verbose {
-		if worktrees, ok := listFromGitMetadata(g.Dir); ok {
+		if worktrees, ok := listFromGitMetadata(g.Dir, opts); ok {
 			return worktrees, nil
 		}
 	}
@@ -62,7 +70,7 @@ func List(g *git.Git) ([]Worktree, error) {
 	return parsePorcelain(out), nil
 }
 
-func listFromGitMetadata(commonDir string) ([]Worktree, bool) {
+func listFromGitMetadata(commonDir string, opts ListOptions) ([]Worktree, bool) {
 	commonDir = filepath.Clean(commonDir)
 	if !isBareCommonDir(commonDir) {
 		return nil, false
@@ -82,7 +90,7 @@ func listFromGitMetadata(commonDir string) ([]Worktree, bool) {
 		if !entry.IsDir() {
 			continue
 		}
-		wt, ok := readLinkedWorktree(filepath.Join(commonDir, "worktrees", entry.Name()), &resolver)
+		wt, ok := readLinkedWorktree(filepath.Join(commonDir, "worktrees", entry.Name()), &resolver, opts)
 		if !ok {
 			return nil, false
 		}
@@ -115,7 +123,7 @@ type refResolver struct {
 	packedRefsSet bool
 }
 
-func readLinkedWorktree(adminDir string, refs *refResolver) (Worktree, bool) {
+func readLinkedWorktree(adminDir string, refs *refResolver, opts ListOptions) (Worktree, bool) {
 	gitDirData, err := os.ReadFile(filepath.Join(adminDir, "gitdir"))
 	if err != nil {
 		return Worktree{}, false
@@ -148,12 +156,14 @@ func readLinkedWorktree(adminDir string, refs *refResolver) (Worktree, bool) {
 		if !ok || branch == "" {
 			return Worktree{}, false
 		}
-		resolved, ok := refs.resolve(ref)
-		if !ok {
-			return Worktree{}, false
-		}
 		wt.Branch = branch
-		wt.Head = resolved
+		if opts.ResolveHeads {
+			resolved, ok := refs.resolve(ref)
+			if !ok {
+				return Worktree{}, false
+			}
+			wt.Head = resolved
+		}
 		return wt, true
 	}
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -77,11 +77,12 @@ func listFromGitMetadata(commonDir string) ([]Worktree, bool) {
 		return nil, false
 	}
 
+	resolver := refResolver{commonDir: commonDir}
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
 		}
-		wt, ok := readLinkedWorktree(commonDir, filepath.Join(commonDir, "worktrees", entry.Name()))
+		wt, ok := readLinkedWorktree(filepath.Join(commonDir, "worktrees", entry.Name()), &resolver)
 		if !ok {
 			return nil, false
 		}
@@ -107,7 +108,14 @@ func isBareCommonDir(dir string) bool {
 	return false
 }
 
-func readLinkedWorktree(commonDir, adminDir string) (Worktree, bool) {
+type refResolver struct {
+	commonDir     string
+	packedRefs    map[string]string
+	packedRefsOK  bool
+	packedRefsSet bool
+}
+
+func readLinkedWorktree(adminDir string, refs *refResolver) (Worktree, bool) {
 	gitDirData, err := os.ReadFile(filepath.Join(adminDir, "gitdir"))
 	if err != nil {
 		return Worktree{}, false
@@ -140,7 +148,7 @@ func readLinkedWorktree(commonDir, adminDir string) (Worktree, bool) {
 		if !ok || branch == "" {
 			return Worktree{}, false
 		}
-		resolved, ok := resolveRef(commonDir, ref)
+		resolved, ok := refs.resolve(ref)
 		if !ok {
 			return Worktree{}, false
 		}
@@ -155,8 +163,8 @@ func readLinkedWorktree(commonDir, adminDir string) (Worktree, bool) {
 	return wt, true
 }
 
-func resolveRef(commonDir, ref string) (string, bool) {
-	data, err := os.ReadFile(filepath.Join(commonDir, filepath.FromSlash(ref)))
+func (r *refResolver) resolve(ref string) (string, bool) {
+	data, err := os.ReadFile(filepath.Join(r.commonDir, filepath.FromSlash(ref)))
 	if err == nil {
 		value := strings.TrimSpace(string(data))
 		return value, value != ""
@@ -165,21 +173,40 @@ func resolveRef(commonDir, ref string) (string, bool) {
 		return "", false
 	}
 
-	data, err = os.ReadFile(filepath.Join(commonDir, "packed-refs"))
-	if err != nil {
+	refs, ok := r.loadPackedRefs()
+	if !ok {
 		return "", false
 	}
+	value := refs[ref]
+	return value, value != ""
+}
+
+func (r *refResolver) loadPackedRefs() (map[string]string, bool) {
+	if r.packedRefsSet {
+		return r.packedRefs, r.packedRefsOK
+	}
+
+	r.packedRefsSet = true
+	data, err := os.ReadFile(filepath.Join(r.commonDir, "packed-refs"))
+	if err != nil {
+		r.packedRefs = map[string]string{}
+		r.packedRefsOK = errors.Is(err, os.ErrNotExist)
+		return r.packedRefs, r.packedRefsOK
+	}
+
+	r.packedRefs = make(map[string]string)
 	for _, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {
 			continue
 		}
 		sha, name, ok := strings.Cut(line, " ")
-		if ok && name == ref && sha != "" {
-			return sha, true
+		if ok && sha != "" && name != "" {
+			r.packedRefs[name] = sha
 		}
 	}
-	return "", false
+	r.packedRefsOK = true
+	return r.packedRefs, true
 }
 
 func parsePorcelain(output string) []Worktree {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,6 +1,10 @@
 package worktree
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParsePorcelain_SingleWorktree(t *testing.T) {
 	input := `worktree /home/user/.willow/repos/myrepo.git
@@ -100,5 +104,67 @@ branch refs/heads/main
 	wts := parsePorcelain(input)
 	if len(wts) != 0 {
 		t.Errorf("expected 0 worktrees for block without path, got %d", len(wts))
+	}
+}
+
+func TestListFromGitMetadata(t *testing.T) {
+	root := t.TempDir()
+	commonDir := filepath.Join(root, "repo.git")
+	if err := os.MkdirAll(filepath.Join(commonDir, "worktrees", "feature-auth"), 0o755); err != nil {
+		t.Fatalf("mkdir feature admin dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(commonDir, "worktrees", "detached"), 0o755); err != nil {
+		t.Fatalf("mkdir detached admin dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(commonDir, "HEAD"), "ref: refs/heads/main\n")
+	writeTestFile(t, filepath.Join(commonDir, "config"), "[core]\n\tbare = true\n")
+	writeTestFile(t, filepath.Join(commonDir, "packed-refs"), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb refs/heads/feature/auth\n")
+
+	featurePath := filepath.Join(root, "worktrees", "feature-auth")
+	detachedPath := filepath.Join(root, "worktrees", "detached")
+	writeTestFile(t, filepath.Join(commonDir, "worktrees", "feature-auth", "gitdir"), filepath.Join(featurePath, ".git")+"\n")
+	writeTestFile(t, filepath.Join(commonDir, "worktrees", "feature-auth", "HEAD"), "ref: refs/heads/feature/auth\n")
+	writeTestFile(t, filepath.Join(commonDir, "worktrees", "detached", "gitdir"), filepath.Join(detachedPath, ".git")+"\n")
+	writeTestFile(t, filepath.Join(commonDir, "worktrees", "detached", "HEAD"), "cccccccccccccccccccccccccccccccccccccccc\n")
+
+	wts, ok := listFromGitMetadata(commonDir)
+	if !ok {
+		t.Fatal("listFromGitMetadata returned ok=false")
+	}
+	if len(wts) != 3 {
+		t.Fatalf("len(worktrees) = %d, want 3: %+v", len(wts), wts)
+	}
+	if !wts[0].IsBare || wts[0].Path != filepath.Clean(commonDir) {
+		t.Fatalf("bare worktree = %+v, want bare path %q", wts[0], filepath.Clean(commonDir))
+	}
+	if wts[1].Branch != DetachedBranch || !wts[1].Detached || wts[1].Head != "cccccccccccccccccccccccccccccccccccccccc" || wts[1].Path != detachedPath {
+		t.Fatalf("detached worktree = %+v", wts[1])
+	}
+	if wts[2].Branch != "feature/auth" || wts[2].Head != "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" || wts[2].Path != featurePath {
+		t.Fatalf("feature worktree = %+v", wts[2])
+	}
+}
+
+func TestListFromGitMetadataRequiresBareRepo(t *testing.T) {
+	root := t.TempDir()
+	gitDir := filepath.Join(root, "repo", ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir git dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(gitDir, "HEAD"), "ref: refs/heads/main\n")
+	writeTestFile(t, filepath.Join(gitDir, "config"), "[core]\n\tbare = false\n")
+
+	if wts, ok := listFromGitMetadata(gitDir); ok {
+		t.Fatalf("listFromGitMetadata() = %+v, true; want fallback for non-bare repo", wts)
+	}
+}
+
+func writeTestFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -127,7 +127,7 @@ func TestListFromGitMetadata(t *testing.T) {
 	writeTestFile(t, filepath.Join(commonDir, "worktrees", "detached", "gitdir"), filepath.Join(detachedPath, ".git")+"\n")
 	writeTestFile(t, filepath.Join(commonDir, "worktrees", "detached", "HEAD"), "cccccccccccccccccccccccccccccccccccccccc\n")
 
-	wts, ok := listFromGitMetadata(commonDir)
+	wts, ok := listFromGitMetadata(commonDir, ListOptions{ResolveHeads: true})
 	if !ok {
 		t.Fatal("listFromGitMetadata returned ok=false")
 	}
@@ -145,6 +145,31 @@ func TestListFromGitMetadata(t *testing.T) {
 	}
 }
 
+func TestListFromGitMetadataCanSkipBranchHeads(t *testing.T) {
+	root := t.TempDir()
+	commonDir := filepath.Join(root, "repo.git")
+	adminDir := filepath.Join(commonDir, "worktrees", "feature")
+	wtDir := filepath.Join(root, "worktrees", "feature")
+	if err := os.MkdirAll(adminDir, 0o755); err != nil {
+		t.Fatalf("mkdir admin dir: %v", err)
+	}
+	writeTestFile(t, filepath.Join(commonDir, "HEAD"), "ref: refs/heads/main\n")
+	writeTestFile(t, filepath.Join(commonDir, "config"), "[core]\n\tbare = true\n")
+	writeTestFile(t, filepath.Join(adminDir, "gitdir"), filepath.Join(wtDir, ".git")+"\n")
+	writeTestFile(t, filepath.Join(adminDir, "HEAD"), "ref: refs/heads/feature\n")
+
+	wts, ok := listFromGitMetadata(commonDir, ListOptions{ResolveHeads: false})
+	if !ok {
+		t.Fatal("listFromGitMetadata returned ok=false")
+	}
+	if len(wts) != 2 {
+		t.Fatalf("len(worktrees) = %d, want 2: %+v", len(wts), wts)
+	}
+	if wts[1].Branch != "feature" || wts[1].Head != "" {
+		t.Fatalf("worktree = %+v, want branch without resolved head", wts[1])
+	}
+}
+
 func TestListFromGitMetadataRequiresBareRepo(t *testing.T) {
 	root := t.TempDir()
 	gitDir := filepath.Join(root, "repo", ".git")
@@ -154,7 +179,7 @@ func TestListFromGitMetadataRequiresBareRepo(t *testing.T) {
 	writeTestFile(t, filepath.Join(gitDir, "HEAD"), "ref: refs/heads/main\n")
 	writeTestFile(t, filepath.Join(gitDir, "config"), "[core]\n\tbare = false\n")
 
-	if wts, ok := listFromGitMetadata(gitDir); ok {
+	if wts, ok := listFromGitMetadata(gitDir, ListOptions{ResolveHeads: true}); ok {
 		t.Fatalf("listFromGitMetadata() = %+v, true; want fallback for non-bare repo", wts)
 	}
 }


### PR DESCRIPTION
## Description of the change
Optimizes Willow's non-Sentry CLI hot paths using the `willow-autoresearch` harness against a Willow-managed reference fixture. The accepted benchmark best reduced `total_median_ms` from `158.489ms` to `56.168ms` (`64.6%` faster) across the measured `ls`, `status`, `tmux list`, and empty/startup-style paths.

The main optimizations are:
- avoid extra git subprocesses when reading merged-worktree cache metadata
- skip the unused tmux session lookup while building picker items
- list Willow-managed worktrees directly from git metadata instead of shelling out to `git worktree list --porcelain`
- load `packed-refs` once per worktree listing
- let `ww ls` skip a failing git probe when run outside a Willow-managed repo
- avoid unread-session file checks when there are no DONE sessions
- let `ww status` skip branch HEAD resolution when it only needs status output

**Ticket:**

## Test plan
Unit tests:

`go test ./... -count=1`

Benchmark harness with telemetry disabled against the reference fixture:

`WILLOW_TELEMETRY=off python3 skills/willow-autoresearch/scripts/bench_willow.py --reference-repo <reference-fixture> --runs 7 --warmups 2 --json`

Accepted benchmark result:
- baseline `total_median_ms`: `158.489ms`
- best accepted `total_median_ms`: `56.168ms`
- improvement: `64.6%`

Best accepted scenario medians:
- `empty-ls`: `8.361ms`
- `ls-json`: `11.274ms`
- `ls-table`: `13.070ms`
- `status-json`: `10.241ms`
- `tmux-list`: `13.222ms`

Best accepted trace medians addressed:
- `worktree.List`: about `2.9-3.0ms`
- `cli.status`: `3.0ms`
- `BuildPickerItems` / `tmux.list`: `4.9ms`
- `gh.CachedMergedWorktreeSet` / `gh.MergedWorktreeSet`: about `0.1ms`

## Loom or screenshots

## Considerations
No user-facing behavior changes intended. The reference repo was used as a read-only benchmark fixture; mutating paths were kept inside the harness's isolated `WILLOW_BASE_DIR`.