### PR TITLE
:sparkles: feat[cleanup]: add stale worktree pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ This gives you:
 | `ww promote [name] <branch>` | Promote a detached worktree to a branch |
 | `ww rename [worktree] <name>` | Rename a worktree, branch, status dir, and tmux session |
 | `ww checkout <branch>` | Smart checkout + cd (switch or create, tmux-aware) |
+| `ww gc` | Clean trash and list stale worktrees |
 | `wwn <branch>` | Shorthand for `ww new` |
 | `wwc <branch>` | Shorthand for `ww checkout` |
 | `www` | cd to `<willow-base>/worktrees/` |
@@ -352,7 +353,7 @@ Switch worktrees via fzf. Shows Claude Code agent status per worktree, sorted by
 
 Remove a worktree. Without arguments, opens fzf picker with multi-select (TAB to toggle, Ctrl-A to select all).
 
-From the tmux picker, `Ctrl-D` removes the selected worktree and `Ctrl-X` bulk-removes safe merged worktrees currently shown in the picker, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
+From the tmux picker, `Ctrl-D` removes the selected worktree and `Ctrl-X` bulk-removes safe stale worktrees currently shown in the picker. Stale means the exact current-head PR is merged or the branch's configured upstream is gone; the active tmux session, dirty worktrees, stacked parents, and remote-gone branches with local-only commits are skipped.
 
 ```bash
 ww rm auth-refactor              # direct removal
@@ -366,6 +367,27 @@ ww rm auth-refactor --prune      # also run git worktree prune
 | `-f, --force` | Skip safety checks |
 | `--keep-branch` | Keep the local branch |
 | `--prune` | Run `git worktree prune` after |
+
+### `ww gc`
+
+Clean up leftover trash from removed worktrees and list stale worktrees. Stale candidates are worktrees whose exact current-head PR is merged or whose configured upstream branch is gone after `git fetch --prune`.
+
+```bash
+ww gc                    # empty trash and list stale worktrees
+ww gc --repo myrepo      # scan one repo
+ww gc --no-fetch         # use local remote-tracking refs as-is
+ww gc --prune            # confirm and remove the safe subset
+ww gc --prune --dry-run  # show what --prune would remove
+```
+
+| Flag | Description |
+|------|-------------|
+| `--prune` | Interactively remove safe stale worktrees |
+| `--dry-run` | Show what would be cleaned up without removing anything |
+| `-r, --repo` | Target a willow-managed repo by name |
+| `--no-fetch` | Skip `git fetch --prune` before scanning |
+
+`ww gc --prune` skips dirty worktrees, branches with stacked children, and remote-gone branches whose commits are not reachable from their expected base. PR-merged worktrees use the existing exact GitHub match and do not fall back to Git ancestry.
 
 ### `ww ls [repo]`
 

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -1,0 +1,311 @@
+package cleanup
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/gh"
+	"github.com/iamrajjoshi/willow/internal/git"
+	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/worktree"
+)
+
+type Reason string
+
+const (
+	ReasonMergedPR     Reason = "merged-pr"
+	ReasonGoneUpstream Reason = "gone-upstream"
+)
+
+type Candidate struct {
+	RepoName        string
+	BareDir         string
+	Branch          string
+	Head            string
+	Path            string
+	WtDirName       string
+	ExpectedBaseRef string
+	Reasons         []Reason
+}
+
+type Skip struct {
+	Candidate Candidate
+	Reason    string
+}
+
+type ScanOptions struct {
+	RefreshPRState bool
+	Verbose        bool
+}
+
+type UpstreamStatus struct {
+	Upstream string
+	Gone     bool
+}
+
+func ScanRepo(repoName, bareDir string, opts ScanOptions) ([]Candidate, error) {
+	repoGit := &git.Git{Dir: bareDir, Verbose: opts.Verbose}
+	wts, err := worktree.List(repoGit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %w", err)
+	}
+	return CandidatesForWorktrees(repoName, bareDir, wts, opts)
+}
+
+func CandidatesForWorktrees(repoName, bareDir string, wts []worktree.Worktree, opts ScanOptions) ([]Candidate, error) {
+	repoGit := &git.Git{Dir: bareDir, Verbose: opts.Verbose}
+	cfg := config.Load(bareDir)
+	st := stack.Load(bareDir)
+	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
+
+	branchHeads := make(map[string]string, len(wts))
+	branchBases := make(map[string]string, len(wts))
+	branchNames := make([]string, 0, len(wts))
+	repoDir := ""
+	for _, wt := range wts {
+		if wt.IsBare || wt.Detached || wt.Branch == "" {
+			continue
+		}
+		if repoDir == "" {
+			repoDir = wt.Path
+		}
+		branchHeads[wt.Branch] = wt.Head
+		branchNames = append(branchNames, wt.Branch)
+		if parent := st.Parent(wt.Branch); parent != "" {
+			branchBases[wt.Branch] = parent
+		}
+	}
+	if len(branchNames) == 0 {
+		return nil, nil
+	}
+
+	var mergedSet map[string]bool
+	if opts.RefreshPRState {
+		mergedSet = gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
+	} else {
+		mergedSet = gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
+	}
+
+	upstreams, err := UpstreamStatuses(repoGit, branchNames)
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []Candidate
+	for _, wt := range wts {
+		if wt.IsBare || wt.Detached || wt.Branch == "" {
+			continue
+		}
+		var reasons []Reason
+		if mergedSet[wt.Branch] {
+			reasons = append(reasons, ReasonMergedPR)
+		}
+		if upstreams[wt.Branch].Gone {
+			reasons = append(reasons, ReasonGoneUpstream)
+		}
+		if len(reasons) == 0 {
+			continue
+		}
+		candidates = append(candidates, Candidate{
+			RepoName:        repoName,
+			BareDir:         bareDir,
+			Branch:          wt.Branch,
+			Head:            wt.Head,
+			Path:            wt.Path,
+			WtDirName:       filepath.Base(wt.Path),
+			ExpectedBaseRef: ExpectedBaseRef(repoGit, st, baseBranch, wt.Branch),
+			Reasons:         reasons,
+		})
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].RepoName != candidates[j].RepoName {
+			return candidates[i].RepoName < candidates[j].RepoName
+		}
+		return candidates[i].Branch < candidates[j].Branch
+	})
+	return candidates, nil
+}
+
+func UpstreamStatuses(g *git.Git, branches []string) (map[string]UpstreamStatus, error) {
+	statuses := make(map[string]UpstreamStatus, len(branches))
+	if len(branches) == 0 {
+		return statuses, nil
+	}
+
+	args := []string{"for-each-ref", "--format=%(refname:short)%00%(upstream:short)%00%(upstream:track)"}
+	for _, branch := range branches {
+		if branch != "" {
+			args = append(args, "refs/heads/"+branch)
+		}
+	}
+	out, err := g.Run(args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect branch upstreams: %w", err)
+	}
+	if out == "" {
+		return statuses, nil
+	}
+
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Split(line, "\x00")
+		if len(fields) < 3 {
+			continue
+		}
+		branch := strings.TrimSpace(fields[0])
+		upstream := strings.TrimSpace(fields[1])
+		track := strings.TrimSpace(fields[2])
+		if branch == "" {
+			continue
+		}
+		statuses[branch] = UpstreamStatus{
+			Upstream: upstream,
+			Gone:     upstream != "" && strings.Contains(track, "[gone]"),
+		}
+	}
+	return statuses, nil
+}
+
+func ExpectedBaseRef(repoGit *git.Git, st *stack.Stack, baseBranch, branch string) string {
+	if st != nil {
+		if parent := st.Parent(branch); parent != "" {
+			if st.IsTracked(parent) && repoGit.LocalBranchExists(parent) {
+				return "refs/heads/" + parent
+			}
+			return "refs/remotes/origin/" + parent
+		}
+	}
+	if baseBranch == "" {
+		return ""
+	}
+	return "refs/remotes/origin/" + baseBranch
+}
+
+func FilterSafe(candidates []Candidate) ([]Candidate, []Skip, error) {
+	stacks := make(map[string]*stack.Stack)
+	var safe []Candidate
+	var skipped []Skip
+
+	for _, candidate := range candidates {
+		st, ok := stacks[candidate.BareDir]
+		if !ok {
+			st = stack.Load(candidate.BareDir)
+			stacks[candidate.BareDir] = st
+		}
+		reason, err := SkipReason(candidate, st)
+		if err != nil {
+			return nil, nil, err
+		}
+		if reason != "" {
+			skipped = append(skipped, Skip{Candidate: candidate, Reason: reason})
+			continue
+		}
+		safe = append(safe, candidate)
+	}
+	return safe, skipped, nil
+}
+
+func SkipReason(candidate Candidate, st *stack.Stack) (string, error) {
+	var children []string
+	if st != nil {
+		children = st.Children(candidate.Branch)
+	}
+
+	wtGit := &git.Git{Dir: candidate.Path}
+	dirty, err := wtGit.IsDirty()
+	if err != nil {
+		return "", err
+	}
+
+	reachable := true
+	if !candidate.HasReason(ReasonMergedPR) {
+		reachable = false
+		if candidate.ExpectedBaseRef == "" {
+			return skipReasonFromState(children, dirty, false, "base ref missing"), nil
+		}
+
+		repoGit := &git.Git{Dir: candidate.BareDir}
+		if !refExists(repoGit, candidate.ExpectedBaseRef) {
+			return skipReasonFromState(children, dirty, false, "base ref missing: "+shortRef(candidate.ExpectedBaseRef)), nil
+		}
+		branchRef := "refs/heads/" + candidate.Branch
+		if !refExists(repoGit, branchRef) {
+			return skipReasonFromState(children, dirty, false, "branch ref missing: "+candidate.Branch), nil
+		}
+		reachable = isAncestor(repoGit, branchRef, candidate.ExpectedBaseRef)
+	}
+
+	return skipReasonFromState(children, dirty, reachable, "not merged into "+shortRef(candidate.ExpectedBaseRef)), nil
+}
+
+func skipReasonFromState(children []string, dirty, reachable bool, reachabilityReason string) string {
+	var reasons []string
+	if len(children) > 0 {
+		reasons = append(reasons, "stacked children: "+strings.Join(children, ", "))
+	}
+	if dirty {
+		reasons = append(reasons, "uncommitted changes")
+	}
+	if !reachable {
+		reasons = append(reasons, reachabilityReason)
+	}
+	return strings.Join(reasons, "; ")
+}
+
+func refExists(g *git.Git, ref string) bool {
+	_, err := g.Run("rev-parse", "--verify", ref+"^{commit}")
+	return err == nil
+}
+
+func isAncestor(g *git.Git, ancestor, descendant string) bool {
+	_, err := g.Run("merge-base", "--is-ancestor", ancestor, descendant)
+	return err == nil
+}
+
+func (c Candidate) HasReason(reason Reason) bool {
+	for _, r := range c.Reasons {
+		if r == reason {
+			return true
+		}
+	}
+	return false
+}
+
+func (c Candidate) ReasonString() string {
+	return ReasonsString(c.Reasons)
+}
+
+func ReasonsString(reasons []Reason) string {
+	parts := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		parts = append(parts, string(reason))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func Label(candidate Candidate, multiRepo bool) string {
+	if multiRepo {
+		return candidate.RepoName + "/" + candidate.Branch
+	}
+	return candidate.Branch
+}
+
+func HasMultipleRepos(candidates []Candidate) bool {
+	repos := make(map[string]bool)
+	for _, candidate := range candidates {
+		repos[candidate.RepoName] = true
+		if len(repos) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func shortRef(ref string) string {
+	ref = strings.TrimPrefix(ref, "refs/heads/")
+	ref = strings.TrimPrefix(ref, "refs/remotes/")
+	return ref
+}

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -1,0 +1,102 @@
+package cleanup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/iamrajjoshi/willow/internal/git"
+)
+
+func TestUpstreamStatusesDetectsGoneExistingAndNoUpstream(t *testing.T) {
+	workDir := setupCleanupGitRepo(t)
+	g := &git.Git{Dir: workDir}
+
+	createAndPushBranch(t, g, workDir, "gone")
+	createAndPushBranch(t, g, workDir, "existing")
+
+	if _, err := g.Run("checkout", "-b", "local-only", "main"); err != nil {
+		t.Fatalf("checkout local-only: %v", err)
+	}
+	writeCommit(t, g, workDir, "local-only.txt", "local only")
+
+	if _, err := (&git.Git{Dir: filepath.Join(filepath.Dir(workDir), "origin.git")}).Run("update-ref", "-d", "refs/heads/gone"); err != nil {
+		t.Fatalf("delete remote branch: %v", err)
+	}
+	if _, err := g.Run("fetch", "--prune", "origin"); err != nil {
+		t.Fatalf("fetch --prune: %v", err)
+	}
+
+	statuses, err := UpstreamStatuses(g, []string{"gone", "existing", "local-only", "missing"})
+	if err != nil {
+		t.Fatalf("UpstreamStatuses: %v", err)
+	}
+	if !statuses["gone"].Gone {
+		t.Fatalf("gone branch status = %#v, want gone", statuses["gone"])
+	}
+	if statuses["existing"].Gone {
+		t.Fatalf("existing branch status = %#v, want not gone", statuses["existing"])
+	}
+	if statuses["local-only"].Gone || statuses["local-only"].Upstream != "" {
+		t.Fatalf("local-only branch status = %#v, want no upstream and not gone", statuses["local-only"])
+	}
+	if _, ok := statuses["missing"]; ok {
+		t.Fatalf("missing branch should not appear in statuses: %#v", statuses["missing"])
+	}
+}
+
+func setupCleanupGitRepo(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	g := &git.Git{}
+	if _, err := g.Run("init", "--bare", "--initial-branch=main", origin); err != nil {
+		t.Fatalf("git init --bare: %v", err)
+	}
+
+	workDir := filepath.Join(root, "work")
+	if _, err := g.Run("clone", origin, workDir); err != nil {
+		t.Fatalf("git clone: %v", err)
+	}
+	wg := &git.Git{Dir: workDir}
+	if _, err := wg.Run("config", "user.email", "test@test.com"); err != nil {
+		t.Fatalf("config email: %v", err)
+	}
+	if _, err := wg.Run("config", "user.name", "Test"); err != nil {
+		t.Fatalf("config name: %v", err)
+	}
+	writeCommit(t, wg, workDir, "README.md", "initial")
+	if _, err := wg.Run("push", "-u", "origin", "main"); err != nil {
+		t.Fatalf("push main: %v", err)
+	}
+	return workDir
+}
+
+func createAndPushBranch(t *testing.T, g *git.Git, workDir, branch string) {
+	t.Helper()
+
+	if _, err := g.Run("checkout", "-b", branch, "main"); err != nil {
+		t.Fatalf("checkout %s: %v", branch, err)
+	}
+	writeCommit(t, g, workDir, branch+".txt", branch)
+	if _, err := g.Run("push", "-u", "origin", branch); err != nil {
+		t.Fatalf("push %s: %v", branch, err)
+	}
+}
+
+func writeCommit(t *testing.T, g *git.Git, dir, name, contents string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents+"\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	if _, err := g.Run("add", name); err != nil {
+		t.Fatalf("git add %s: %v", name, err)
+	}
+	msg := "add " + strings.TrimSuffix(name, filepath.Ext(name))
+	if _, err := g.Run("commit", "-m", msg); err != nil {
+		t.Fatalf("git commit %s: %v", name, err)
+	}
+}

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
+	"github.com/iamrajjoshi/willow/internal/cleanup"
 	"github.com/iamrajjoshi/willow/internal/config"
-	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
-	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
@@ -23,11 +21,20 @@ func gcCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "prune",
-				Usage: "Interactively remove merged worktrees",
+				Usage: "Interactively remove safe stale worktrees",
 			},
 			&cli.BoolFlag{
 				Name:  "dry-run",
 				Usage: "Show what would be cleaned up without removing anything",
+			},
+			&cli.StringFlag{
+				Name:    "repo",
+				Aliases: []string{"r"},
+				Usage:   "Target a willow-managed repo by name",
+			},
+			&cli.BoolFlag{
+				Name:  "no-fetch",
+				Usage: "Skip fetching and pruning remotes before scanning",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -59,87 +66,73 @@ func gcCmd() *cli.Command {
 				u.Success(fmt.Sprintf("Cleaned up %d trash entries", len(entries)))
 			}
 
-			repos, err := config.ListRepos()
+			repos, err := gcRepos(cmd.String("repo"))
 			if err != nil {
-				return fmt.Errorf("failed to list repos: %w", err)
+				return err
 			}
+			var candidates []cleanup.Candidate
+			for _, repo := range repos {
+				cfg := config.Load(repo.BareDir)
+				repoGit := &git.Git{Dir: repo.BareDir, Verbose: flags.Verbose}
+				if *cfg.Defaults.Fetch && !cmd.Bool("no-fetch") {
+					if _, err := repoGit.Run("fetch", "--prune", "origin"); err != nil {
+						u.Warn(fmt.Sprintf("Skipping remote refresh for %s: %v", repo.Name, err))
+					}
+				}
 
-			type mergedWorktree struct {
-				repoName string
-				branch   string
-			}
-			var candidates []mergedWorktree
-
-			for _, repoName := range repos {
-				bareDir, err := config.ResolveRepo(repoName)
+				repoCandidates, err := cleanup.ScanRepo(repo.Name, repo.BareDir, cleanup.ScanOptions{
+					RefreshPRState: true,
+					Verbose:        flags.Verbose,
+				})
 				if err != nil {
-					u.Warn(fmt.Sprintf("Skipping repo %s: %v", repoName, err))
+					u.Warn(fmt.Sprintf("Skipping repo %s: %v", repo.Name, err))
 					continue
 				}
-
-				cfg := config.Load(bareDir)
-				repoGit := &git.Git{Dir: bareDir}
-				wts, err := worktree.List(repoGit)
-				if err != nil {
-					u.Warn(fmt.Sprintf("Skipping repo %s: failed to list worktrees: %v", repoName, err))
-					continue
-				}
-
-				baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
-				branchHeads := make(map[string]string, len(wts))
-				branchBases := make(map[string]string, len(wts))
-				repoDir := ""
-				st := stack.Load(bareDir)
-				for _, wt := range wts {
-					if wt.IsBare || wt.Detached || wt.Branch == "" {
-						continue
-					}
-					if repoDir == "" {
-						repoDir = wt.Path
-					}
-					branchHeads[wt.Branch] = wt.Head
-					if parent := st.Parent(wt.Branch); parent != "" {
-						branchBases[wt.Branch] = parent
-					}
-				}
-
-				mergedSet := gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
-				if len(mergedSet) == 0 {
-					continue
-				}
-
-				for _, wt := range wts {
-					if !wt.IsBare && !wt.Detached && mergedSet[wt.Branch] {
-						candidates = append(candidates, mergedWorktree{repoName: repoName, branch: wt.Branch})
-					}
-				}
+				candidates = append(candidates, repoCandidates...)
 			}
 
 			if len(candidates) == 0 {
-				u.Info("No merged worktrees found.")
+				u.Info("No stale worktrees found.")
 				return nil
 			}
 
-			u.Info(fmt.Sprintf("\nFound %d merged worktree(s):", len(candidates)))
+			multiRepo := cleanup.HasMultipleRepos(candidates)
+			u.Info(fmt.Sprintf("\nFound %d stale worktree(s):", len(candidates)))
 			for _, c := range candidates {
-				u.Info(fmt.Sprintf("  %s (repo: %s)", c.branch, c.repoName))
+				u.Info(fmt.Sprintf("  %s (%s)", cleanup.Label(c, multiRepo), c.ReasonString()))
 			}
 
 			if !prune {
 				u.Info("\nTo remove these, run:")
 				for _, c := range candidates {
-					u.Info(fmt.Sprintf("  willow rm %s --repo %s", c.branch, c.repoName))
+					u.Info(fmt.Sprintf("  willow rm %s --repo %s", c.Branch, c.RepoName))
 				}
-				u.Info("\nOr re-run with --prune to interactively remove them.")
+				u.Info("\nOr re-run with --prune to interactively remove the safe subset.")
 				return nil
+			}
+
+			safe, skipped, err := cleanup.FilterSafe(candidates)
+			if err != nil {
+				return err
+			}
+			if len(skipped) > 0 {
+				u.Info("\nSkipping unsafe stale worktrees:")
+				for _, skip := range skipped {
+					u.Info(fmt.Sprintf("  %s (%s)", cleanup.Label(skip.Candidate, multiRepo), skip.Reason))
+				}
 			}
 
 			if dryRun {
-				u.Info("\nDry run: would remove the above worktrees.")
+				u.Info(fmt.Sprintf("\nDry run: would remove %d safe stale worktree(s).", len(safe)))
 				return nil
 			}
 
-			fmt.Fprintf(os.Stderr, "\nRemove %d merged worktree(s)? [y/N] ", len(candidates))
+			if len(safe) == 0 {
+				u.Info("\nNo safe stale worktrees to remove.")
+				return nil
+			}
+
+			fmt.Fprintf(os.Stderr, "\nRemove %d safe stale worktree(s)? [y/N] ", len(safe))
 			var answer string
 			fmt.Fscanf(os.Stdin, "%s", &answer)
 			if answer != "y" && answer != "Y" {
@@ -147,22 +140,47 @@ func gcCmd() *cli.Command {
 				return nil
 			}
 
-			self, err := os.Executable()
-			if err != nil {
-				self = "willow"
-			}
-
-			for _, c := range candidates {
-				u.Info(fmt.Sprintf("Removing %s from %s...", c.branch, c.repoName))
-				rmCmd := exec.Command(self, "rm", c.branch, "--force", "--repo", c.repoName)
-				rmCmd.Stdout = os.Stdout
-				rmCmd.Stderr = os.Stderr
-				if err := rmCmd.Run(); err != nil {
-					u.Warn(fmt.Sprintf("Failed to remove %s: %v", c.branch, err))
+			tr := trace.FromContext(ctx)
+			for _, c := range safe {
+				u.Info(fmt.Sprintf("Removing %s from %s...", c.Branch, c.RepoName))
+				repoGit := &git.Git{Dir: c.BareDir, Verbose: flags.Verbose}
+				cfg := config.Load(c.BareDir)
+				wt := worktree.Worktree{
+					Branch: c.Branch,
+					Path:   c.Path,
+					Head:   c.Head,
+				}
+				if err := removeWorktree(ctx, tr, u, repoGit, &wt, c.BareDir, cfg, true, false, flags.Verbose); err != nil {
+					u.Warn(fmt.Sprintf("Failed to remove %s: %v", c.Branch, err))
 				}
 			}
 
 			return nil
 		},
 	}
+}
+
+func gcRepos(repoFlag string) ([]repoInfo, error) {
+	if repoFlag != "" {
+		bareDir, err := config.ResolveRepo(repoFlag)
+		if err != nil {
+			return nil, err
+		}
+		return []repoInfo{{Name: repoFlag, BareDir: bareDir}}, nil
+	}
+
+	repoNames, err := config.ListRepos()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list repos: %w", err)
+	}
+
+	repos := make([]repoInfo, 0, len(repoNames))
+	for _, repoName := range repoNames {
+		bareDir, err := config.ResolveRepo(repoName)
+		if err != nil {
+			continue
+		}
+		repos = append(repos, repoInfo{Name: repoName, BareDir: bareDir})
+	}
+	return repos, nil
 }

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -13,9 +13,9 @@ import (
 	"time"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/cleanup"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
-	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
@@ -984,7 +984,7 @@ func TestRm_KeepBranch(t *testing.T) {
 	}
 }
 
-func TestFilterMergedDeleteCandidates_SkipsUnsafeWorktrees(t *testing.T) {
+func TestCleanupFilterSafe_SkipsUnsafeStaleWorktrees(t *testing.T) {
 	origin := setupTestEnv(t)
 	home, _ := os.UserHomeDir()
 
@@ -1013,7 +1013,7 @@ func TestFilterMergedDeleteCandidates_SkipsUnsafeWorktrees(t *testing.T) {
 		t.Fatalf("git config name: %v", err)
 	}
 
-	createMergedBranch := func(branch string, pushBranch, dirtyAfterMerge, unsetUpstream bool) string {
+	createBranch := func(branch string, pushBranch, mergeToBase, dirtyAfterMerge bool) string {
 		t.Helper()
 
 		if err := runApp("new", branch, "--no-fetch"); err != nil {
@@ -1037,28 +1037,25 @@ func TestFilterMergedDeleteCandidates_SkipsUnsafeWorktrees(t *testing.T) {
 				t.Fatalf("git push %s: %v", branch, err)
 			}
 		}
-		if _, err := mainGit.Run("merge", "--no-ff", branch, "-m", "merge "+branch); err != nil {
-			t.Fatalf("git merge %s: %v", branch, err)
-		}
-		if _, err := mainGit.Run("push", "origin", mainBranch); err != nil {
-			t.Fatalf("git push %s: %v", mainBranch, err)
+		if mergeToBase {
+			if _, err := mainGit.Run("merge", "--no-ff", branch, "-m", "merge "+branch); err != nil {
+				t.Fatalf("git merge %s: %v", branch, err)
+			}
+			if _, err := mainGit.Run("push", "origin", mainBranch); err != nil {
+				t.Fatalf("git push %s: %v", mainBranch, err)
+			}
 		}
 		if dirtyAfterMerge {
 			if err := os.WriteFile(file, []byte(branch+"\ndirty\n"), 0o644); err != nil {
 				t.Fatalf("dirty write %s: %v", file, err)
 			}
 		}
-		if unsetUpstream {
-			if _, err := wtGit.Run("branch", "--unset-upstream"); err != nil {
-				t.Fatalf("unset upstream %s: %v", branch, err)
-			}
-		}
 		return wtPath
 	}
 
-	safePath := createMergedBranch("safe-merged", true, false, false)
-	dirtyPath := createMergedBranch("dirty-merged", true, true, false)
-	unpushedPath := createMergedBranch("unpushed-merged", false, false, true)
+	safePath := createBranch("safe-merged", true, true, false)
+	dirtyPath := createBranch("dirty-merged", true, true, true)
+	localOnlyPath := createBranch("local-only-gone", false, false, false)
 
 	if err := runApp("new", "stack-parent", "--no-fetch"); err != nil {
 		t.Fatalf("new stack-parent failed: %v", err)
@@ -1089,32 +1086,37 @@ func TestFilterMergedDeleteCandidates_SkipsUnsafeWorktrees(t *testing.T) {
 		t.Fatalf("git push %s: %v", mainBranch, err)
 	}
 
-	items := []tmux.PickerItem{
-		{RepoName: "testrepo", Branch: "safe-merged", WtDirName: "safe-merged", WtPath: safePath},
-		{RepoName: "testrepo", Branch: "dirty-merged", WtDirName: "dirty-merged", WtPath: dirtyPath},
-		{RepoName: "testrepo", Branch: "unpushed-merged", WtDirName: "unpushed-merged", WtPath: unpushedPath},
-		{RepoName: "testrepo", Branch: "stack-parent", WtDirName: "stack-parent", WtPath: parentPath},
+	baseRef := "refs/remotes/origin/" + mainBranch
+	candidates := []cleanup.Candidate{
+		{RepoName: "testrepo", BareDir: filepath.Join(home, ".willow", "repos", "testrepo.git"), Branch: "safe-merged", WtDirName: "safe-merged", Path: safePath, ExpectedBaseRef: baseRef, Reasons: []cleanup.Reason{cleanup.ReasonGoneUpstream}},
+		{RepoName: "testrepo", BareDir: filepath.Join(home, ".willow", "repos", "testrepo.git"), Branch: "dirty-merged", WtDirName: "dirty-merged", Path: dirtyPath, ExpectedBaseRef: baseRef, Reasons: []cleanup.Reason{cleanup.ReasonGoneUpstream}},
+		{RepoName: "testrepo", BareDir: filepath.Join(home, ".willow", "repos", "testrepo.git"), Branch: "local-only-gone", WtDirName: "local-only-gone", Path: localOnlyPath, ExpectedBaseRef: baseRef, Reasons: []cleanup.Reason{cleanup.ReasonGoneUpstream}},
+		{RepoName: "testrepo", BareDir: filepath.Join(home, ".willow", "repos", "testrepo.git"), Branch: "stack-parent", WtDirName: "stack-parent", Path: parentPath, ExpectedBaseRef: baseRef, Reasons: []cleanup.Reason{cleanup.ReasonMergedPR}},
 	}
 
-	safe, skipped, err := filterMergedDeleteCandidates(items)
+	safe, skipped, err := cleanup.FilterSafe(candidates)
 	if err != nil {
-		t.Fatalf("filterMergedDeleteCandidates failed: %v", err)
+		t.Fatalf("FilterSafe failed: %v", err)
 	}
 
-	if got := branches(safe); len(got) != 1 || got[0] != "safe-merged" {
+	got := make([]string, len(safe))
+	for i, candidate := range safe {
+		got[i] = candidate.Branch
+	}
+	if len(got) != 1 || got[0] != "safe-merged" {
 		t.Fatalf("safe branches = %v, want [safe-merged]", got)
 	}
 
 	reasons := make(map[string]string)
 	for _, skip := range skipped {
-		reasons[skip.Item.Branch] = skip.Reason
+		reasons[skip.Candidate.Branch] = skip.Reason
 	}
 
 	if !strings.Contains(reasons["dirty-merged"], "uncommitted changes") {
 		t.Fatalf("dirty-merged reason = %q, want uncommitted changes", reasons["dirty-merged"])
 	}
-	if !strings.Contains(reasons["unpushed-merged"], "unpushed commits") {
-		t.Fatalf("unpushed-merged reason = %q, want unpushed commits", reasons["unpushed-merged"])
+	if !strings.Contains(reasons["local-only-gone"], "not merged into origin/"+mainBranch) {
+		t.Fatalf("local-only-gone reason = %q, want reachability skip", reasons["local-only-gone"])
 	}
 	if !strings.Contains(reasons["stack-parent"], "stacked children: stack-child") {
 		t.Fatalf("stack-parent reason = %q, want stacked child", reasons["stack-parent"])
@@ -2053,6 +2055,138 @@ func TestGc_CleansTrash(t *testing.T) {
 	}
 }
 
+func TestGcListsGoneUpstreamAndRespectsRepoFilter(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "goneone"); err != nil {
+		t.Fatalf("clone goneone failed: %v", err)
+	}
+	if err := runApp("clone", origin, "gonetwo"); err != nil {
+		t.Fatalf("clone gonetwo failed: %v", err)
+	}
+
+	createGoneUpstreamWorktree(t, home, origin, "goneone", "gone-one", false, false)
+	createGoneUpstreamWorktree(t, home, origin, "gonetwo", "gone-two", false, false)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("gc", "--repo", "goneone")
+	})
+	if err != nil {
+		t.Fatalf("gc --repo failed: %v", err)
+	}
+	if !strings.Contains(out, "gone-one (gone-upstream)") {
+		t.Fatalf("expected gone-one stale output, got:\n%s", out)
+	}
+	if strings.Contains(out, "gone-two") {
+		t.Fatalf("gc --repo should not include gonetwo, got:\n%s", out)
+	}
+}
+
+func TestGcNoFetchDoesNotDiscoverNewlyGoneUpstream(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "gcnofetch"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+	createGoneUpstreamWorktree(t, home, origin, "gcnofetch", "gone-without-prune", false, false)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("gc", "--repo", "gcnofetch", "--no-fetch")
+	})
+	if err != nil {
+		t.Fatalf("gc --no-fetch failed: %v", err)
+	}
+	if strings.Contains(out, "gone-without-prune") {
+		t.Fatalf("--no-fetch should not discover newly gone upstream, got:\n%s", out)
+	}
+}
+
+func TestGcPruneDeletesOnlySafeGoneUpstreamWorktrees(t *testing.T) {
+	origin := setupTestEnv(t)
+	home, _ := os.UserHomeDir()
+
+	if err := runApp("clone", origin, "gcstale"); err != nil {
+		t.Fatalf("clone failed: %v", err)
+	}
+
+	safePath := createGoneUpstreamWorktree(t, home, origin, "gcstale", "safe-gone", true, false)
+	localOnlyPath := createGoneUpstreamWorktree(t, home, origin, "gcstale", "local-only-gone", false, false)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdin: %v", err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+	if _, err := w.WriteString("y\n"); err != nil {
+		t.Fatalf("write confirmation: %v", err)
+	}
+	_ = w.Close()
+
+	out, err := captureStdout(t, func() error {
+		return runApp("gc", "--repo", "gcstale", "--prune")
+	})
+	os.Stdin = origStdin
+	if err != nil {
+		t.Fatalf("gc --prune failed: %v", err)
+	}
+	if !strings.Contains(out, "local-only-gone (not merged into origin/") {
+		t.Fatalf("expected local-only skip reason, got:\n%s", out)
+	}
+	if _, err := os.Stat(safePath); !os.IsNotExist(err) {
+		t.Fatalf("safe-gone should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(localOnlyPath); err != nil {
+		t.Fatalf("local-only-gone should remain, stat err=%v", err)
+	}
+}
+
+func createGoneUpstreamWorktree(t *testing.T, home, origin, repoName, branch string, mergeToBase, dirty bool) string {
+	t.Helper()
+
+	worktreeRoot := filepath.Join(home, ".willow", "worktrees", repoName)
+	mainDir := filepath.Join(worktreeRoot, firstWorktreeDir(t, worktreeRoot))
+	baseBranch := filepath.Base(mainDir)
+	if err := os.Chdir(mainDir); err != nil {
+		t.Fatalf("chdir main: %v", err)
+	}
+	if err := runApp("new", branch, "--repo", repoName, "--no-fetch"); err != nil {
+		t.Fatalf("new %s failed: %v", branch, err)
+	}
+
+	wtPath := filepath.Join(worktreeRoot, branch)
+	commitFile(t, wtPath, branch+".txt", branch+"\n", "add "+branch)
+	wtGit := &git.Git{Dir: wtPath}
+	if _, err := wtGit.Run("push", "-u", "origin", branch); err != nil {
+		t.Fatalf("push %s: %v", branch, err)
+	}
+
+	if mergeToBase {
+		mainGit := &git.Git{Dir: mainDir}
+		if _, err := mainGit.Run("merge", "--no-ff", branch, "-m", "merge "+branch); err != nil {
+			t.Fatalf("merge %s: %v", branch, err)
+		}
+		if _, err := mainGit.Run("push", "origin", baseBranch); err != nil {
+			t.Fatalf("push %s: %v", baseBranch, err)
+		}
+	}
+
+	if dirty {
+		if err := os.WriteFile(filepath.Join(wtPath, branch+".txt"), []byte(branch+"\ndirty\n"), 0o644); err != nil {
+			t.Fatalf("dirty write %s: %v", branch, err)
+		}
+	}
+
+	originGit := &git.Git{Dir: origin}
+	if _, err := originGit.Run("update-ref", "-d", "refs/heads/"+branch); err != nil {
+		t.Fatalf("delete remote branch %s: %v", branch, err)
+	}
+	return wtPath
+}
+
 func TestMergedWorktrees_UsesGitHubMergedPRsAcrossCLI(t *testing.T) {
 	origin := setupTestEnv(t)
 	home, _ := os.UserHomeDir()
@@ -2093,7 +2227,7 @@ func TestMergedWorktrees_UsesGitHubMergedPRsAcrossCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gc failed: %v", err)
 	}
-	if !strings.Contains(gcOut, "feature-merged (repo: mergedrepo)") {
+	if !strings.Contains(gcOut, "feature-merged (merged-pr)") {
 		t.Fatalf("expected gc output to include merged feature worktree, got:\n%s", gcOut)
 	}
 
@@ -2150,7 +2284,7 @@ func TestMergedWorktrees_OpenPRDoesNotMarkMergedAcrossCLI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gc failed: %v", err)
 	}
-	if strings.Contains(gcOut, "feature-open (repo: openprrepo)") {
+	if strings.Contains(gcOut, "feature-open") {
 		t.Fatalf("open PR worktree should not be offered as merged, got:\n%s", gcOut)
 	}
 
@@ -2207,7 +2341,7 @@ func TestMergedWorktrees_GitMergedBranchWithoutPRIsNotMerged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("gc failed: %v", err)
 	}
-	if strings.Contains(gcOut, "manual-merged (repo: gitmergedrepo)") {
+	if strings.Contains(gcOut, "manual-merged") {
 		t.Fatalf("git-only merged worktree should not be offered as PR-merged, got:\n%s", gcOut)
 	}
 }

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/cleanup"
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/errors"
 	"github.com/iamrajjoshi/willow/internal/fzf"
@@ -850,44 +851,47 @@ func tmuxPickDelete(self, selection string, items []tmux.PickerItem) error {
 }
 
 func tmuxPickDeleteMerged(self, currentSession string, items []tmux.PickerItem) error {
-	candidates, skippedCurrent := mergedDeleteCandidates(items, currentSession)
+	candidates, skippedCurrent, err := staleDeleteCandidates(items, currentSession)
+	if err != nil {
+		return err
+	}
 	if len(candidates) == 0 {
 		if skippedCurrent {
-			return errors.Userf("no merged worktrees available to delete (current session skipped)")
+			return errors.Userf("no stale worktrees available to delete (current session skipped)")
 		}
-		return errors.Userf("no merged worktrees available to delete")
+		return errors.Userf("no stale worktrees available to delete")
 	}
 
-	safe, skipped, err := filterMergedDeleteCandidates(candidates)
+	safe, skipped, err := cleanup.FilterSafe(candidates)
 	if err != nil {
 		return err
 	}
 
-	multiRepo := mergedDeleteHasMultipleRepos(items)
+	multiRepo := cleanup.HasMultipleRepos(candidates)
 	if len(safe) == 0 {
 		if skippedCurrent {
 			fmt.Fprintln(os.Stderr, "Skipping the active tmux session's worktree.")
 		}
 		if len(skipped) > 0 {
-			fmt.Fprintln(os.Stderr, "Skipping unsafe merged worktrees:")
+			fmt.Fprintln(os.Stderr, "Skipping unsafe stale worktrees:")
 			for _, skip := range skipped {
-				fmt.Fprintf(os.Stderr, "  %s (%s)\n", mergedDeleteLabel(skip.Item, multiRepo), skip.Reason)
+				fmt.Fprintf(os.Stderr, "  %s (%s)\n", cleanup.Label(skip.Candidate, multiRepo), skip.Reason)
 			}
 		}
-		return errors.Userf("no safe merged worktrees available to delete")
+		return errors.Userf("no safe stale worktrees available to delete")
 	}
 
-	fmt.Fprintf(os.Stderr, "Remove %d merged worktree(s)?\n", len(safe))
-	for _, item := range safe {
-		fmt.Fprintf(os.Stderr, "  %s\n", mergedDeleteLabel(item, multiRepo))
+	fmt.Fprintf(os.Stderr, "Remove %d safe stale worktree(s)?\n", len(safe))
+	for _, candidate := range safe {
+		fmt.Fprintf(os.Stderr, "  %s (%s)\n", cleanup.Label(candidate, multiRepo), candidate.ReasonString())
 	}
 	if skippedCurrent {
 		fmt.Fprintln(os.Stderr, "\nSkipping the active tmux session's worktree.")
 	}
 	if len(skipped) > 0 {
-		fmt.Fprintln(os.Stderr, "\nSkipping unsafe merged worktrees:")
+		fmt.Fprintln(os.Stderr, "\nSkipping unsafe stale worktrees:")
 		for _, skip := range skipped {
-			fmt.Fprintf(os.Stderr, "  %s (%s)\n", mergedDeleteLabel(skip.Item, multiRepo), skip.Reason)
+			fmt.Fprintf(os.Stderr, "  %s (%s)\n", cleanup.Label(skip.Candidate, multiRepo), skip.Reason)
 		}
 	}
 
@@ -899,124 +903,83 @@ func tmuxPickDeleteMerged(self, currentSession string, items []tmux.PickerItem) 
 	}
 
 	failures := 0
-	for _, item := range safe {
-		fmt.Fprintf(os.Stderr, "Removing %s...\n", mergedDeleteLabel(item, multiRepo))
-		if err := tmuxPickDeleteItem(self, item); err != nil {
+	for _, candidate := range safe {
+		fmt.Fprintf(os.Stderr, "Removing %s...\n", cleanup.Label(candidate, multiRepo))
+		item := pickerItemForCandidate(items, candidate)
+		if item == nil {
 			failures++
-			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", mergedDeleteLabel(item, multiRepo), err)
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: worktree not found\n", cleanup.Label(candidate, multiRepo))
+			continue
+		}
+		if err := tmuxPickDeleteItem(self, *item); err != nil {
+			failures++
+			fmt.Fprintf(os.Stderr, "Warning: failed to remove %s: %v\n", cleanup.Label(candidate, multiRepo), err)
 		}
 	}
 	if failures > 0 {
-		return fmt.Errorf("failed to remove %d merged worktree(s)", failures)
+		return fmt.Errorf("failed to remove %d stale worktree(s)", failures)
 	}
 
-	fmt.Fprintf(os.Stderr, "Removed %d merged worktree(s).\n", len(safe))
+	fmt.Fprintf(os.Stderr, "Removed %d stale worktree(s).\n", len(safe))
 	return nil
 }
 
-type mergedDeleteSkip struct {
-	Item   tmux.PickerItem
-	Reason string
-}
-
-func filterMergedDeleteCandidates(items []tmux.PickerItem) ([]tmux.PickerItem, []mergedDeleteSkip, error) {
-	bareDirs := make(map[string]string)
-	stacks := make(map[string]*stack.Stack)
-	var safe []tmux.PickerItem
-	var skipped []mergedDeleteSkip
-
-	for _, item := range items {
-		bareDir, ok := bareDirs[item.RepoName]
-		if !ok {
-			resolved, err := config.ResolveRepo(item.RepoName)
-			if err != nil {
-				return nil, nil, err
-			}
-			bareDir = resolved
-			bareDirs[item.RepoName] = bareDir
-			stacks[item.RepoName] = stack.Load(bareDir)
-		}
-
-		reason, err := mergedDeleteSkipReason(item, stacks[item.RepoName])
-		if err != nil {
-			return nil, nil, err
-		}
-		if reason != "" {
-			skipped = append(skipped, mergedDeleteSkip{Item: item, Reason: reason})
-			continue
-		}
-		safe = append(safe, item)
-	}
-
-	return safe, skipped, nil
-}
-
-func mergedDeleteCandidates(items []tmux.PickerItem, currentSession string) ([]tmux.PickerItem, bool) {
-	var candidates []tmux.PickerItem
+func staleDeleteCandidates(items []tmux.PickerItem, currentSession string) ([]cleanup.Candidate, bool, error) {
+	var candidates []cleanup.Candidate
 	skippedCurrent := false
 	for _, item := range items {
-		if !item.Merged {
+		if !item.IsStale() {
 			continue
 		}
 		if currentSession != "" && tmux.SessionNameForWorktree(item.RepoName, item.WtDirName) == currentSession {
 			skippedCurrent = true
 			continue
 		}
-		candidates = append(candidates, item)
+		candidate, err := cleanupCandidateForPickerItem(item)
+		if err != nil {
+			return nil, false, err
+		}
+		candidates = append(candidates, candidate)
 	}
-	return candidates, skippedCurrent
+	return candidates, skippedCurrent, nil
 }
 
-func mergedDeleteSkipReason(item tmux.PickerItem, st *stack.Stack) (string, error) {
-	var children []string
-	if st != nil {
-		children = st.Children(item.Branch)
-	}
-
-	wtGit := &git.Git{Dir: item.WtPath}
-	dirty, err := wtGit.IsDirty()
+func cleanupCandidateForPickerItem(item tmux.PickerItem) (cleanup.Candidate, error) {
+	bareDir, err := config.ResolveRepo(item.RepoName)
 	if err != nil {
-		return "", err
+		return cleanup.Candidate{}, err
 	}
-
-	unpushed, err := wtGit.HasUnpushedCommits()
-	if err != nil {
-		return "", err
+	reasons := item.StaleReasons
+	if len(reasons) == 0 && item.Merged {
+		reasons = []cleanup.Reason{cleanup.ReasonMergedPR}
 	}
-
-	return mergedDeleteSkipReasonFromState(children, dirty, unpushed), nil
+	expectedBaseRef := item.ExpectedBaseRef
+	if expectedBaseRef == "" {
+		repoGit := &git.Git{Dir: bareDir}
+		cfg := config.Load(bareDir)
+		st := stack.Load(bareDir)
+		baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
+		expectedBaseRef = cleanup.ExpectedBaseRef(repoGit, st, baseBranch, item.Branch)
+	}
+	return cleanup.Candidate{
+		RepoName:        item.RepoName,
+		BareDir:         bareDir,
+		Branch:          item.Branch,
+		Head:            item.Head,
+		Path:            item.WtPath,
+		WtDirName:       item.WtDirName,
+		ExpectedBaseRef: expectedBaseRef,
+		Reasons:         reasons,
+	}, nil
 }
 
-func mergedDeleteSkipReasonFromState(children []string, dirty, unpushed bool) string {
-	var reasons []string
-	if len(children) > 0 {
-		reasons = append(reasons, "stacked children: "+strings.Join(children, ", "))
-	}
-	if dirty {
-		reasons = append(reasons, "uncommitted changes")
-	}
-	if unpushed {
-		reasons = append(reasons, "unpushed commits")
-	}
-	return strings.Join(reasons, "; ")
-}
-
-func mergedDeleteLabel(item tmux.PickerItem, multiRepo bool) string {
-	if multiRepo {
-		return item.RepoName + "/" + item.Branch
-	}
-	return item.Branch
-}
-
-func mergedDeleteHasMultipleRepos(items []tmux.PickerItem) bool {
-	repos := make(map[string]bool)
-	for _, item := range items {
-		repos[item.RepoName] = true
-		if len(repos) > 1 {
-			return true
+func pickerItemForCandidate(items []tmux.PickerItem, candidate cleanup.Candidate) *tmux.PickerItem {
+	for i := range items {
+		if items[i].RepoName == candidate.RepoName && items[i].Branch == candidate.Branch && items[i].WtPath == candidate.Path {
+			return &items[i]
 		}
 	}
-	return false
+	return nil
 }
 
 func readTrimmedStdinLine() string {

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/cleanup"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
 	"github.com/iamrajjoshi/willow/internal/tmux"
@@ -24,6 +25,14 @@ func item(repo, branch string) tmux.PickerItem {
 }
 
 func branches(items []tmux.PickerItem) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.Branch
+	}
+	return out
+}
+
+func cleanupBranches(items []cleanup.Candidate) []string {
 	out := make([]string, len(items))
 	for i, it := range items {
 		out[i] = it.Branch
@@ -344,7 +353,8 @@ func TestTmuxPickDeleteArgsDetachedUsesDirName(t *testing.T) {
 	}
 }
 
-func TestMergedDeleteCandidates_SkipsCurrentSessionAndKeepsOrder(t *testing.T) {
+func TestStaleDeleteCandidates_SkipsCurrentSessionAndKeepsOrder(t *testing.T) {
+	setupTmuxCommandHome(t, "repo")
 	items := []tmux.PickerItem{
 		{RepoName: "repo", Branch: "main", WtDirName: "main"},
 		{RepoName: "repo", Branch: "feature-a", WtDirName: "feature-a", Merged: true},
@@ -352,70 +362,36 @@ func TestMergedDeleteCandidates_SkipsCurrentSessionAndKeepsOrder(t *testing.T) {
 		{RepoName: "repo", Branch: "feature-c", WtDirName: "feature-c", Merged: true},
 	}
 
-	got, skippedCurrent := mergedDeleteCandidates(items, "repo/feature-b")
+	got, skippedCurrent, err := staleDeleteCandidates(items, "repo/feature-b")
+	if err != nil {
+		t.Fatalf("staleDeleteCandidates: %v", err)
+	}
 	if !skippedCurrent {
 		t.Fatal("expected current session worktree to be skipped")
 	}
 
 	want := []string{"feature-a", "feature-c"}
-	assertBranches(t, branches(got), want)
+	assertBranches(t, cleanupBranches(got), want)
 }
 
-func TestMergedDeleteCandidates_NoCurrentSessionDeletesAllMerged(t *testing.T) {
+func TestStaleDeleteCandidates_NoCurrentSessionDeletesAllStale(t *testing.T) {
+	setupTmuxCommandHome(t, "repo", "other")
 	items := []tmux.PickerItem{
 		{RepoName: "repo", Branch: "main", WtDirName: "main"},
 		{RepoName: "repo", Branch: "feature-a", WtDirName: "feature-a", Merged: true},
-		{RepoName: "other", Branch: "feature-b", WtDirName: "feature-b", Merged: true},
+		{RepoName: "other", Branch: "feature-b", WtDirName: "feature-b", StaleReasons: []cleanup.Reason{cleanup.ReasonGoneUpstream}},
 	}
 
-	got, skippedCurrent := mergedDeleteCandidates(items, "")
+	got, skippedCurrent, err := staleDeleteCandidates(items, "")
+	if err != nil {
+		t.Fatalf("staleDeleteCandidates: %v", err)
+	}
 	if skippedCurrent {
 		t.Fatal("did not expect any current session skip")
 	}
 
 	want := []string{"feature-a", "feature-b"}
-	assertBranches(t, branches(got), want)
-}
-
-func TestMergedDeleteSkipReasonFromState(t *testing.T) {
-	tests := []struct {
-		name     string
-		children []string
-		dirty    bool
-		unpushed bool
-		want     string
-	}{
-		{
-			name: "safe",
-			want: "",
-		},
-		{
-			name:     "stacked children only",
-			children: []string{"child-a", "child-b"},
-			want:     "stacked children: child-a, child-b",
-		},
-		{
-			name:  "dirty only",
-			dirty: true,
-			want:  "uncommitted changes",
-		},
-		{
-			name:     "all reasons",
-			children: []string{"child-a"},
-			dirty:    true,
-			unpushed: true,
-			want:     "stacked children: child-a; uncommitted changes; unpushed commits",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := mergedDeleteSkipReasonFromState(tt.children, tt.dirty, tt.unpushed)
-			if got != tt.want {
-				t.Fatalf("got %q, want %q", got, tt.want)
-			}
-		})
-	}
+	assertBranches(t, cleanupBranches(got), want)
 }
 
 func TestAvailableExistingBranches(t *testing.T) {
@@ -519,24 +495,24 @@ func TestExtractBranchFromPRLine(t *testing.T) {
 	}
 }
 
-func TestMergedDeleteLabel(t *testing.T) {
-	item := tmux.PickerItem{RepoName: "repo-a", Branch: "feature-a"}
-	if got := mergedDeleteLabel(item, false); got != "feature-a" {
+func TestCleanupLabel(t *testing.T) {
+	item := cleanup.Candidate{RepoName: "repo-a", Branch: "feature-a"}
+	if got := cleanup.Label(item, false); got != "feature-a" {
 		t.Fatalf("single-repo label = %q, want feature-a", got)
 	}
-	if got := mergedDeleteLabel(item, true); got != "repo-a/feature-a" {
+	if got := cleanup.Label(item, true); got != "repo-a/feature-a" {
 		t.Fatalf("multi-repo label = %q, want repo-a/feature-a", got)
 	}
 }
 
-func TestMergedDeleteHasMultipleRepos(t *testing.T) {
-	if mergedDeleteHasMultipleRepos(nil) {
+func TestCleanupHasMultipleRepos(t *testing.T) {
+	if cleanup.HasMultipleRepos(nil) {
 		t.Fatal("empty item set should not count as multiple repos")
 	}
-	if mergedDeleteHasMultipleRepos([]tmux.PickerItem{item("repo-a", "main"), item("repo-a", "feature")}) {
+	if cleanup.HasMultipleRepos([]cleanup.Candidate{{RepoName: "repo-a"}, {RepoName: "repo-a"}}) {
 		t.Fatal("same repo items should not count as multiple repos")
 	}
-	if !mergedDeleteHasMultipleRepos([]tmux.PickerItem{item("repo-a", "main"), item("repo-b", "feature")}) {
+	if !cleanup.HasMultipleRepos([]cleanup.Candidate{{RepoName: "repo-a"}, {RepoName: "repo-b"}}) {
 		t.Fatal("different repo items should count as multiple repos")
 	}
 }
@@ -931,7 +907,7 @@ func TestTmuxPickDeleteKillsSessionAndRunsWillowRm(t *testing.T) {
 
 func TestTmuxPickDeleteMergedReportsNoCandidates(t *testing.T) {
 	self, _ := installFakeWillowForTmux(t, filepath.Join(t.TempDir(), "worktrees"))
-	if err := tmuxPickDeleteMerged(self, "", nil); err == nil || !strings.Contains(err.Error(), "no merged worktrees") {
+	if err := tmuxPickDeleteMerged(self, "", nil); err == nil || !strings.Contains(err.Error(), "no stale worktrees") {
 		t.Fatalf("tmuxPickDeleteMerged empty error = %v", err)
 	}
 	items := []tmux.PickerItem{{RepoName: "repo", Branch: "merged", WtDirName: "merged", Merged: true}}

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -10,8 +10,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/iamrajjoshi/willow/internal/claude"
+	"github.com/iamrajjoshi/willow/internal/cleanup"
 	"github.com/iamrajjoshi/willow/internal/config"
-	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/stack"
@@ -29,23 +29,29 @@ const (
 )
 
 type PickerItem struct {
-	RepoName    string
-	Branch      string
-	Head        string
-	Detached    bool
-	WtDirName   string
-	WtPath      string
-	Status      claude.Status
-	Unread      bool
-	HasSession  bool
-	Sessions    []*claude.SessionStatus
-	Merged      bool
-	StackPrefix string // tree-drawing prefix for stacked branches (e.g., "├─ ")
+	RepoName        string
+	Branch          string
+	Head            string
+	Detached        bool
+	WtDirName       string
+	WtPath          string
+	Status          claude.Status
+	Unread          bool
+	HasSession      bool
+	Sessions        []*claude.SessionStatus
+	Merged          bool
+	StaleReasons    []cleanup.Reason
+	ExpectedBaseRef string
+	StackPrefix     string // tree-drawing prefix for stacked branches (e.g., "├─ ")
+}
+
+func (item PickerItem) IsStale() bool {
+	return len(item.StaleReasons) > 0 || item.Merged
 }
 
 type pickerGroup struct {
 	items    []PickerItem
-	merged   bool
+	stale    bool
 	priority int
 }
 
@@ -118,31 +124,18 @@ func buildPickerItemsForRepo(ctx context.Context, repoName string, opts PickerBu
 		return result
 	}
 
-	cfg := config.Load(bareDir)
-	baseBranch := repoGit.ResolveBaseBranch(cfg.BaseBranch)
-	branchHeads := make(map[string]string, len(wts))
-	branchBases := make(map[string]string, len(wts))
-	repoDir := ""
-	for _, wt := range wts {
-		if !wt.IsBare && !wt.Detached && wt.Branch != "" {
-			if repoDir == "" {
-				repoDir = wt.Path
-			}
-			branchHeads[wt.Branch] = wt.Head
-			if parent := result.stack.Parent(wt.Branch); parent != "" {
-				branchBases[wt.Branch] = parent
-			}
-		}
-	}
-
-	done = trace.Span(ctx, "gh.MergedWorktreeSet/"+repoName)
-	var mergedSet map[string]bool
-	if opts.RefreshGitHubMerged {
-		mergedSet = gh.MergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
-	} else {
-		mergedSet = gh.CachedMergedWorktreeSet(repoDir, baseBranch, branchHeads, branchBases)
-	}
+	done = trace.Span(ctx, "cleanup.CandidatesForWorktrees/"+repoName)
+	candidates, err := cleanup.CandidatesForWorktrees(repoName, bareDir, wts, cleanup.ScanOptions{
+		RefreshPRState: opts.RefreshGitHubMerged,
+	})
 	done()
+	if err != nil {
+		candidates = nil
+	}
+	candidatesByBranch := make(map[string]cleanup.Candidate, len(candidates))
+	for _, candidate := range candidates {
+		candidatesByBranch[candidate.Branch] = candidate
+	}
 
 	done = trace.Span(ctx, "per-wt-loop/"+repoName)
 	for _, wt := range wts {
@@ -152,17 +145,20 @@ func buildPickerItemsForRepo(ctx context.Context, repoName string, opts PickerBu
 		wtDir := filepath.Base(wt.Path)
 		sessions := claude.ReadAllSessions(repoName, wtDir)
 		ws := claude.AggregateStatus(sessions)
+		candidate := candidatesByBranch[wt.Branch]
 		result.items = append(result.items, PickerItem{
-			RepoName:  repoName,
-			Branch:    wt.Branch,
-			Head:      wt.Head,
-			Detached:  wt.Detached,
-			WtDirName: wtDir,
-			WtPath:    wt.Path,
-			Status:    ws.Status,
-			Unread:    ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
-			Sessions:  sessions,
-			Merged:    !wt.Detached && mergedSet[wt.Branch],
+			RepoName:        repoName,
+			Branch:          wt.Branch,
+			Head:            wt.Head,
+			Detached:        wt.Detached,
+			WtDirName:       wtDir,
+			WtPath:          wt.Path,
+			Status:          ws.Status,
+			Unread:          ws.Status == claude.StatusDone && claude.CountUnreadIn(repoName, wtDir, sessions) > 0,
+			Sessions:        sessions,
+			Merged:          candidate.HasReason(cleanup.ReasonMergedPR),
+			StaleReasons:    candidate.Reasons,
+			ExpectedBaseRef: candidate.ExpectedBaseRef,
 		})
 	}
 	done()
@@ -183,8 +179,8 @@ func defaultPickerStackLoader(repoName string) *stack.Stack {
 func sortPickerItems(items []PickerItem, repoNames []string, loadStack pickerStackLoader) []PickerItem {
 	groups := buildPickerGroups(items, repoNames, loadStack)
 	sort.SliceStable(groups, func(i, j int) bool {
-		if groups[i].merged != groups[j].merged {
-			return !groups[i].merged
+		if groups[i].stale != groups[j].stale {
+			return !groups[i].stale
 		}
 		return groups[i].priority < groups[j].priority
 	})
@@ -273,12 +269,12 @@ func buildPickerGroups(items []PickerItem, repoNames []string, loadStack pickerS
 func newPickerGroup(items []PickerItem) pickerGroup {
 	group := pickerGroup{
 		items:    items,
-		merged:   true,
+		stale:    true,
 		priority: claude.WorktreeUrgencyOrder(claude.StatusOffline, false),
 	}
 	for _, item := range items {
-		if !item.Merged {
-			group.merged = false
+		if !item.IsStale() {
+			group.stale = false
 		}
 		priority := claude.WorktreeUrgencyOrder(item.Status, item.Unread)
 		if priority < group.priority {
@@ -309,9 +305,7 @@ func FormatPickerLines(items []PickerItem) []string {
 	nameW := 0
 	for _, item := range items {
 		plain := displayName(item, multiRepo)
-		if item.Merged {
-			plain += " [merged]"
-		}
+		plain += staleTagsPlain(item)
 		if utf8.RuneCountInString(plain) > nameW {
 			nameW = utf8.RuneCountInString(plain)
 		}
@@ -330,9 +324,12 @@ func FormatPickerLines(items []PickerItem) []string {
 
 		namePlain := displayName(item, multiRepo)
 		name := namePlain
-		if item.Merged {
-			namePlain += " [merged]"
-			name += fmt.Sprintf(" %s[merged]%s", colorDim, colorReset)
+		tags := staleTags(item)
+		if len(tags) > 0 {
+			namePlain += staleTagsPlain(item)
+			for _, tag := range tags {
+				name += fmt.Sprintf(" %s[%s]%s", colorDim, tag, colorReset)
+			}
 		}
 		padding := nameW - utf8.RuneCountInString(namePlain)
 		if padding < 0 {
@@ -413,6 +410,38 @@ func displayName(item PickerItem, multiRepo bool) string {
 		name = item.StackPrefix + name
 	}
 	return name
+}
+
+func staleTags(item PickerItem) []string {
+	if len(item.StaleReasons) == 0 && item.Merged {
+		return []string{"merged"}
+	}
+
+	tags := make([]string, 0, len(item.StaleReasons))
+	for _, reason := range item.StaleReasons {
+		switch reason {
+		case cleanup.ReasonMergedPR:
+			tags = append(tags, "merged")
+		case cleanup.ReasonGoneUpstream:
+			tags = append(tags, "gone")
+		}
+	}
+	return tags
+}
+
+func staleTagsPlain(item PickerItem) string {
+	tags := staleTags(item)
+	if len(tags) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, tag := range tags {
+		b.WriteString(" [")
+		b.WriteString(tag)
+		b.WriteString("]")
+	}
+	return b.String()
 }
 
 // ExtractPathFromLine pulls the worktree path from the last pipe-delimited field,

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -190,7 +190,7 @@ Pass a name to skip the picker: `ww sw auth-refactor`.
 
 Remove a worktree. Without arguments, opens fzf picker with multi-select (TAB to toggle, Ctrl-A to select all).
 
-From the tmux picker, `Ctrl-D` removes the selected worktree and `Ctrl-X` bulk-removes safe merged worktrees currently shown in the picker, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
+From the tmux picker, `Ctrl-D` removes the selected worktree and `Ctrl-X` bulk-removes safe stale worktrees currently shown in the picker. Stale means the exact current-head PR is merged or the branch's configured upstream is gone; the active tmux session, dirty worktrees, stacked parents, and remote-gone branches with local-only commits are skipped.
 
 ```bash
 ww rm auth-refactor              # direct removal
@@ -405,21 +405,25 @@ ww log --json                   # raw JSON output
 
 ### `ww gc`
 
-Clean up leftover trash from removed worktrees and, optionally, prune worktrees whose exact current-head PRs are merged.
+Clean up leftover trash from removed worktrees and list stale worktrees. Stale candidates are worktrees whose exact current-head PR is merged or whose configured upstream branch is gone after `git fetch --prune`.
 
 ```bash
-ww gc                    # empty <willow-base>/trash/ and list PR-merged worktrees
-ww gc --prune            # also interactively remove merged worktrees
+ww gc                    # empty <willow-base>/trash/ and list stale worktrees
+ww gc --repo myrepo      # scan one repo
+ww gc --no-fetch         # use local remote-tracking refs as-is
+ww gc --prune            # confirm and remove the safe subset
 ww gc --dry-run          # preview without touching anything
 ww gc --prune --dry-run  # list what --prune would remove
 ```
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--prune` | Interactively remove merged worktrees | `false` |
+| `--prune` | Interactively remove safe stale worktrees | `false` |
 | `--dry-run` | Show what would be cleaned up without removing anything | `false` |
+| `-r, --repo` | Target a willow-managed repo by name | All repos |
+| `--no-fetch` | Skip `git fetch --prune` before scanning | `false` |
 
-Without `--prune`, willow only empties the trash directory and prints the commands you'd run to remove each merged worktree. With `--prune`, it checks GitHub PR state and only treats a worktree as merged when the PR head branch, head SHA, and expected base branch match the current worktree. If `gh` is missing or lookup fails, willow skips merged detection instead of falling back to Git ancestry.
+Without `--prune`, willow only empties the trash directory and prints the commands you'd run to remove each stale worktree. With `--prune`, it removes only safe stale candidates: dirty worktrees, branches with stacked children, and remote-gone branches whose commits are not reachable from their expected base are skipped. PR-merged worktrees use the existing exact GitHub match and do not fall back to Git ancestry.
 
 ## Agents
 
@@ -594,7 +598,7 @@ ww tmux install           # print tmux.conf lines to add
 ```
 
 Setup: `ww tmux install` prints the config to add to `~/.tmux.conf`, including a `prefix + w` keybinding for the picker popup.
-Inside the picker, `Ctrl-T` creates a detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree, `Ctrl-D` deletes the selected worktree, and `Ctrl-X` bulk-deletes safe merged worktrees currently shown, skipping the active tmux session plus any merged worktrees with local changes, unpushed commits, or stacked children.
+Inside the picker, `Ctrl-T` creates a detached worktree from the selected HEAD, `Ctrl-U` promotes a selected detached worktree, `Ctrl-D` deletes the selected worktree, and `Ctrl-X` bulk-deletes safe stale worktrees currently shown, skipping the active tmux session plus any dirty worktrees, stacked parents, or remote-gone branches with local-only commits.
 By default, the picker shows a right-side live preview. Set `"tmux": {"switcherPreview": false}` in config to hide it, use the full popup for fzf, and make `ww tmux install` emit a compact `70%` by `70%` popup binding.
 
 ### Aliases

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -47,7 +47,7 @@ Set `"tmux": {"switcherPreview": false}` in config to hide that panel, use the f
 | `Ctrl-G` | Dispatch: create worktree from query text as prompt, launch Claude Code |
 | `Ctrl-S` | Sync stacked worktrees (selected branch's subtree, or all) |
 | `Ctrl-D` | Delete selected worktree and its tmux session |
-| `Ctrl-X` | Delete merged worktrees currently shown, skipping unsafe ones |
+| `Ctrl-X` | Delete stale worktrees currently shown, skipping unsafe ones |
 | `Esc` | Close picker |
 
 ### Dispatch
@@ -76,9 +76,9 @@ Rename refuses to overwrite an existing tmux session. If you use the shell integ
 
 Press `Ctrl-E` to open a secondary picker showing all remote branches that don't already have worktrees. Willow opens this picker immediately from cached refs, then refreshes from origin in the background (unless `defaults.fetch` is disabled) so freshly pushed branches appear without blocking the initial render. Press `Ctrl-R` inside the branch picker to force a synchronous refresh.
 
-### Merged worktree indicator
+### Stale worktree cleanup
 
-Worktrees whose exact current-head PR is merged show a dim `[merged]` tag. Willow matches the PR head branch, head SHA, and expected base branch, using stack parents as the base for stacked branches. The picker uses cached GitHub PR-state results on open so slow PR lookups don't block rendering. These sort to the bottom of the list, making it easy to spot stale worktrees. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session and any merged worktrees with local changes, unpushed commits, or stacked children are skipped), or use `ww gc --prune`.
+Worktrees whose exact current-head PR is merged show a dim `[merged]` tag, and worktrees whose configured upstream branch is gone show `[gone]`. Willow matches PRs by head branch, head SHA, and expected base branch, using stack parents as the base for stacked branches. The picker uses cached GitHub PR-state results on open so slow PR lookups don't block rendering. Stale rows and fully stale stack groups sort toward the bottom of the list. Clean them up one at a time with `Ctrl-D`, bulk-delete the safe subset currently shown with `Ctrl-X` (the active tmux session, dirty worktrees, stacked parents, and remote-gone branches with local-only commits are skipped), or use `ww gc --prune`.
 
 ### Features
 

--- a/website/src/lib/docs-nav.ts
+++ b/website/src/lib/docs-nav.ts
@@ -92,7 +92,7 @@ export const DOCS_NAV: DocNavGroup[] = [
           { id: "pr-picker", text: "PR picker", level: 3 },
           { id: "renaming-worktrees", text: "Renaming worktrees", level: 3 },
           { id: "existing-branch-picker", text: "Existing branch picker", level: 3 },
-          { id: "merged-worktree-indicator", text: "Merged worktree indicator", level: 3 },
+          { id: "stale-worktree-cleanup", text: "Stale worktree cleanup", level: 3 },
           { id: "features", text: "Features", level: 3 },
           { id: "status-bar-widget", text: "Status bar widget", level: 2 },
           { id: "configuration", text: "Configuration", level: 3 },


### PR DESCRIPTION
## Description of the change
Adds a consolidated stale worktree cleanup path for Willow. `ww gc` now reports worktrees whose exact current-head PR is merged or whose configured upstream is gone, and `ww gc --prune` removes only the safe subset using shared cleanup rules. The tmux picker now uses the same stale cleanup logic for `Ctrl-X` and shows `[gone]` alongside existing `[merged]` tags.

**Ticket:** 

## Test plan
Go unit and integration tests; website production build.

## Loom or screenshots

## Considerations
`ww gc --prune` skips dirty worktrees, branches with stacked children, and remote-gone branches whose commits are not reachable from their expected base.