### PR TITLE
:sparkles: feat[notify]: surface desktop notification config

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ ww log --json                   # raw JSON output
 
 Desktop notifications fire directly from Claude Code's hook system — no daemon, no polling. Run `ww cc-setup` once; whenever an agent transitions from BUSY to DONE or WAIT, a macOS Notification Center alert appears within ~200ms.
 
-Enable with `"notify": {"desktop": true}` in config. Set `"notify": {"command": "..."}` to run a custom shell command instead (it receives `WILLOW_NOTIFY_TITLE` and `WILLOW_NOTIFY_BODY` env vars). The tmux status bar widget uses a separate sound-only channel and is unaffected.
+Desktop notifications are enabled by default. Set `"notify": {"desktop": false}` to disable them, or set `"notify": {"command": "..."}` to run a custom shell command instead (it receives `WILLOW_NOTIFY_TITLE` and `WILLOW_NOTIFY_BODY` env vars). The tmux status bar widget uses a separate sound-only channel and is unaffected.
 
 ### `ww dispatch <prompt> [flags]`
 
@@ -529,6 +529,10 @@ Config merges two tiers (local wins):
   "defaults": {
     "fetch": true,
     "autoSetupRemote": true
+  },
+  "notify": {
+    "desktop": true,
+    "command": ""
   },
   "tmux": {
     "switcherPreview": true,

--- a/internal/cli/config_cmd.go
+++ b/internal/cli/config_cmd.go
@@ -93,6 +93,8 @@ func configShowCmd() *cli.Command {
 			printField("teardown", merged.Teardown, fieldSourceSlice(local.Teardown, global.Teardown, def.Teardown))
 			printField("defaults.fetch", merged.Defaults.Fetch, fieldSourceBoolPtr(local.Defaults.Fetch, global.Defaults.Fetch, def.Defaults.Fetch))
 			printField("defaults.autoSetupRemote", merged.Defaults.AutoSetupRemote, fieldSourceBoolPtr(local.Defaults.AutoSetupRemote, global.Defaults.AutoSetupRemote, def.Defaults.AutoSetupRemote))
+			printField("notify.desktop", merged.Notify.Desktop, fieldSourceBoolPtr(local.Notify.Desktop, global.Notify.Desktop, def.Notify.Desktop))
+			printField("notify.command", merged.Notify.Command, fieldSource(local.Notify.Command, global.Notify.Command, def.Notify.Command))
 			printField("tmux.reloadInterval", merged.Tmux.ReloadInterval, fieldSource(local.Tmux.ReloadInterval, global.Tmux.ReloadInterval, def.Tmux.ReloadInterval))
 			printField("tmux.notification", merged.Tmux.Notification, fieldSourceBoolPtr(local.Tmux.Notification, global.Tmux.Notification, def.Tmux.Notification))
 			printField("tmux.notifyCommand", merged.Tmux.NotifyCommand, fieldSource(local.Tmux.NotifyCommand, global.Tmux.NotifyCommand, def.Tmux.NotifyCommand))

--- a/internal/cli/config_cmd_test.go
+++ b/internal/cli/config_cmd_test.go
@@ -82,7 +82,36 @@ func TestConfigShowPrintsSourceAnnotationsAndWarnings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("config show failed: %v", err)
 	}
-	for _, want := range []string{"baseDir:", "# default", "tmux.panes:", "# global", "tmux.panes configured"} {
+	for _, want := range []string{"baseDir:", "# default", "notify.desktop:", "tmux.panes:", "# global", "tmux.panes configured"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("config show output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestConfigShowPrintsNotifyConfigSources(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfgPath := config.GlobalConfigPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte(`{"notify":{"desktop":false,"command":"printf notify"}}`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	out, err := captureStdout(t, func() error {
+		return runApp("config", "show")
+	})
+	if err != nil {
+		t.Fatalf("config show failed: %v", err)
+	}
+	for _, want := range []string{
+		"notify.desktop:",
+		"false  # global",
+		"notify.command:",
+		`"printf notify"  # global`,
+	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("config show output missing %q:\n%s", want, out)
 		}

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -36,6 +36,8 @@ func setupCmd() *cli.Command {
 			u.Info("")
 			u.Info("Claude Code will now report agent status for willow-managed worktrees.")
 			u.Info("Use 'ww status' or 'ww ls' to see agent status.")
+			u.Info("Desktop notifications are enabled by default for agent finish/input events.")
+			u.Info("Set notify.desktop=false to disable, or notify.command to customize.")
 
 			cfg := config.Load("")
 			if cfg.Telemetry == nil {

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -21,7 +21,7 @@ func TestSetupCmdInstallsHooksWithExistingTelemetryPreference(t *testing.T) {
 		t.Fatalf("cc-setup failed: %v", err)
 	}
 
-	for _, want := range []string{"Installed Claude Code hooks", "hook:", "status:"} {
+	for _, want := range []string{"Installed Claude Code hooks", "hook:", "status:", "Desktop notifications are enabled by default", "notify.command"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("cc-setup output missing %q:\n%s", want, out)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,9 @@ func DefaultConfig() *Config {
 		Tmux: TmuxConfig{
 			SwitcherPreview: BoolPtr(true),
 		},
+		Notify: NotifyConfig{
+			Desktop: BoolPtr(true),
+		},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -28,6 +28,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Tmux.SwitcherPreview == nil || !*cfg.Tmux.SwitcherPreview {
 		t.Error("Tmux.SwitcherPreview should be true")
 	}
+	if cfg.Notify.Desktop == nil || !*cfg.Notify.Desktop {
+		t.Error("Notify.Desktop should be true")
+	}
 }
 
 func TestMerge_StringOverride(t *testing.T) {

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -427,7 +427,7 @@ Without `--prune`, willow only empties the trash directory and prints the comman
 
 Desktop notifications fire directly from Claude Code's hook system after you run `ww cc-setup` — there's no daemon, no polling, and no `ww notify` subcommand. Whenever an agent transitions from `BUSY` to `DONE` or `WAIT`, the hook fires a macOS Notification Center alert within ~200ms.
 
-**Enable desktop notifications:** Set `"notify": {"desktop": true}` in config. The tmux status bar is a separate channel and is unaffected.
+**Desktop notifications:** Enabled by default. Set `"notify": {"desktop": false}` in config to disable them. The tmux status bar is a separate channel and is unaffected.
 
 **Custom notification command:** Set `notify.command` in config to run your own script instead of the built-in dispatch. The command receives `WILLOW_NOTIFY_TITLE` and `WILLOW_NOTIFY_BODY` as environment variables.
 

--- a/website/src/app/(docs)/configuration/page.mdx
+++ b/website/src/app/(docs)/configuration/page.mdx
@@ -39,6 +39,10 @@ The local config lives inside the bare repo directory, so it's private to your m
     "fetch": true,
     "autoSetupRemote": true
   },
+  "notify": {
+    "desktop": true,
+    "command": ""
+  },
   "tmux": {
     "notification": true,
     "notifyCommand": "afplay /System/Library/Sounds/Glass.aiff",
@@ -65,6 +69,8 @@ The local config lives inside the bare repo directory, so it's private to your m
 | `teardown` | `string[]` | Commands to run before removing a worktree |
 | `defaults.fetch` | `boolean` | Whether to fetch before creating a worktree |
 | `defaults.autoSetupRemote` | `boolean` | Auto-configure remote tracking for new branches |
+| `notify.desktop` | `boolean` | Send desktop notifications from Claude Code hooks when an agent finishes or needs input (default: `true`) |
+| `notify.command` | `string` | Custom command for non-tmux notifications. Receives `WILLOW_NOTIFY_TITLE` and `WILLOW_NOTIFY_BODY` |
 | `tmux.notification` | `boolean` | Play sound on BUSY→DONE transitions (default: `true`) |
 | `tmux.notifyCommand` | `string` | Command to run for notifications (default: `afplay Glass.aiff`) |
 | `tmux.switcherPreview` | `boolean` | Show the right-side live preview in the tmux picker. Set to `false` for an fzf-only picker and compact `ww tmux install` popup binding (default: `true`) |


### PR DESCRIPTION
## Description of the change

Make Willow’s existing non-tmux desktop notification support easier to discover.

- show `notify.desktop` and `notify.command` in `ww config show`
- make `ww cc-setup` mention finish/input desktop notifications
- document the top-level `notify` config in README and website docs

## Test plan

- `env GOCACHE=/tmp/willow-gocache go test ./internal/claude ./internal/notify ./internal/tmux ./internal/cli -count=1`
- `pnpm --dir website build`
