### PR TITLE
:sparkles: feat[tmux]: show agent harness labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ After running `ww cc-setup`, `ww codex-setup`, or `ww agent setup all`, supporte
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
+Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. In the tmux picker, active parent rows include a harness label like `[claude]` or `[codex]`; multiple same-harness sessions show `[claude x2]`, and mixed harnesses show `[mixed]` with per-session sub-rows. Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
 
 ## Configuration
 

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -313,9 +313,14 @@ func FormatPickerLines(items []PickerItem) []string {
 
 	var lines []string
 	for _, item := range items {
+		activeSessions := filterActiveSessions(item.Sessions)
 		color := statusColor(item.Status)
 		icon := agent.StatusIcon(item.Status)
 		label := fmt.Sprintf("%-7s", agent.StatusLabel(item.Status))
+		harnessLabel := harnessSummaryLabel(activeSessions)
+		if harnessLabel != "" {
+			harnessLabel = " " + colorDim + harnessLabel + colorReset
+		}
 
 		dot := " "
 		if item.Unread {
@@ -337,14 +342,13 @@ func FormatPickerLines(items []PickerItem) []string {
 		}
 		nameCol := name + strings.Repeat(" ", padding)
 
-		line := fmt.Sprintf("%s%s %s%s%s | %s | %s%s%s",
-			color, icon, label, dot, colorReset,
+		line := fmt.Sprintf("%s%s %s%s%s%s | %s | %s%s%s",
+			color, icon, label, dot, colorReset, harnessLabel,
 			nameCol,
 			colorDim, shortenPathWithHome(item.WtPath, home), colorReset,
 		)
 		lines = append(lines, line)
 
-		activeSessions := filterActiveSessions(item.Sessions)
 		if len(activeSessions) > 1 {
 			for _, ss := range activeSessions {
 				effStatus := agent.EffectiveStatus(ss.Status, ss.Timestamp)
@@ -384,6 +388,32 @@ func FormatPickerLines(items []PickerItem) []string {
 		}
 	}
 	return lines
+}
+
+func harnessSummaryLabel(sessions []*agent.SessionStatus) string {
+	if len(sessions) == 0 {
+		return ""
+	}
+
+	counts := map[string]int{}
+	for _, ss := range sessions {
+		name := strings.TrimSpace(ss.Harness)
+		if name == "" {
+			name = "claude"
+		}
+		counts[name]++
+	}
+	if len(counts) != 1 {
+		return "[mixed]"
+	}
+
+	for name, count := range counts {
+		if count > 1 {
+			return fmt.Sprintf("[%s x%d]", name, count)
+		}
+		return "[" + name + "]"
+	}
+	return ""
 }
 
 func filterActiveSessions(sessions []*agent.SessionStatus) []*agent.SessionStatus {

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -323,6 +323,79 @@ func TestFormatPickerLinesMultiRepoMergedUnreadAndSubSessions(t *testing.T) {
 	}
 }
 
+func TestFormatPickerLinesHarnessSummaryLabels(t *testing.T) {
+	t.Setenv("HOME", "/fakehome")
+	now := time.Now()
+
+	lines := FormatPickerLines([]PickerItem{
+		{
+			RepoName: "repo",
+			Branch:   "codex-single",
+			WtPath:   "/fakehome/worktrees/repo/codex-single",
+			Status:   agent.StatusDone,
+			Sessions: []*agent.SessionStatus{
+				{Harness: "codex", SessionID: "codex-session", Status: agent.StatusDone, Timestamp: now},
+			},
+		},
+		{
+			RepoName: "repo",
+			Branch:   "claude-pair",
+			WtPath:   "/fakehome/worktrees/repo/claude-pair",
+			Status:   agent.StatusBusy,
+			Sessions: []*agent.SessionStatus{
+				{Harness: "claude", SessionID: "claude-one", Status: agent.StatusBusy, Timestamp: now},
+				{Harness: "claude", SessionID: "claude-two", Status: agent.StatusDone, Timestamp: now},
+			},
+		},
+		{
+			RepoName: "repo",
+			Branch:   "mixed",
+			WtPath:   "/fakehome/worktrees/repo/mixed",
+			Status:   agent.StatusBusy,
+			Sessions: []*agent.SessionStatus{
+				{Harness: "claude", SessionID: "claude-session", Status: agent.StatusBusy, Timestamp: now},
+				{Harness: "codex", SessionID: "codex-session", Status: agent.StatusDone, Timestamp: now},
+			},
+		},
+		{
+			RepoName: "repo",
+			Branch:   "idle-only",
+			WtPath:   "/fakehome/worktrees/repo/idle-only",
+			Status:   agent.StatusIdle,
+			Sessions: []*agent.SessionStatus{
+				{Harness: "codex", SessionID: "idle-session", Status: agent.StatusIdle, Timestamp: now},
+			},
+		},
+	})
+
+	if len(lines) != 8 {
+		t.Fatalf("FormatPickerLines() returned %d lines, want 8: %#v", len(lines), lines)
+	}
+
+	plain := make([]string, len(lines))
+	for i, line := range lines {
+		plain[i] = stripAnsi(line)
+	}
+
+	for _, tt := range []struct {
+		line int
+		want string
+	}{
+		{line: 0, want: "[codex]"},
+		{line: 1, want: "[claude x2]"},
+		{line: 4, want: "[mixed]"},
+		{line: 5, want: "claude:claude-s"},
+		{line: 6, want: "codex:codex-se"},
+	} {
+		if !strings.Contains(plain[tt.line], tt.want) {
+			t.Fatalf("line %d missing %q:\n%s", tt.line, tt.want, strings.Join(plain, "\n"))
+		}
+	}
+	if strings.Contains(plain[7], "[codex]") {
+		t.Fatalf("idle-only parent should not show inactive harness label:\n%s", plain[7])
+	}
+}
+
 func TestBuildPickerItemsUsesRepoWorktreesAndStatuses(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -501,7 +501,7 @@ After running `ww cc-setup`, `ww codex-setup`, or `ww agent setup all`, supporte
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
+Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`. The tmux picker labels active parent rows with the harness name (`[claude]`, `[codex]`, `[claude x2]`, or `[mixed]`) so single-session worktrees are easy to distinguish.
 
 ## Configuration
 

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -90,6 +90,7 @@ Worktrees whose exact current-head PR is merged show a dim `[merged]` tag, and w
 - **Urgency sort** — current session first, then `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline
 - **Status colors** — BUSY (green), WAIT (red), DONE (blue), IDLE (yellow)
 - **Unread indicator** — `●` marks completed sessions you haven't viewed
+- **Harness labels** — active parent rows show `[claude]`, `[codex]`, `[claude x2]`, or `[mixed]`
 - **Merged indicator** — `[merged]` marks worktrees whose exact current-head PR is merged when `gh` data is available
 - **Stack-aware ordering** — stacked branches stay grouped together and inherit the most urgent item in the tree
 - **Multi-agent sub-rows** — when a worktree has multiple active sessions, each is shown as an indented sub-row with its harness label, status, and tool info


### PR DESCRIPTION
## Description of the change
Show plain harness labels on active tmux picker parent rows so single-session Claude and Codex worktrees are distinguishable at a glance. Multiple same-harness sessions render like `[claude x2]`, and mixed harnesses render `[mixed]` with the existing detailed sub-rows.

## Test plan
Go test suite, website build, and diff whitespace check.

Generated with Codex.