### PR TITLE
:bug: fix[tmux]: hide parent labels for multi-session agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ After running `ww cc-setup`, `ww codex-setup`, or `ww agent setup all`, supporte
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. In the tmux picker, active parent rows include a harness label like `[claude]` or `[codex]`; multiple same-harness sessions show `[claude x2]`, and mixed harnesses show `[mixed]` with per-session sub-rows. Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
+Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. In the tmux picker, active parent rows with one session include a harness label like `[claude]` or `[codex]`; multi-session rows rely on the labeled child rows. Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
 
 ## Configuration
 

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -391,29 +391,14 @@ func FormatPickerLines(items []PickerItem) []string {
 }
 
 func harnessSummaryLabel(sessions []*agent.SessionStatus) string {
-	if len(sessions) == 0 {
+	if len(sessions) != 1 {
 		return ""
 	}
-
-	counts := map[string]int{}
-	for _, ss := range sessions {
-		name := strings.TrimSpace(ss.Harness)
-		if name == "" {
-			name = "claude"
-		}
-		counts[name]++
+	name := strings.TrimSpace(sessions[0].Harness)
+	if name == "" {
+		name = "claude"
 	}
-	if len(counts) != 1 {
-		return "[mixed]"
-	}
-
-	for name, count := range counts {
-		if count > 1 {
-			return fmt.Sprintf("[%s x%d]", name, count)
-		}
-		return "[" + name + "]"
-	}
-	return ""
+	return "[" + name + "]"
 }
 
 func filterActiveSessions(sessions []*agent.SessionStatus) []*agent.SessionStatus {

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -382,13 +382,22 @@ func TestFormatPickerLinesHarnessSummaryLabels(t *testing.T) {
 		want string
 	}{
 		{line: 0, want: "[codex]"},
-		{line: 1, want: "[claude x2]"},
-		{line: 4, want: "[mixed]"},
 		{line: 5, want: "claude:claude-s"},
 		{line: 6, want: "codex:codex-se"},
 	} {
 		if !strings.Contains(plain[tt.line], tt.want) {
 			t.Fatalf("line %d missing %q:\n%s", tt.line, tt.want, strings.Join(plain, "\n"))
+		}
+	}
+	for _, tt := range []struct {
+		line  int
+		label string
+	}{
+		{line: 1, label: "[claude x2]"},
+		{line: 4, label: "[mixed]"},
+	} {
+		if strings.Contains(plain[tt.line], tt.label) {
+			t.Fatalf("multi-session parent line %d should not show %q:\n%s", tt.line, tt.label, plain[tt.line])
 		}
 	}
 	if strings.Contains(plain[7], "[codex]") {

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -501,7 +501,7 @@ After running `ww cc-setup`, `ww codex-setup`, or `ww agent setup all`, supporte
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`. The tmux picker labels active parent rows with the harness name (`[claude]`, `[codex]`, `[claude x2]`, or `[mixed]`) so single-session worktrees are easy to distinguish.
+Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`. The tmux picker labels active parent rows with one session (`[claude]` or `[codex]`) so single-session worktrees are easy to distinguish; multi-session rows rely on the labeled child rows.
 
 ## Configuration
 

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -90,7 +90,7 @@ Worktrees whose exact current-head PR is merged show a dim `[merged]` tag, and w
 - **Urgency sort** — current session first, then `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline
 - **Status colors** — BUSY (green), WAIT (red), DONE (blue), IDLE (yellow)
 - **Unread indicator** — `●` marks completed sessions you haven't viewed
-- **Harness labels** — active parent rows show `[claude]`, `[codex]`, `[claude x2]`, or `[mixed]`
+- **Harness labels** — active single-session parent rows show `[claude]` or `[codex]`; multi-session rows use labeled child rows
 - **Merged indicator** — `[merged]` marks worktrees whose exact current-head PR is merged when `gh` data is available
 - **Stack-aware ordering** — stacked branches stay grouped together and inherit the most urgent item in the tree
 - **Multi-agent sub-rows** — when a worktree has multiple active sessions, each is shown as an indented sub-row with its harness label, status, and tool info


### PR DESCRIPTION
## Description of the change
Only show tmux picker parent harness labels when a worktree has exactly one active agent session. Worktrees with multiple active sessions now leave the parent row clean and rely on the existing child rows, which already include `harness:session` labels.

## Test plan
Go test suite, website build, diff whitespace check, and a local `go run ./cmd/willow tmux list --repo evergreen` render check.

Generated with Codex.