### PR TITLE
:bug: fix[cli]: keep list output width-safe

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/getsentry/sentry-go v0.44.1
 	github.com/junegunn/fzf v0.70.0
+	github.com/mattn/go-runewidth v0.0.16
 	github.com/urfave/cli/v3 v3.6.2
 	golang.org/x/term v0.34.0
 )
@@ -16,7 +17,6 @@ require (
 	github.com/junegunn/go-shellwords v0.0.0-20250127100254-2aa3b3277741 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/iamrajjoshi/willow/internal/log"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 	"github.com/iamrajjoshi/willow/internal/trace"
+	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/urfave/cli/v3"
 )
 
@@ -77,33 +79,77 @@ func logCmd() *cli.Command {
 				return enc.Encode(events)
 			}
 
-			actionW, repoW, branchW := 0, 0, 0
-			for _, e := range events {
-				if len(e.Action) > actionW {
-					actionW = len(e.Action)
-				}
-				if len(e.Repo) > repoW {
-					repoW = len(e.Repo)
-				}
-				if len(e.Branch) > branchW {
-					branchW = len(e.Branch)
-				}
-			}
-
-			for _, e := range events {
-				ts := e.Timestamp.Local().Format("Jan 02 15:04")
-				meta := formatMetadata(e.Metadata)
-				line := fmt.Sprintf("  %s  %-*s  %-*s  %-*s",
-					u.Dim(ts), actionW, e.Action, repoW, e.Repo, branchW, e.Branch)
-				if meta != "" {
-					line += "  " + u.Dim(meta)
-				}
+			for _, line := range formatLogLines(u, events, termfmt.TerminalWidth()) {
 				u.Info(line)
 			}
 
 			return nil
 		},
 	}
+}
+
+func formatLogLines(u *ui.UI, events []log.Event, width int) []string {
+	type row struct {
+		ts     string
+		action string
+		repo   string
+		branch string
+		meta   string
+	}
+	rows := make([]row, 0, len(events))
+	tsW, actionW, repoW, branchW, metaW := 0, 0, 0, 0, 0
+	for _, e := range events {
+		r := row{
+			ts:     e.Timestamp.Local().Format("Jan 02 15:04"),
+			action: e.Action,
+			repo:   e.Repo,
+			branch: e.Branch,
+			meta:   formatMetadata(e.Metadata),
+		}
+		rows = append(rows, r)
+		tsW = max(tsW, termfmt.VisibleWidth(r.ts))
+		actionW = max(actionW, termfmt.VisibleWidth(r.action))
+		repoW = max(repoW, termfmt.VisibleWidth(r.repo))
+		branchW = max(branchW, termfmt.VisibleWidth(r.branch))
+		metaW = max(metaW, termfmt.VisibleWidth(r.meta))
+	}
+
+	termWidth := termfmt.Width(width)
+	fixedWithoutBranchMeta := 2 + tsW + 2 + actionW + 2 + repoW
+	hasMeta := metaW > 0
+	if hasMeta {
+		fixedWithoutBranchMeta += 2
+	}
+	available := termWidth - fixedWithoutBranchMeta
+	if hasMeta && branchW+2+metaW > available {
+		if metaAvailable := available - branchW - 2; metaAvailable >= 1 {
+			metaW = min(metaW, metaAvailable)
+		} else {
+			metaW = 1
+			branchAvailable := available - metaW - 2
+			if branchAvailable < 1 {
+				branchAvailable = 1
+			}
+			branchW = min(branchW, branchAvailable)
+		}
+	} else if !hasMeta && branchW > available {
+		branchW = max(1, available)
+	}
+
+	lines := make([]string, 0, len(rows))
+	for _, r := range rows {
+		line := fmt.Sprintf("  %s  %s  %s  %s",
+			u.Dim(termfmt.FitRight(r.ts, tsW)),
+			termfmt.FitRight(r.action, actionW),
+			termfmt.FitRight(r.repo, repoW),
+			termfmt.FitRight(r.branch, branchW),
+		)
+		if hasMeta {
+			line += "  " + u.Dim(termfmt.FitRight(r.meta, metaW))
+		}
+		lines = append(lines, line)
+	}
+	return lines
 }
 
 func formatMetadata(m map[string]string) string {

--- a/internal/cli/log_cmd_test.go
+++ b/internal/cli/log_cmd_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	activitylog "github.com/iamrajjoshi/willow/internal/log"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
+	"github.com/iamrajjoshi/willow/internal/ui"
 )
 
 func TestParseDurationSupportsDaysAndReportsBadInput(t *testing.T) {
@@ -45,6 +47,32 @@ func TestFormatMetadataSkipsEmptyAndTruncatesLongValues(t *testing.T) {
 	}
 	if !strings.Contains(got, "long="+strings.Repeat("x", 57)+"...") {
 		t.Fatalf("formatMetadata missing truncated long value: %q", got)
+	}
+}
+
+func TestFormatLogLinesFitsNarrowWidth(t *testing.T) {
+	u := &ui.UI{}
+	ts := time.Date(2026, 6, 22, 12, 30, 0, 0, time.UTC)
+	events := []activitylog.Event{
+		{
+			Action:    "create",
+			Repo:      "evergreen",
+			Branch:    "raj--tprm-464--backend-validate-review-risk-subtype",
+			Timestamp: ts,
+			Metadata:  map[string]string{"path": strings.Repeat("x", 80)},
+		},
+	}
+	lines := formatLogLines(u, events, 72)
+	for _, line := range lines {
+		if got := termfmt.VisibleWidth(line); got > 72 {
+			t.Fatalf("line width = %d, want <= 72:\n%s", got, termfmt.StripANSI(line))
+		}
+	}
+	plain := termfmt.StripANSI(strings.Join(lines, "\n"))
+	for _, want := range []string{ts.Local().Format("Jan 02 15:04"), "create", "evergreen"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("log line missing %q:\n%s", want, plain)
+		}
 	}
 }
 

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/iamrajjoshi/willow/internal/agent"
 	"github.com/iamrajjoshi/willow/internal/config"
@@ -17,7 +16,9 @@ import (
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 	"github.com/iamrajjoshi/willow/internal/trace"
+	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
@@ -106,6 +107,14 @@ func listWorktrees(ctx context.Context, flags Flags, cmd *cli.Command, repoGit *
 	return nil
 }
 
+type repoListRow struct {
+	repo        string
+	count       int
+	activeCount int
+	unreadCount int
+	ok          bool
+}
+
 func printRepoList(flags Flags) error {
 	u := flags.NewUI()
 	repos, err := config.ListRepos()
@@ -118,23 +127,6 @@ func printRepoList(flags Flags) error {
 		return nil
 	}
 
-	nameW := len("REPO")
-	for _, r := range repos {
-		if len(r) > nameW {
-			nameW = len(r)
-		}
-	}
-
-	header := fmt.Sprintf("  %-*s  %-9s  %-6s  %s", nameW, "REPO", "WORKTREES", "ACTIVE", "UNREAD")
-	u.Info(u.Bold(header))
-
-	type repoListRow struct {
-		repo        string
-		count       int
-		activeCount int
-		unreadCount int
-		ok          bool
-	}
 	rows := parallel.Map(repos, func(_ int, r string) repoListRow {
 		bareDir, err := config.ResolveRepo(r)
 		if err != nil {
@@ -164,14 +156,53 @@ func printRepoList(flags Flags) error {
 		return row
 	})
 
+	for _, line := range formatRepoListRows(u, rows, termfmt.TerminalWidth()) {
+		u.Info(line)
+	}
+	return nil
+}
+
+func formatRepoListRows(u *ui.UI, rows []repoListRow, width int) []string {
+	nameW := len("REPO")
+	worktreesW := len("WORKTREES")
+	activeW := len("ACTIVE")
+	unreadW := len("UNREAD")
 	for _, row := range rows {
 		if !row.ok {
 			continue
 		}
-		line := fmt.Sprintf("  %-*s  %-9d  %-6d  %d", nameW, row.repo, row.count, row.activeCount, row.unreadCount)
-		u.Info(line)
+		nameW = max(nameW, termfmt.VisibleWidth(row.repo))
+		worktreesW = max(worktreesW, termfmt.VisibleWidth(fmt.Sprintf("%d", row.count)))
+		activeW = max(activeW, termfmt.VisibleWidth(fmt.Sprintf("%d", row.activeCount)))
+		unreadW = max(unreadW, termfmt.VisibleWidth(fmt.Sprintf("%d", row.unreadCount)))
 	}
-	return nil
+
+	termWidth := termfmt.Width(width)
+	fixed := 2 + 2 + worktreesW + 2 + activeW + 2 + unreadW
+	if available := termWidth - fixed; available < nameW {
+		nameW = max(1, available)
+	}
+
+	lines := []string{
+		u.Bold(fmt.Sprintf("  %s  %s  %s  %s",
+			termfmt.FitRight("REPO", nameW),
+			termfmt.FitRight("WORKTREES", worktreesW),
+			termfmt.FitRight("ACTIVE", activeW),
+			termfmt.FitRight("UNREAD", unreadW),
+		)),
+	}
+	for _, row := range rows {
+		if !row.ok {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("  %s  %s  %s  %s",
+			termfmt.FitRight(row.repo, nameW),
+			termfmt.FitRight(fmt.Sprintf("%d", row.count), worktreesW),
+			termfmt.FitRight(fmt.Sprintf("%d", row.activeCount), activeW),
+			termfmt.FitRight(fmt.Sprintf("%d", row.unreadCount), unreadW),
+		))
+	}
+	return lines
 }
 
 func completeRepos(ctx context.Context, cmd *cli.Command) {
@@ -254,29 +285,26 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 	}
 	rows = sortLSRows(rows, st)
 
+	for _, line := range formatLSTableRows(u, rows, termfmt.TerminalWidth()) {
+		u.Info(line)
+	}
+}
+
+type lsDisplayRow struct {
+	branchPlain   string
+	branchDisplay string
+	status        string
+	path          string
+	age           string
+}
+
+func formatLSTableRows(u *ui.UI, rows []lsRow, width int) []string {
+	home, _ := os.UserHomeDir()
+	displayRows := make([]lsDisplayRow, 0, len(rows))
 	branchW := len("BRANCH")
 	statusW := len("STATUS")
 	pathW := len("PATH")
 	ageW := len("AGE")
-	for _, row := range rows {
-		display := row.prefix + row.wt.DisplayName()
-		if row.merged {
-			display += " [merged]"
-		}
-		if utf8.RuneCountInString(display) > branchW {
-			branchW = utf8.RuneCountInString(display)
-		}
-		if len(row.wt.Path) > pathW {
-			pathW = len(row.wt.Path)
-		}
-		if len(row.age) > ageW {
-			ageW = len(row.age)
-		}
-	}
-
-	header := fmt.Sprintf("  %-*s  %-*s  %-*s  %*s", branchW, "BRANCH", statusW, "STATUS", pathW, "PATH", ageW, "AGE")
-	u.Info(u.Bold(header))
-
 	for _, row := range rows {
 		statusLabel := agent.StatusLabel(row.status)
 		if row.unread {
@@ -288,17 +316,66 @@ func printTable(ctx context.Context, flags Flags, worktrees []worktree.Worktree,
 			branchPlain += " [merged]"
 			branchDisplay += " " + u.Dim("[merged]")
 		}
-		// Pad based on plain text width to avoid ANSI code miscount
-		padding := branchW - utf8.RuneCountInString(branchPlain)
-		if padding < 0 {
-			padding = 0
-		}
-		branchCol := branchDisplay + strings.Repeat(" ", padding)
-		pathPadded := fmt.Sprintf("%-*s", pathW, row.wt.Path)
-		agePadded := fmt.Sprintf("%*s", ageW, row.age)
-		line := fmt.Sprintf("  %s  %-*s  %s  %s", branchCol, statusW, statusLabel, u.Dim(pathPadded), u.Dim(agePadded))
-		u.Info(line)
+		path := termfmt.ShortenHome(row.wt.Path, home)
+		displayRows = append(displayRows, lsDisplayRow{
+			branchPlain:   branchPlain,
+			branchDisplay: branchDisplay,
+			status:        statusLabel,
+			path:          path,
+			age:           row.age,
+		})
+		branchW = max(branchW, termfmt.VisibleWidth(branchPlain))
+		statusW = max(statusW, termfmt.VisibleWidth(statusLabel))
+		pathW = max(pathW, termfmt.VisibleWidth(path))
+		ageW = max(ageW, termfmt.VisibleWidth(row.age))
 	}
+
+	branchW, pathW = fitNameAndPathWidths(termfmt.Width(width), branchW, pathW, statusW, ageW)
+	lines := []string{
+		u.Bold(fmt.Sprintf("  %s  %s  %s  %s",
+			termfmt.FitRight("BRANCH", branchW),
+			termfmt.FitRight("STATUS", statusW),
+			termfmt.FitRight("PATH", pathW),
+			termfmt.FitLeft("AGE", ageW),
+		)),
+	}
+	for _, row := range displayRows {
+		lines = append(lines, fmt.Sprintf("  %s  %s  %s  %s",
+			fitDisplayRight(row.branchDisplay, row.branchPlain, branchW),
+			termfmt.FitRight(row.status, statusW),
+			u.Dim(termfmt.FitRight(row.path, pathW)),
+			u.Dim(termfmt.FitLeft(row.age, ageW)),
+		))
+	}
+	return lines
+}
+
+func fitNameAndPathWidths(width, nameW, pathW, statusW, tailW int) (int, int) {
+	minPathW := len("PATH")
+	fixedWithoutNamePath := 2 + 2 + statusW + 2 + 2 + tailW
+	available := width - fixedWithoutNamePath
+	if available <= 2 {
+		return 1, 1
+	}
+	if nameW+2+pathW <= available {
+		return nameW, pathW
+	}
+	if availablePath := available - nameW - 2; availablePath >= minPathW {
+		return nameW, min(pathW, availablePath)
+	}
+	pathW = minPathW
+	nameAvailable := available - pathW - 2
+	if nameAvailable < 1 {
+		nameAvailable = 1
+	}
+	return min(nameW, nameAvailable), pathW
+}
+
+func fitDisplayRight(display, plain string, width int) string {
+	if termfmt.VisibleWidth(plain) > width {
+		return termfmt.FitRight(plain, width)
+	}
+	return termfmt.PadRight(display, width)
 }
 
 func sortLSRows(rows []lsRow, st *stack.Stack) []lsRow {

--- a/internal/cli/ls_test.go
+++ b/internal/cli/ls_test.go
@@ -1,11 +1,14 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/iamrajjoshi/willow/internal/agent"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
+	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
@@ -89,5 +92,50 @@ func TestSortLSRows_StackStaysContiguousAndRanksByUrgency(t *testing.T) {
 	}
 	if got[1].prefix == "" {
 		t.Fatal("child prefix should be preserved")
+	}
+}
+
+func TestFormatLSTableRowsFitsNarrowWidth(t *testing.T) {
+	t.Setenv("HOME", "/Users/raj.joshi")
+	u := &ui.UI{}
+	long := "raj--tprm-464--backend-validate-review-risk-subtype"
+	rows := []lsRow{
+		{
+			branch: long,
+			prefix: "\u2514\u2500 ",
+			status: agent.StatusDone,
+			age:    "1h",
+			wt: worktree.Worktree{
+				Branch: long,
+				Path:   "/Users/raj.joshi/.willow/worktrees/evergreen/" + long,
+			},
+		},
+	}
+
+	lines := formatLSTableRows(u, rows, 80)
+	for _, line := range lines {
+		if got := termfmt.VisibleWidth(line); got > 80 {
+			t.Fatalf("line width = %d, want <= 80:\n%s", got, termfmt.StripANSI(line))
+		}
+	}
+	plain := termfmt.StripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(plain, "AGE") || !strings.Contains(plain, "1h") {
+		t.Fatalf("formatted ls table should preserve age column:\n%s", plain)
+	}
+	if !strings.Contains(plain, "…") {
+		t.Fatalf("formatted ls table should truncate narrow output:\n%s", plain)
+	}
+}
+
+func TestFormatRepoListRowsFitsNarrowWidth(t *testing.T) {
+	u := &ui.UI{}
+	rows := []repoListRow{
+		{repo: "evergreen-with-a-very-long-name", count: 15, activeCount: 10, unreadCount: 1, ok: true},
+	}
+	lines := formatRepoListRows(u, rows, 36)
+	for _, line := range lines {
+		if got := termfmt.VisibleWidth(line); got > 36 {
+			t.Fatalf("line width = %d, want <= 36:\n%s", got, termfmt.StripANSI(line))
+		}
 	}
 }

--- a/internal/cli/stack_cmd.go
+++ b/internal/cli/stack_cmd.go
@@ -6,13 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-	"unicode/utf8"
 
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/errors"
 	"github.com/iamrajjoshi/willow/internal/gh"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/urfave/cli/v3"
@@ -95,37 +94,47 @@ func stackStatusCmd() *cli.Command {
 				return enc.Encode(prMap)
 			}
 
-			maxBranchWidth := 0
-			for _, tl := range treeLines {
-				w := utf8.RuneCountInString(tl.Prefix) + utf8.RuneCountInString(tl.Branch)
-				if w > maxBranchWidth {
-					maxBranchWidth = w
-				}
-			}
-
-			for _, tl := range treeLines {
-				branchDisplay := tl.Prefix + tl.Branch
-				plainWidth := utf8.RuneCountInString(branchDisplay)
-				padding := maxBranchWidth - plainWidth
-				if padding < 0 {
-					padding = 0
-				}
-
-				pr := prMap[tl.Branch]
-				var annotation string
-				if pr == nil {
-					annotation = u.Dim("(no PR)")
-				} else {
-					annotation = formatPRAnnotation(u, pr)
-				}
-
-				line := fmt.Sprintf("  %s%s  %s", branchDisplay, strings.Repeat(" ", padding), annotation)
+			for _, line := range formatStackStatusLines(u, treeLines, prMap, termfmt.TerminalWidth()) {
 				u.Info(line)
 			}
 
 			return nil
 		},
 	}
+}
+
+func formatStackStatusLines(u *ui.UI, treeLines []stack.TreeLine, prMap map[string]*gh.PRInfo, width int) []string {
+	type row struct {
+		branch     string
+		annotation string
+	}
+	rows := make([]row, 0, len(treeLines))
+	branchW, annotationW := 0, 0
+	for _, tl := range treeLines {
+		annotation := u.Dim("(no PR)")
+		if pr := prMap[tl.Branch]; pr != nil {
+			annotation = formatPRAnnotation(u, pr)
+		}
+		r := row{branch: tl.Prefix + tl.Branch, annotation: annotation}
+		rows = append(rows, r)
+		branchW = max(branchW, termfmt.VisibleWidth(r.branch))
+		annotationW = max(annotationW, termfmt.VisibleWidth(r.annotation))
+	}
+
+	termWidth := termfmt.Width(width)
+	availableBranch := termWidth - (2 + 2 + annotationW)
+	if availableBranch < branchW {
+		branchW = max(1, availableBranch)
+	}
+
+	lines := make([]string, 0, len(rows))
+	for _, r := range rows {
+		lines = append(lines, fmt.Sprintf("  %s  %s",
+			termfmt.FitRight(r.branch, branchW),
+			termfmt.FitRight(r.annotation, annotationW),
+		))
+	}
+	return lines
 }
 
 func formatPRAnnotation(u *ui.UI, pr *gh.PRInfo) string {

--- a/internal/cli/stack_cmd_test.go
+++ b/internal/cli/stack_cmd_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/iamrajjoshi/willow/internal/gh"
+	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 	"github.com/iamrajjoshi/willow/internal/ui"
 )
 
@@ -49,6 +51,32 @@ func TestFormatPRAnnotation(t *testing.T) {
 	for _, want := range []string{"#42", "CI", "Review", "MERGEABLE", "+3", "-1"} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("formatPRAnnotation() missing %q: %q", want, got)
+		}
+	}
+}
+
+func TestFormatStackStatusLinesFitsNarrowWidth(t *testing.T) {
+	u := &ui.UI{}
+	lines := formatStackStatusLines(u, []stack.TreeLine{
+		{Prefix: "\u2514\u2500 ", Branch: "raj--tprm-464--backend-validate-review-risk-subtype"},
+	}, map[string]*gh.PRInfo{
+		"raj--tprm-464--backend-validate-review-risk-subtype": {
+			Number:       42,
+			ReviewStatus: "APPROVED",
+			Mergeable:    "MERGEABLE",
+			Additions:    12,
+			Deletions:    4,
+		},
+	}, 72)
+	for _, line := range lines {
+		if got := termfmt.VisibleWidth(line); got > 72 {
+			t.Fatalf("line width = %d, want <= 72:\n%s", got, termfmt.StripANSI(line))
+		}
+	}
+	plain := termfmt.StripANSI(strings.Join(lines, "\n"))
+	for _, want := range []string{"#42", "CI", "Review", "MERGEABLE"} {
+		if !strings.Contains(plain, want) {
+			t.Fatalf("stack status line missing %q:\n%s", want, plain)
 		}
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -10,7 +10,9 @@ import (
 	"github.com/iamrajjoshi/willow/internal/agent"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/parallel"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 	"github.com/iamrajjoshi/willow/internal/trace"
+	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 	"github.com/urfave/cli/v3"
 )
@@ -125,6 +127,58 @@ func statusBranchLabel(branch, harnessID, sessionID string) string {
 	return fmt.Sprintf("%s [%s]", branch, prefix)
 }
 
+func formatStatusEntryLines(u *ui.UI, entries []sessionEntry, width int) []string {
+	branchW := 0
+	labelW := 0
+	timeW := 0
+	type row struct {
+		icon   string
+		branch string
+		label  string
+		ts     string
+	}
+	rows := make([]row, 0, len(entries))
+	for _, e := range entries {
+		label := e.Status
+		if e.Unread {
+			label += "\u25CF" // bullet
+		}
+		r := row{
+			icon:   agent.StatusIcon(agent.Status(e.Status)),
+			branch: statusBranchLabel(e.Branch, e.Harness, e.SessionID),
+			label:  label,
+			ts:     e.Timestamp,
+		}
+		rows = append(rows, r)
+		branchW = max(branchW, termfmt.VisibleWidth(r.branch))
+		labelW = max(labelW, termfmt.VisibleWidth(r.label))
+		timeW = max(timeW, termfmt.VisibleWidth(r.ts))
+	}
+
+	termWidth := termfmt.Width(width)
+	fixed := 2 + 2 + 1 + 2 + labelW
+	if timeW > 0 {
+		fixed += 2 + timeW
+	}
+	if available := termWidth - fixed; available < branchW {
+		branchW = max(1, available)
+	}
+
+	lines := make([]string, 0, len(rows))
+	for _, r := range rows {
+		icon := termfmt.PadRight(r.icon, 2)
+		branch := termfmt.FitRight(r.branch, branchW)
+		label := termfmt.FitRight(r.label, labelW)
+		if timeW > 0 {
+			lines = append(lines, fmt.Sprintf("  %s %s  %s  %s",
+				icon, branch, label, u.Dim(termfmt.FitRight(r.ts, timeW))))
+		} else {
+			lines = append(lines, fmt.Sprintf("  %s %s  %s", icon, branch, label))
+		}
+	}
+	return lines
+}
+
 func statusCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "status",
@@ -176,29 +230,7 @@ func statusCmd() *cli.Command {
 				headerParts += ")\n"
 				u.Info(headerParts)
 
-				branchW := 0
-				for _, e := range rs.Entries {
-					label := statusBranchLabel(e.Branch, e.Harness, e.SessionID)
-					if len(label) > branchW {
-						branchW = len(label)
-					}
-				}
-
-				for _, e := range rs.Entries {
-					icon := agent.StatusIcon(agent.Status(e.Status))
-					label := e.Status
-					if e.Unread {
-						label += "\u25CF" // bullet
-					}
-					branchLabel := statusBranchLabel(e.Branch, e.Harness, e.SessionID)
-					var line string
-					if e.Timestamp != "" {
-						line = fmt.Sprintf("  %s %-*s  %-6s  %s",
-							icon, branchW, branchLabel, label, u.Dim(e.Timestamp))
-					} else {
-						line = fmt.Sprintf("  %s %-*s  %s",
-							icon, branchW, branchLabel, label)
-					}
+				for _, line := range formatStatusEntryLines(u, rs.Entries, termfmt.TerminalWidth()) {
 					u.Info(line)
 				}
 			}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/iamrajjoshi/willow/internal/agent"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
+	"github.com/iamrajjoshi/willow/internal/ui"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 )
 
@@ -106,6 +109,30 @@ func TestStatusBranchLabel(t *testing.T) {
 	}
 	if got := statusBranchLabel("main", "", ""); got != "main" {
 		t.Errorf("statusBranchLabel without session = %q, want %q", got, "main")
+	}
+}
+
+func TestFormatStatusEntryLinesFitsNarrowWidth(t *testing.T) {
+	u := &ui.UI{}
+	entries := []sessionEntry{
+		{
+			Branch:    "raj--tprm-464--backend-validate-review-risk-subtype",
+			Harness:   "codex",
+			SessionID: "1234567890abcdef",
+			Status:    string(agent.StatusDone),
+			Timestamp: "2h ago",
+			Unread:    true,
+		},
+	}
+	lines := formatStatusEntryLines(u, entries, 52)
+	for _, line := range lines {
+		if got := termfmt.VisibleWidth(line); got > 52 {
+			t.Fatalf("line width = %d, want <= 52:\n%s", got, termfmt.StripANSI(line))
+		}
+	}
+	plain := termfmt.StripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(plain, "DONE\u25CF") || !strings.Contains(plain, "2h ago") {
+		t.Fatalf("status line should preserve status and timestamp:\n%s", plain)
 	}
 }
 

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/log"
 	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
@@ -1349,7 +1350,7 @@ func tmuxListCmd() *cli.Command {
 			if sess := cmd.String("session"); sess != "" {
 				items = moveToFront(items, sess)
 			}
-			for _, line := range tmux.FormatPickerLines(items) {
+			for _, line := range tmux.FormatPickerLinesWithWidth(items, termfmt.TerminalWidth()) {
 				fmt.Println(line)
 			}
 			return nil

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/config"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 	"github.com/iamrajjoshi/willow/internal/tmux"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 )
@@ -1105,8 +1106,10 @@ func TestTmuxListCommand_PrintsPickerLines(t *testing.T) {
 	if !strings.Contains(out, "feature-picker") {
 		t.Fatalf("expected picker output to include feature branch, got:\n%s", out)
 	}
-	if !strings.Contains(out, filepath.Join(".willow", "worktrees", "tmuxlist", "feature-picker")) {
-		t.Fatalf("expected picker output to include shortened worktree path, got:\n%s", out)
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if got := termfmt.VisibleWidth(line); got > termfmt.DefaultWidth {
+			t.Fatalf("picker line width = %d, want <= %d:\n%s", got, termfmt.DefaultWidth, termfmt.StripANSI(line))
+		}
 	}
 }
 

--- a/internal/termfmt/termfmt.go
+++ b/internal/termfmt/termfmt.go
@@ -1,0 +1,134 @@
+package termfmt
+
+import (
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
+	"golang.org/x/term"
+)
+
+const DefaultWidth = 120
+
+func TerminalWidth() int {
+	if width, _, err := term.GetSize(int(os.Stdout.Fd())); err == nil && width > 0 {
+		return width
+	}
+	if width, _, err := term.GetSize(int(os.Stderr.Fd())); err == nil && width > 0 {
+		return width
+	}
+	return DefaultWidth
+}
+
+func Width(width int) int {
+	if width > 0 {
+		return width
+	}
+	return DefaultWidth
+}
+
+func ShortenHome(path, home string) string {
+	if home != "" && strings.HasPrefix(path, home) {
+		return "~" + path[len(home):]
+	}
+	return path
+}
+
+func VisibleWidth(s string) int {
+	return runewidth.StringWidth(StripANSI(s))
+}
+
+func PadRight(s string, width int) string {
+	padding := width - VisibleWidth(s)
+	if padding <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", padding)
+}
+
+func PadLeft(s string, width int) string {
+	padding := width - VisibleWidth(s)
+	if padding <= 0 {
+		return s
+	}
+	return strings.Repeat(" ", padding) + s
+}
+
+func FitRight(s string, width int) string {
+	return PadRight(TruncateEnd(s, width), width)
+}
+
+func FitLeft(s string, width int) string {
+	return PadLeft(TruncateEnd(s, width), width)
+}
+
+func TruncateEnd(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if VisibleWidth(s) <= width {
+		return s
+	}
+
+	ellipsis := "…"
+	ellipsisW := runewidth.StringWidth(ellipsis)
+	if width <= ellipsisW {
+		return ellipsis
+	}
+
+	limit := width - ellipsisW
+	var b strings.Builder
+	used := 0
+	hasANSI := false
+	for i := 0; i < len(s); {
+		if seq, next, ok := ansiSequence(s, i); ok {
+			b.WriteString(seq)
+			hasANSI = true
+			i = next
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		rw := runewidth.RuneWidth(r)
+		if used+rw > limit {
+			break
+		}
+		b.WriteRune(r)
+		used += rw
+		i += size
+	}
+	b.WriteString(ellipsis)
+	if hasANSI {
+		b.WriteString("\033[0m")
+	}
+	return b.String()
+}
+
+func StripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if _, next, ok := ansiSequence(s, i); ok {
+			i = next
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		b.WriteRune(r)
+		i += size
+	}
+	return b.String()
+}
+
+func ansiSequence(s string, i int) (string, int, bool) {
+	if i+1 >= len(s) || s[i] != '\x1b' || s[i+1] != '[' {
+		return "", i, false
+	}
+	next := i + 2
+	for next < len(s) {
+		c := s[next]
+		next++
+		if c >= 0x40 && c <= 0x7e {
+			return s[i:next], next, true
+		}
+	}
+	return s[i:], len(s), true
+}

--- a/internal/termfmt/termfmt_test.go
+++ b/internal/termfmt/termfmt_test.go
@@ -1,0 +1,60 @@
+package termfmt
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVisibleWidthIgnoresANSIAndCountsWideRunes(t *testing.T) {
+	got := VisibleWidth("\033[31m✅ DONE\033[0m └─ branch")
+	want := 17
+	if got != want {
+		t.Fatalf("VisibleWidth() = %d, want %d", got, want)
+	}
+}
+
+func TestPaddingUsesVisibleWidth(t *testing.T) {
+	got := PadRight("\033[2mabc\033[0m", 5)
+	if VisibleWidth(got) != 5 {
+		t.Fatalf("PadRight visible width = %d, want 5", VisibleWidth(got))
+	}
+	if !strings.HasSuffix(got, "  ") {
+		t.Fatalf("PadRight() = %q, want two visible spaces at end", got)
+	}
+
+	got = PadLeft("✅", 4)
+	if VisibleWidth(got) != 4 {
+		t.Fatalf("PadLeft visible width = %d, want 4", VisibleWidth(got))
+	}
+	if !strings.HasPrefix(got, "  ") {
+		t.Fatalf("PadLeft() = %q, want two visible spaces at start", got)
+	}
+}
+
+func TestTruncateEndAddsEllipsisAtWidth(t *testing.T) {
+	got := TruncateEnd("raj--tprm-464--backend-validate-review-risk-subtype", 18)
+	if got != "raj--tprm-464--ba…" {
+		t.Fatalf("TruncateEnd() = %q", got)
+	}
+	if VisibleWidth(got) != 18 {
+		t.Fatalf("TruncateEnd visible width = %d, want 18", VisibleWidth(got))
+	}
+}
+
+func TestTruncateEndPreservesANSI(t *testing.T) {
+	got := TruncateEnd("\033[2mabcdef\033[0m", 4)
+	if !strings.Contains(got, "\033[2m") || !strings.HasSuffix(got, "\033[0m") {
+		t.Fatalf("TruncateEnd() should preserve ANSI wrapping, got %q", got)
+	}
+	if VisibleWidth(got) != 4 {
+		t.Fatalf("TruncateEnd visible width = %d, want 4", VisibleWidth(got))
+	}
+}
+
+func TestShortenHome(t *testing.T) {
+	got := ShortenHome("/Users/raj.joshi/.willow/worktrees/repo/main", "/Users/raj.joshi")
+	want := "~/.willow/worktrees/repo/main"
+	if got != want {
+		t.Fatalf("ShortenHome() = %q, want %q", got, want)
+	}
+}

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/parallel"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 	"github.com/iamrajjoshi/willow/internal/trace"
 	"github.com/iamrajjoshi/willow/internal/worktree"
 )
@@ -299,6 +300,21 @@ func pickerStableItemKey(item PickerItem) string {
 // When a worktree has multiple active agent sessions, sub-rows are shown
 // indented below the parent row.
 func FormatPickerLines(items []PickerItem) []string {
+	return formatPickerLines(items)
+}
+
+func FormatPickerLinesWithWidth(items []PickerItem, width int) []string {
+	lines := formatPickerLines(items)
+	width = termfmt.Width(width)
+	for i, line := range lines {
+		if termfmt.VisibleWidth(line) > width {
+			lines[i] = termfmt.TruncateEnd(line, width)
+		}
+	}
+	return lines
+}
+
+func formatPickerLines(items []PickerItem) []string {
 	multiRepo := hasMultipleRepos(items)
 	home, _ := os.UserHomeDir()
 

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iamrajjoshi/willow/internal/agent"
 	"github.com/iamrajjoshi/willow/internal/git"
 	"github.com/iamrajjoshi/willow/internal/stack"
+	"github.com/iamrajjoshi/willow/internal/termfmt"
 )
 
 func TestStripAnsi(t *testing.T) {
@@ -402,6 +403,28 @@ func TestFormatPickerLinesHarnessSummaryLabels(t *testing.T) {
 	}
 	if strings.Contains(plain[7], "[codex]") {
 		t.Fatalf("idle-only parent should not show inactive harness label:\n%s", plain[7])
+	}
+}
+
+func TestFormatPickerLinesWithWidthFitsNarrowWidth(t *testing.T) {
+	t.Setenv("HOME", "/fakehome")
+	long := "raj--tprm-464--backend-validate-review-risk-subtype"
+	lines := FormatPickerLinesWithWidth([]PickerItem{
+		{
+			RepoName:  "repo",
+			Branch:    long,
+			WtDirName: long,
+			WtPath:    "/fakehome/worktrees/repo/" + long,
+			Status:    agent.StatusDone,
+		},
+	}, 72)
+	for _, line := range lines {
+		if got := termfmt.VisibleWidth(line); got > 72 {
+			t.Fatalf("line width = %d, want <= 72:\n%s", got, termfmt.StripANSI(line))
+		}
+	}
+	if full := FormatPickerLines([]PickerItem{{RepoName: "repo", Branch: long, WtDirName: long, WtPath: "/fakehome/worktrees/repo/" + long}})[0]; termfmt.VisibleWidth(full) <= 72 {
+		t.Fatalf("unbounded picker line should remain untruncated for fzf selection parsing: %s", full)
 	}
 }
 


### PR DESCRIPTION
## Description of the change
Fixes terminal wrapping in list-style Willow output by adding ANSI-aware, terminal-width-aware formatting for `ww ls`, repo lists, `ww status`, `ww log`, `ww stack status`, and diagnostic `ww tmux list` output.

The root issue was fixed-width padding against full paths, which let long path columns wrap and push age/status details onto separate lines.

## Test plan
- `go test ./... -count=1`
- Manually checked `go run ./cmd/willow ls evergreen`
- Manually checked `go run ./cmd/willow tmux list --repo evergreen`

## Considerations
`ww tmux pick` continues to use full, untruncated picker lines internally so selection parsing stays reliable. Codex assisted with this change.