### PR TITLE
:bug: fix[tmux]: align harness labels in picker

### DIFF
--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/iamrajjoshi/willow/internal/agent"
 	"github.com/iamrajjoshi/willow/internal/cleanup"
@@ -320,10 +319,19 @@ func formatPickerLines(items []PickerItem) []string {
 
 	nameW := 0
 	for _, item := range items {
-		plain := displayName(item, multiRepo)
+		activeSessions := filterActiveSessions(item.Sessions)
+		plain := pickerNamePlain(item, multiRepo, activeSessions)
 		plain += staleTagsPlain(item)
-		if utf8.RuneCountInString(plain) > nameW {
-			nameW = utf8.RuneCountInString(plain)
+		if termfmt.VisibleWidth(plain) > nameW {
+			nameW = termfmt.VisibleWidth(plain)
+		}
+		if len(activeSessions) > 1 {
+			for _, ss := range activeSessions {
+				plain := pickerSessionInfoPlain(ss)
+				if termfmt.VisibleWidth(plain) > nameW {
+					nameW = termfmt.VisibleWidth(plain)
+				}
+			}
 		}
 	}
 
@@ -333,18 +341,14 @@ func formatPickerLines(items []PickerItem) []string {
 		color := statusColor(item.Status)
 		icon := agent.StatusIcon(item.Status)
 		label := fmt.Sprintf("%-7s", agent.StatusLabel(item.Status))
-		harnessLabel := harnessSummaryLabel(activeSessions)
-		if harnessLabel != "" {
-			harnessLabel = " " + colorDim + harnessLabel + colorReset
-		}
 
 		dot := " "
 		if item.Unread {
 			dot = "\u25CF"
 		}
 
-		namePlain := displayName(item, multiRepo)
-		name := namePlain
+		namePlain := pickerNamePlain(item, multiRepo, activeSessions)
+		name := pickerNameANSI(item, multiRepo, activeSessions)
 		tags := staleTags(item)
 		if len(tags) > 0 {
 			namePlain += staleTagsPlain(item)
@@ -352,14 +356,14 @@ func formatPickerLines(items []PickerItem) []string {
 				name += fmt.Sprintf(" %s[%s]%s", colorDim, tag, colorReset)
 			}
 		}
-		padding := nameW - utf8.RuneCountInString(namePlain)
+		padding := nameW - termfmt.VisibleWidth(namePlain)
 		if padding < 0 {
 			padding = 0
 		}
 		nameCol := name + strings.Repeat(" ", padding)
 
-		line := fmt.Sprintf("%s%s %s%s%s%s | %s | %s%s%s",
-			color, icon, label, dot, colorReset, harnessLabel,
+		line := fmt.Sprintf("%s%s %s%s%s | %s | %s%s%s",
+			color, icon, label, dot, colorReset,
 			nameCol,
 			colorDim, shortenPathWithHome(item.WtPath, home), colorReset,
 		)
@@ -372,21 +376,9 @@ func formatPickerLines(items []PickerItem) []string {
 				subIcon := agent.StatusIcon(effStatus)
 				subLabel := fmt.Sprintf("%-6s", agent.StatusLabel(effStatus))
 
-				prefix := "\u2514 "
-				sid := truncate(ss.SessionID, 8)
-				if ss.Harness != "" {
-					sid = ss.Harness + ":" + sid
-				}
-				timeAgo := agent.TimeSince(ss.Timestamp)
-
-				plainLen := utf8.RuneCountInString(prefix) + len(sid)
-				infoAnsi := colorDim + prefix + sid
-				if ss.Tool != "" {
-					infoAnsi += fmt.Sprintf(" %s(%s)%s", colorDim, ss.Tool, colorReset)
-					plainLen += 2 + len(ss.Tool) + 1 // " (" + tool + ")"
-				}
-				infoAnsi += " " + timeAgo
-				plainLen += 1 + utf8.RuneCountInString(timeAgo)
+				infoPlain := pickerSessionInfoPlain(ss)
+				infoAnsi := pickerSessionInfoANSI(ss)
+				plainLen := termfmt.VisibleWidth(infoPlain)
 
 				pad := nameW - plainLen
 				if pad < 0 {
@@ -404,6 +396,53 @@ func formatPickerLines(items []PickerItem) []string {
 		}
 	}
 	return lines
+}
+
+func pickerNamePlain(item PickerItem, multiRepo bool, activeSessions []*agent.SessionStatus) string {
+	name := displayName(item, multiRepo)
+	if label := harnessSummaryLabel(activeSessions); label != "" {
+		return label + " " + name
+	}
+	return name
+}
+
+func pickerNameANSI(item PickerItem, multiRepo bool, activeSessions []*agent.SessionStatus) string {
+	name := displayName(item, multiRepo)
+	if label := harnessSummaryLabel(activeSessions); label != "" {
+		return fmt.Sprintf("%s%s%s %s", colorDim, label, colorReset, name)
+	}
+	return name
+}
+
+func pickerSessionInfoPlain(ss *agent.SessionStatus) string {
+	return pickerSessionInfo(ss, false)
+}
+
+func pickerSessionInfoANSI(ss *agent.SessionStatus) string {
+	return pickerSessionInfo(ss, true)
+}
+
+func pickerSessionInfo(ss *agent.SessionStatus, ansi bool) string {
+	prefix := "\u2514 "
+	sid := truncate(ss.SessionID, 8)
+	if ss.Harness != "" {
+		sid = ss.Harness + ":" + sid
+	}
+
+	var b strings.Builder
+	if ansi {
+		b.WriteString(colorDim)
+	}
+	b.WriteString(prefix)
+	b.WriteString(sid)
+	if ss.Tool != "" {
+		b.WriteString(" (")
+		b.WriteString(ss.Tool)
+		b.WriteString(")")
+	}
+	b.WriteString(" ")
+	b.WriteString(agent.TimeSince(ss.Timestamp))
+	return b.String()
 }
 
 func harnessSummaryLabel(sessions []*agent.SessionStatus) string {

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -390,6 +390,22 @@ func TestFormatPickerLinesHarnessSummaryLabels(t *testing.T) {
 			t.Fatalf("line %d missing %q:\n%s", tt.line, tt.want, strings.Join(plain, "\n"))
 		}
 	}
+	firstSep := displayColumnBeforeSeparator(plain[0], strings.Index)
+	secondSep := displayColumnBeforeSeparator(plain[0], strings.LastIndex)
+	if firstSep == -1 || secondSep == -1 || firstSep == secondSep {
+		t.Fatalf("line 0 missing table separators: %q", plain[0])
+	}
+	if strings.Index(plain[0], "[codex]") < strings.Index(plain[0], "|") {
+		t.Fatalf("harness label should render in the name column, not before the first separator: %q", plain[0])
+	}
+	for i, line := range plain {
+		if got := displayColumnBeforeSeparator(line, strings.Index); got != firstSep {
+			t.Fatalf("line %d first separator = %d, want %d:\n%s", i, got, firstSep, strings.Join(plain, "\n"))
+		}
+		if got := displayColumnBeforeSeparator(line, strings.LastIndex); got != secondSep {
+			t.Fatalf("line %d path separator = %d, want %d:\n%s", i, got, secondSep, strings.Join(plain, "\n"))
+		}
+	}
 	for _, tt := range []struct {
 		line  int
 		label string
@@ -426,6 +442,14 @@ func TestFormatPickerLinesWithWidthFitsNarrowWidth(t *testing.T) {
 	if full := FormatPickerLines([]PickerItem{{RepoName: "repo", Branch: long, WtDirName: long, WtPath: "/fakehome/worktrees/repo/" + long}})[0]; termfmt.VisibleWidth(full) <= 72 {
 		t.Fatalf("unbounded picker line should remain untruncated for fzf selection parsing: %s", full)
 	}
+}
+
+func displayColumnBeforeSeparator(line string, index func(string, string) int) int {
+	i := index(line, "|")
+	if i < 0 {
+		return -1
+	}
+	return termfmt.VisibleWidth(line[:i])
 }
 
 func TestBuildPickerItemsUsesRepoWorktreesAndStatuses(t *testing.T) {


### PR DESCRIPTION
## Description of the change
Keep tmux picker harness labels inside the worktree/name column and size that column from the rendered label plus worktree name. Multi-session parent rows stay unlabeled, while child session rows continue to show harness/session labels and participate in width calculation so the table separators remain aligned.

## Test plan
Go test suite, website build, diff whitespace check, and local tmux list render check.

Generated with Codex.