### PR TITLE
:bug: fix[tmux]: bracket child harness labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ List worktrees with status. Uses the same urgency ordering as `ww sw`, while kee
 
 ### `ww status`
 
-Show agent status per worktree/session. Multiple sessions in the same worktree render with a `harness:session` label and unread indicators (`●`) for completed sessions you haven't reviewed.
+Show agent status per worktree/session. Multiple sessions in the same worktree render child rows with labels like `[claude] a044b2af` and unread indicators (`●`) for completed sessions you haven't reviewed.
 
 ![ww status](screenshots/demo-status.gif)
 

--- a/internal/tmux/picker.go
+++ b/internal/tmux/picker.go
@@ -425,15 +425,14 @@ func pickerSessionInfoANSI(ss *agent.SessionStatus) string {
 func pickerSessionInfo(ss *agent.SessionStatus, ansi bool) string {
 	prefix := "\u2514 "
 	sid := truncate(ss.SessionID, 8)
-	if ss.Harness != "" {
-		sid = ss.Harness + ":" + sid
-	}
 
 	var b strings.Builder
 	if ansi {
 		b.WriteString(colorDim)
 	}
 	b.WriteString(prefix)
+	b.WriteString(harnessLabel(ss.Harness))
+	b.WriteString(" ")
 	b.WriteString(sid)
 	if ss.Tool != "" {
 		b.WriteString(" (")
@@ -449,7 +448,11 @@ func harnessSummaryLabel(sessions []*agent.SessionStatus) string {
 	if len(sessions) != 1 {
 		return ""
 	}
-	name := strings.TrimSpace(sessions[0].Harness)
+	return harnessLabel(sessions[0].Harness)
+}
+
+func harnessLabel(name string) string {
+	name = strings.TrimSpace(name)
 	if name == "" {
 		name = "claude"
 	}

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -383,11 +383,16 @@ func TestFormatPickerLinesHarnessSummaryLabels(t *testing.T) {
 		want string
 	}{
 		{line: 0, want: "[codex]"},
-		{line: 5, want: "claude:claude-s"},
-		{line: 6, want: "codex:codex-se"},
+		{line: 5, want: "[claude] claude-s"},
+		{line: 6, want: "[codex] codex-se"},
 	} {
 		if !strings.Contains(plain[tt.line], tt.want) {
 			t.Fatalf("line %d missing %q:\n%s", tt.line, tt.want, strings.Join(plain, "\n"))
+		}
+	}
+	for _, line := range []int{5, 6} {
+		if strings.Contains(plain[line], "claude:") || strings.Contains(plain[line], "codex:") {
+			t.Fatalf("line %d should use bracketed harness labels, not colon labels:\n%s", line, plain[line])
 		}
 	}
 	firstSep := displayColumnBeforeSeparator(plain[0], strings.Index)

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -338,7 +338,7 @@ Requires the [GitHub CLI](https://cli.github.com/) (`gh`).
 
 ### `ww status`
 
-Show agent status per worktree/session. Multiple sessions in the same worktree render with a `harness:session` label.
+Show agent status per worktree/session. Multiple sessions in the same worktree render child rows with labels like `[claude] a044b2af`.
 
 ```
 myrepo (4 worktrees, 3 sessions active, 1 unread)

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -90,7 +90,7 @@ Worktrees whose exact current-head PR is merged show a dim `[merged]` tag, and w
 - **Urgency sort** — current session first, then `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline
 - **Status colors** — BUSY (green), WAIT (red), DONE (blue), IDLE (yellow)
 - **Unread indicator** — `●` marks completed sessions you haven't viewed
-- **Harness labels** — active single-session parent rows show `[claude]` or `[codex]`; multi-session rows use labeled child rows
+- **Harness labels** — active single-session parent rows show `[claude]` or `[codex]`; multi-session rows use child labels like `[claude] a044b2af`
 - **Merged indicator** — `[merged]` marks worktrees whose exact current-head PR is merged when `gh` data is available
 - **Stack-aware ordering** — stacked branches stay grouped together and inherit the most urgent item in the tree
 - **Multi-agent sub-rows** — when a worktree has multiple active sessions, each is shown as an indented sub-row with its harness label, status, and tool info


### PR DESCRIPTION
## Description of the change
Render multi-session child rows with bracketed harness labels followed by the short session hash, for example `[claude] a044b2af`, matching the parent-row harness label treatment.

## Test plan
Go test suite, website build, diff whitespace check, and local tmux list render check.

Generated with Codex.