### PR TITLE
:bug: fix[agent]: avoid status hook temp-file race

### DIFF
--- a/internal/agent/hook_handler.go
+++ b/internal/agent/hook_handler.go
@@ -219,11 +219,30 @@ func writeSession(path string, s SessionStatus) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmpPath := tmp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
 }
 
 // appendFileList appends a file path to sessionID.files only if it is not

--- a/internal/agent/hook_handler_test.go
+++ b/internal/agent/hook_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -272,6 +273,44 @@ func TestHandleHook_PreservesStartTime(t *testing.T) {
 
 	if !first.Equal(second) {
 		t.Errorf("start_time changed: %v → %v", first, second)
+	}
+}
+
+func TestWriteSessionConcurrentWriters(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(home, "session.json")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 64)
+	for i := 0; i < cap(errs); i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			errs <- writeSession(path, SessionStatus{
+				SessionID: "s1",
+				Status:    StatusBusy,
+				ToolCount: i,
+			})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("writeSession returned error under concurrent writes: %v", err)
+		}
+	}
+
+	if got := readSession(path); got.SessionID != "s1" {
+		t.Fatalf("session_id = %q, want s1", got.SessionID)
+	}
+	matches, err := filepath.Glob(filepath.Join(home, "session.json.*.tmp"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("leftover temp files: %v", matches)
 	}
 }
 


### PR DESCRIPTION
## Description of the change
Fixes intermittent Willow agent hook errors when multiple hook events write the same session status file concurrently. Each status write now uses its own same-directory temp file before atomically renaming into place.

**Ticket:**

## Test plan
Unit tests, full Go test suite, and a race-focused concurrent writer regression test.

## Loom or screenshots

## Considerations
