### PR TITLE
:recycle: ref[agent]: remove legacy marker reads

### DIFF
--- a/internal/agent/hook_handler.go
+++ b/internal/agent/hook_handler.go
@@ -60,9 +60,6 @@ func HandleHook(r io.Reader, harnessIDs ...string) error {
 
 	if in.EventName == "SessionEnd" {
 		_ = removeSessionArtifacts(repo, wt, h.ID(), in.SessionID)
-		if h.ID() == harness.ClaudeID {
-			_ = removeSessionArtifacts(repo, wt, "", in.SessionID)
-		}
 		return nil
 	}
 

--- a/internal/agent/hook_handler_test.go
+++ b/internal/agent/hook_handler_test.go
@@ -130,7 +130,7 @@ func TestHandleHook_StopSetsDone(t *testing.T) {
 
 func TestHandleHook_SessionEndRemovesFiles(t *testing.T) {
 	repo, wt := setupWorktreeHome(t)
-	dir := filepath.Join(StatusDir(), repo, wt)
+	dir := SessionDir(repo, wt, "claude")
 	os.MkdirAll(dir, 0o755)
 	os.WriteFile(filepath.Join(dir, "s1.json"), []byte("{}"), 0o644)
 	os.WriteFile(filepath.Join(dir, "s1.files"), []byte("/x"), 0o644)

--- a/internal/agent/status.go
+++ b/internal/agent/status.go
@@ -43,7 +43,6 @@ type SessionStatus struct {
 	TurnID         string    `json:"turn_id,omitempty"`
 	PermissionMode string    `json:"permission_mode,omitempty"`
 	Worktree       string    `json:"worktree,omitempty"`
-	Legacy         bool      `json:"-"`
 }
 
 func StatusDir() string {
@@ -52,8 +51,6 @@ func StatusDir() string {
 
 // ReadAllSessions reads all session status files from:
 // <willow-base>/status/<repo>/<worktree>/<harness>/*.json.
-// It also reads legacy flat Claude files at <repo>/<worktree>/*.json so
-// existing installs keep their status after upgrading.
 func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 	dir := StatusWorktreeDir(repoName, worktreeDir)
 	entries, err := os.ReadDir(dir)
@@ -63,17 +60,11 @@ func ReadAllSessions(repoName, worktreeDir string) []*SessionStatus {
 
 	var sessions []*SessionStatus
 	for _, e := range entries {
-		if e.IsDir() {
-			harnessID := e.Name()
-			sessions = append(sessions, readHarnessSessions(repoName, worktreeDir, harnessID)...)
+		if !e.IsDir() {
 			continue
 		}
-		if strings.HasSuffix(e.Name(), ".json") {
-			sessionID := strings.TrimSuffix(e.Name(), ".json")
-			if ss := readSessionFile(repoName, worktreeDir, "", sessionID, filepath.Join(dir, e.Name()), true); ss != nil {
-				sessions = append(sessions, ss)
-			}
-		}
+		harnessID := e.Name()
+		sessions = append(sessions, readHarnessSessions(repoName, worktreeDir, harnessID)...)
 	}
 	return sessions
 }
@@ -90,14 +81,14 @@ func readHarnessSessions(repoName, worktreeDir, harnessID string) []*SessionStat
 			continue
 		}
 		sessionID := strings.TrimSuffix(e.Name(), ".json")
-		if ss := readSessionFile(repoName, worktreeDir, harnessID, sessionID, filepath.Join(dir, e.Name()), false); ss != nil {
+		if ss := readSessionFile(repoName, worktreeDir, harnessID, sessionID, filepath.Join(dir, e.Name())); ss != nil {
 			sessions = append(sessions, ss)
 		}
 	}
 	return sessions
 }
 
-func readSessionFile(repoName, worktreeDir, harnessID, sessionID, path string, legacy bool) *SessionStatus {
+func readSessionFile(repoName, worktreeDir, harnessID, sessionID, path string) *SessionStatus {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -108,7 +99,6 @@ func readSessionFile(repoName, worktreeDir, harnessID, sessionID, path string, l
 		return nil
 	}
 	applySessionDefaults(&ss, harnessID, sessionID, worktreeDir)
-	ss.Legacy = legacy
 	return &ss
 }
 
@@ -236,14 +226,11 @@ type SessionFileInfo struct {
 }
 
 func RemoveSessionFileForSession(repoName, worktreeDir string, session SessionStatus) error {
-	if session.Legacy || session.Harness == "" {
-		return removeSessionArtifacts(repoName, worktreeDir, "", session.SessionID)
-	}
 	return removeSessionArtifacts(repoName, worktreeDir, session.Harness, session.SessionID)
 }
 
 func removeSessionArtifacts(repoName, worktreeDir, harnessID, sessionID string) error {
-	if sessionID == "" {
+	if harnessID == "" || sessionID == "" {
 		return nil
 	}
 
@@ -257,17 +244,10 @@ func removeSessionArtifacts(repoName, worktreeDir, harnessID, sessionID string) 
 }
 
 func sessionArtifactPaths(repoName, worktreeDir, harnessID, sessionID string) []string {
-	if harnessID != "" {
-		return []string{
-			SessionPath(repoName, worktreeDir, harnessID, sessionID),
-			FilesPathForHarness(repoName, worktreeDir, harnessID, sessionID),
-			TimelinePathForHarness(repoName, worktreeDir, harnessID, sessionID),
-		}
-	}
 	return []string{
-		LegacySessionPath(repoName, worktreeDir, sessionID),
-		LegacyFilesPath(repoName, worktreeDir, sessionID),
-		LegacyTimelinePath(repoName, worktreeDir, sessionID),
+		SessionPath(repoName, worktreeDir, harnessID, sessionID),
+		FilesPathForHarness(repoName, worktreeDir, harnessID, sessionID),
+		TimelinePathForHarness(repoName, worktreeDir, harnessID, sessionID),
 	}
 }
 
@@ -304,29 +284,16 @@ func ScanAllSessions() ([]SessionFileInfo, error) {
 				continue
 			}
 			for _, se := range sessEntries {
-				if se.IsDir() {
-					for _, ss := range readHarnessSessions(repoName, wtDir, se.Name()) {
-						results = append(results, SessionFileInfo{
-							RepoName:    repoName,
-							WorktreeDir: wtDir,
-							Session:     *ss,
-						})
-					}
+				if !se.IsDir() {
 					continue
 				}
-				if !strings.HasSuffix(se.Name(), ".json") {
-					continue
+				for _, ss := range readHarnessSessions(repoName, wtDir, se.Name()) {
+					results = append(results, SessionFileInfo{
+						RepoName:    repoName,
+						WorktreeDir: wtDir,
+						Session:     *ss,
+					})
 				}
-				sessionID := strings.TrimSuffix(se.Name(), ".json")
-				ss := readSessionFile(repoName, wtDir, "", sessionID, filepath.Join(wtPath, se.Name()), true)
-				if ss == nil {
-					continue
-				}
-				results = append(results, SessionFileInfo{
-					RepoName:    repoName,
-					WorktreeDir: wtDir,
-					Session:     *ss,
-				})
 			}
 		}
 	}
@@ -354,13 +321,10 @@ func ReadFilesTouched(repoName, worktreeDir, sessionID string) []string {
 }
 
 func findFilesPath(repoName, worktreeDir, sessionID string) string {
-	if path := LegacyFilesPath(repoName, worktreeDir, sessionID); fileExists(path) {
-		return path
-	}
 	dir := StatusWorktreeDir(repoName, worktreeDir)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return LegacyFilesPath(repoName, worktreeDir, sessionID)
+		return FilesPathForHarness(repoName, worktreeDir, harness.ClaudeID, sessionID)
 	}
 	for _, e := range entries {
 		if !e.IsDir() {
@@ -371,7 +335,7 @@ func findFilesPath(repoName, worktreeDir, sessionID string) string {
 			return path
 		}
 	}
-	return LegacyFilesPath(repoName, worktreeDir, sessionID)
+	return FilesPathForHarness(repoName, worktreeDir, harness.ClaudeID, sessionID)
 }
 
 // CleanEmptyStatusDirs removes empty worktree/repo directories under StatusDir().
@@ -442,16 +406,8 @@ func SessionPath(repoName, worktreeDir, harnessID, sessionID string) string {
 	return filepath.Join(SessionDir(repoName, worktreeDir, harnessID), sessionID+".json")
 }
 
-func LegacySessionPath(repoName, worktreeDir, sessionID string) string {
-	return filepath.Join(StatusWorktreeDir(repoName, worktreeDir), sessionID+".json")
-}
-
 func FilesPathForHarness(repoName, worktreeDir, harnessID, sessionID string) string {
 	return filepath.Join(SessionDir(repoName, worktreeDir, harnessID), sessionID+".files")
-}
-
-func LegacyFilesPath(repoName, worktreeDir, sessionID string) string {
-	return filepath.Join(StatusWorktreeDir(repoName, worktreeDir), sessionID+".files")
 }
 
 func fileExists(path string) bool {

--- a/internal/agent/status_test.go
+++ b/internal/agent/status_test.go
@@ -30,8 +30,8 @@ func TestReadAllSessions_MultipleSessions(t *testing.T) {
 		{Status: StatusDone, SessionID: "sess-2", Timestamp: now.Add(-1 * time.Minute), Worktree: wtName},
 	}
 	for _, ss := range sessions {
-		data, _ := json.Marshal(ss)
-		os.WriteFile(filepath.Join(sessDir, ss.SessionID+".json"), data, 0o644)
+		ss.Harness = "claude"
+		writeSessionFixture(t, SessionPath(repoName, wtName, "claude", ss.SessionID), ss)
 	}
 
 	got := ReadAllSessions(repoName, wtName)
@@ -77,8 +77,8 @@ func TestReadStatus_AggregatesBusyOverDone(t *testing.T) {
 		{Status: StatusDone, SessionID: "s1", Timestamp: now},
 		{Status: StatusBusy, SessionID: "s2", Timestamp: now},
 	} {
-		data, _ := json.Marshal(ss)
-		os.WriteFile(filepath.Join(sessDir, ss.SessionID+".json"), data, 0o644)
+		ss.Harness = "claude"
+		writeSessionFixture(t, SessionPath(repoName, wtName, "claude", ss.SessionID), ss)
 	}
 
 	got := ReadStatus(repoName, wtName)
@@ -87,106 +87,42 @@ func TestReadStatus_AggregatesBusyOverDone(t *testing.T) {
 	}
 }
 
-func TestReadAllSessions_PreservesOldFiles(t *testing.T) {
+func TestReadAllSessions_IgnoresFlatSessionFiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("WILLOW_BASE_DIR", filepath.Join(home, ".willow"))
 
 	repoName := "myrepo"
-	wtName := "old-sessions"
+	wtName := "flat-sessions"
 	sessDir := filepath.Join(StatusDir(), repoName, wtName)
 	os.MkdirAll(sessDir, 0o755)
 
-	// Old session files should still be readable until an explicit liveness
-	// cleanup path removes them.
-	old := SessionStatus{Status: StatusDone, SessionID: "old-sess", Timestamp: time.Now().UTC().Add(-2 * time.Hour)}
-	data, _ := json.Marshal(old)
-	os.WriteFile(filepath.Join(sessDir, old.SessionID+".json"), data, 0o644)
-	os.WriteFile(filepath.Join(sessDir, old.SessionID+".files"), []byte("/tmp/file\n"), 0o644)
-	os.WriteFile(LegacyTimelinePath(repoName, wtName, old.SessionID), []byte("{}\n"), 0o644)
+	flat := SessionStatus{Status: StatusDone, SessionID: "flat-sess", Timestamp: time.Now().UTC().Add(-2 * time.Hour)}
+	data, _ := json.Marshal(flat)
+	os.WriteFile(filepath.Join(sessDir, flat.SessionID+".json"), data, 0o644)
+	os.WriteFile(filepath.Join(sessDir, flat.SessionID+".files"), []byte("/tmp/file\n"), 0o644)
+	os.WriteFile(filepath.Join(sessDir, flat.SessionID+".timeline"), []byte("{}\n"), 0o644)
 
 	got := ReadAllSessions(repoName, wtName)
-	if len(got) != 1 {
-		t.Fatalf("ReadAllSessions returned %d sessions, want 1", len(got))
-	}
-
-	if _, err := os.Stat(filepath.Join(sessDir, "old-sess.json")); err != nil {
-		t.Fatalf("old session json should still exist: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(sessDir, "old-sess.files")); err != nil {
-		t.Fatalf("old session files sidecar should still exist: %v", err)
-	}
-	if _, err := os.Stat(LegacyTimelinePath(repoName, wtName, "old-sess")); err != nil {
-		t.Fatalf("old session timeline should still exist: %v", err)
+	if len(got) != 0 {
+		t.Fatalf("ReadAllSessions returned %d sessions, want 0", len(got))
 	}
 }
 
-func TestReadAllSessionsRemovesCorruptLegacyFileOnly(t *testing.T) {
+func TestScanAllSessions_IgnoresFlatSessionFiles(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("WILLOW_BASE_DIR", filepath.Join(home, ".willow"))
 
 	repoName := "myrepo"
-	wtName := "legacy-corrupt"
+	wtName := "flat-scan"
 	sessionID := "shared-sess"
 	sessDir := StatusWorktreeDir(repoName, wtName)
 	if err := os.MkdirAll(sessDir, 0o755); err != nil {
 		t.Fatalf("mkdir status dir: %v", err)
 	}
-	if err := os.WriteFile(LegacySessionPath(repoName, wtName, sessionID), []byte("{bad json\n"), 0o644); err != nil {
-		t.Fatalf("write corrupt legacy session: %v", err)
-	}
-	if err := os.WriteFile(LegacyFilesPath(repoName, wtName, sessionID), []byte("/tmp/file\n"), 0o644); err != nil {
-		t.Fatalf("write legacy files sidecar: %v", err)
-	}
-	if err := os.WriteFile(LegacyTimelinePath(repoName, wtName, sessionID), []byte("{}\n"), 0o644); err != nil {
-		t.Fatalf("write legacy timeline sidecar: %v", err)
-	}
-
-	valid := SessionStatus{Harness: "codex", Status: StatusBusy, SessionID: sessionID, Timestamp: time.Now().UTC()}
-	writeSessionFixture(t, SessionPath(repoName, wtName, "codex", sessionID), valid)
-
-	got := ReadAllSessions(repoName, wtName)
-	if len(got) != 1 {
-		t.Fatalf("ReadAllSessions returned %d sessions, want 1: %+v", len(got), got)
-	}
-	if got[0].Harness != "codex" {
-		t.Fatalf("remaining session harness = %q, want codex", got[0].Harness)
-	}
-	if _, err := os.Stat(LegacySessionPath(repoName, wtName, sessionID)); !os.IsNotExist(err) {
-		t.Fatalf("corrupt legacy session should be removed, stat err = %v", err)
-	}
-	if _, err := os.Stat(LegacyFilesPath(repoName, wtName, sessionID)); !os.IsNotExist(err) {
-		t.Fatalf("legacy files sidecar should be removed, stat err = %v", err)
-	}
-	if _, err := os.Stat(LegacyTimelinePath(repoName, wtName, sessionID)); !os.IsNotExist(err) {
-		t.Fatalf("legacy timeline sidecar should be removed, stat err = %v", err)
-	}
-	if _, err := os.Stat(SessionPath(repoName, wtName, "codex", sessionID)); err != nil {
-		t.Fatalf("codex session with same id should remain: %v", err)
-	}
-}
-
-func TestScanAllSessionsRemovesCorruptLegacyFileOnly(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("WILLOW_BASE_DIR", filepath.Join(home, ".willow"))
-
-	repoName := "myrepo"
-	wtName := "legacy-scan-corrupt"
-	sessionID := "shared-sess"
-	sessDir := StatusWorktreeDir(repoName, wtName)
-	if err := os.MkdirAll(sessDir, 0o755); err != nil {
-		t.Fatalf("mkdir status dir: %v", err)
-	}
-	if err := os.WriteFile(LegacySessionPath(repoName, wtName, sessionID), []byte("{bad json\n"), 0o644); err != nil {
-		t.Fatalf("write corrupt legacy session: %v", err)
-	}
-	if err := os.WriteFile(LegacyFilesPath(repoName, wtName, sessionID), []byte("/tmp/file\n"), 0o644); err != nil {
-		t.Fatalf("write legacy files sidecar: %v", err)
-	}
-	if err := os.WriteFile(LegacyTimelinePath(repoName, wtName, sessionID), []byte("{}\n"), 0o644); err != nil {
-		t.Fatalf("write legacy timeline sidecar: %v", err)
+	if err := os.WriteFile(filepath.Join(sessDir, sessionID+".json"), []byte("{bad json\n"), 0o644); err != nil {
+		t.Fatalf("write flat session: %v", err)
 	}
 
 	valid := SessionStatus{Harness: "codex", Status: StatusBusy, SessionID: sessionID, Timestamp: time.Now().UTC()}
@@ -201,9 +137,6 @@ func TestScanAllSessionsRemovesCorruptLegacyFileOnly(t *testing.T) {
 	}
 	if got[0].Session.Harness != "codex" {
 		t.Fatalf("remaining session harness = %q, want codex", got[0].Session.Harness)
-	}
-	if _, err := os.Stat(LegacySessionPath(repoName, wtName, sessionID)); !os.IsNotExist(err) {
-		t.Fatalf("corrupt legacy session should be removed, stat err = %v", err)
 	}
 	if _, err := os.Stat(SessionPath(repoName, wtName, "codex", sessionID)); err != nil {
 		t.Fatalf("codex session with same id should remain: %v", err)
@@ -233,7 +166,10 @@ func TestMoveStatusDir(t *testing.T) {
 	if err := os.MkdirAll(oldDir, 0o755); err != nil {
 		t.Fatalf("mkdir old status dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(oldDir, "s1.json"), []byte("{}"), 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Join(oldDir, "claude"), 0o755); err != nil {
+		t.Fatalf("mkdir harness status dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(oldDir, "claude", "s1.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatalf("write status file: %v", err)
 	}
 
@@ -243,7 +179,7 @@ func TestMoveStatusDir(t *testing.T) {
 	if _, err := os.Stat(StatusWorktreeDir("repo", "old")); !os.IsNotExist(err) {
 		t.Fatalf("old status dir should be gone, err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(StatusWorktreeDir("repo", "new"), "s1.json")); err != nil {
+	if _, err := os.Stat(filepath.Join(StatusWorktreeDir("repo", "new"), "claude", "s1.json")); err != nil {
 		t.Fatalf("new status file missing: %v", err)
 	}
 }
@@ -370,7 +306,7 @@ func TestReadStatus_WaitAggregation(t *testing.T) {
 
 	repoName := "myrepo"
 	wtName := "wait-test"
-	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName, "claude")
 	os.MkdirAll(sessDir, 0o755)
 
 	now := time.Now().UTC()
@@ -422,7 +358,7 @@ func TestReadFilesTouched(t *testing.T) {
 	repoName := "myrepo"
 	wtName := "wt1"
 	sessionID := "sess-1"
-	dir := filepath.Join(StatusDir(), repoName, wtName)
+	dir := SessionDir(repoName, wtName, "claude")
 	os.MkdirAll(dir, 0o755)
 
 	// Write a .files sidecar

--- a/internal/agent/timeline.go
+++ b/internal/agent/timeline.go
@@ -18,9 +18,6 @@ type TimelineEntry struct {
 
 // TimelinePath returns the path to the timeline JSONL file for a session.
 func TimelinePath(repoName, worktreeDir, sessionID string) string {
-	if path := LegacyTimelinePath(repoName, worktreeDir, sessionID); fileExists(path) {
-		return path
-	}
 	dir := StatusWorktreeDir(repoName, worktreeDir)
 	entries, err := os.ReadDir(dir)
 	if err == nil {
@@ -39,10 +36,6 @@ func TimelinePath(repoName, worktreeDir, sessionID string) string {
 
 func TimelinePathForHarness(repoName, worktreeDir, harnessID, sessionID string) string {
 	return filepath.Join(SessionDir(repoName, worktreeDir, harnessID), sessionID+".timeline")
-}
-
-func LegacyTimelinePath(repoName, worktreeDir, sessionID string) string {
-	return filepath.Join(StatusWorktreeDir(repoName, worktreeDir), sessionID+".timeline")
 }
 
 // ReadTimeline reads timeline entries within a time window.

--- a/internal/agent/timeline_test.go
+++ b/internal/agent/timeline_test.go
@@ -105,7 +105,7 @@ func TestReadTimeline(t *testing.T) {
 	wtDir := "feat-auth"
 	sessionID := "sess-1"
 
-	dir := filepath.Join(home, ".willow", "status", repoName, wtDir)
+	dir := filepath.Join(home, ".willow", "status", repoName, wtDir, "claude")
 	os.MkdirAll(dir, 0o755)
 
 	now := time.Now().UTC()

--- a/internal/agent/unread_test.go
+++ b/internal/agent/unread_test.go
@@ -14,7 +14,7 @@ func TestUnreadCount_NoDoneSessionsReturnsZero(t *testing.T) {
 
 	repoName := "myrepo"
 	wtName := "wt1"
-	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName, "claude")
 	os.MkdirAll(sessDir, 0o755)
 
 	ss := SessionStatus{Status: StatusBusy, SessionID: "s1", Timestamp: time.Now().UTC()}
@@ -32,7 +32,7 @@ func TestUnreadCount_DoneSessionIsUnread(t *testing.T) {
 
 	repoName := "myrepo"
 	wtName := "wt2"
-	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName, "claude")
 	os.MkdirAll(sessDir, 0o755)
 
 	ss := SessionStatus{Status: StatusDone, SessionID: "s1", Timestamp: time.Now().UTC()}
@@ -53,7 +53,7 @@ func TestMarkRead_ClearsUnread(t *testing.T) {
 
 	repoName := "myrepo"
 	wtName := "wt3"
-	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName, "claude")
 	os.MkdirAll(sessDir, 0o755)
 
 	past := time.Now().UTC().Add(-1 * time.Minute)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -293,11 +293,12 @@ func TestCheckStaleSessions(t *testing.T) {
 		t.Fatalf("successes = %v, want no stale sessions", u.successes)
 	}
 
-	statusDir := filepath.Join(agent.StatusDir(), "repo", "worktree")
+	statusDir := filepath.Join(agent.StatusDir(), "repo", "worktree", "claude")
 	if err := os.MkdirAll(statusDir, 0o755); err != nil {
 		t.Fatalf("mkdir status dir: %v", err)
 	}
 	session := agent.SessionStatus{
+		Harness:   "claude",
 		Status:    agent.StatusBusy,
 		SessionID: "s1",
 		Timestamp: time.Now().Add(-31 * time.Minute),

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -91,11 +91,12 @@ func writeGlobalConfigFile(t *testing.T, contents string) {
 func writeActiveSessionFile(t *testing.T, repo, wt, sessionID string, status agent.Status) {
 	t.Helper()
 
-	dir := filepath.Join(agent.StatusDir(), repo, wt)
+	dir := filepath.Join(agent.StatusDir(), repo, wt, "claude")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir session dir: %v", err)
 	}
 	data, err := json.Marshal(agent.SessionStatus{
+		Harness:   "claude",
 		Status:    status,
 		SessionID: sessionID,
 		Timestamp: time.Now(),
@@ -711,7 +712,7 @@ func TestPromote_GeneratedDetachedWorktreeMovesToBranchName(t *testing.T) {
 	if _, err := os.Stat(agent.StatusWorktreeDir("testrepo", oldDir)); !os.IsNotExist(err) {
 		t.Fatalf("old status dir should be gone, err=%v", err)
 	}
-	if _, err := os.Stat(filepath.Join(agent.StatusWorktreeDir("testrepo", "feature-generated"), "s1.json")); err != nil {
+	if _, err := os.Stat(agent.SessionPath("testrepo", "feature-generated", "claude", "s1")); err != nil {
 		t.Fatalf("new status file missing: %v", err)
 	}
 	if !strings.Contains(readTestFile(t, tmuxLog), "rename-session|-t|testrepo/"+oldDir+"|testrepo/feature-generated") {

--- a/internal/cli/refresh_status_test.go
+++ b/internal/cli/refresh_status_test.go
@@ -15,7 +15,7 @@ func TestRefreshStatusDryRunAndRemoval(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	writeActiveSessionFile(t, "repo", "feature", "s1", agent.StatusBusy)
-	sessionPath := filepath.Join(agent.StatusDir(), "repo", "feature", "s1.json")
+	sessionPath := agent.SessionPath("repo", "feature", "claude", "s1")
 
 	dryRunOut, err := captureStdout(t, func() error {
 		return runApp("refresh-status", "--dry-run")

--- a/internal/cli/rename_test.go
+++ b/internal/cli/rename_test.go
@@ -190,7 +190,7 @@ func TestRename_MovesStatusDirAndRejectsCollision(t *testing.T) {
 	if err := runApp("rename", "old", "new"); err != nil {
 		t.Fatalf("rename failed: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(agent.StatusWorktreeDir(repo.RepoName, "new"), "s1.json")); err != nil {
+	if _, err := os.Stat(agent.SessionPath(repo.RepoName, "new", "claude", "s1")); err != nil {
 		t.Fatalf("new status file missing: %v", err)
 	}
 	if _, err := os.Stat(agent.StatusWorktreeDir(repo.RepoName, "old")); !os.IsNotExist(err) {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -51,7 +51,7 @@ func TestCollectRepoStatus_WithSessions(t *testing.T) {
 	wtName := "feature"
 
 	// Create session files
-	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName, "claude")
 	os.MkdirAll(sessDir, 0o755)
 
 	now := time.Now().UTC()
@@ -142,7 +142,7 @@ func TestCollectRepoStatus_UnreadMarking(t *testing.T) {
 
 	repoName := "myrepo"
 	wtName := "done-wt"
-	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName, "claude")
 	os.MkdirAll(sessDir, 0o755)
 
 	// Use a past timestamp so MarkRead (which writes "now") is strictly after it
@@ -180,7 +180,7 @@ func TestCollectRepoStatus_MarksOnlyUnreadDoneSession(t *testing.T) {
 
 	repoName := "myrepo"
 	wtName := "done-wt"
-	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName)
+	sessDir := filepath.Join(home, ".willow", "status", repoName, wtName, "claude")
 	os.MkdirAll(sessDir, 0o755)
 
 	base := time.Now().UTC().Add(-10 * time.Minute)
@@ -193,7 +193,7 @@ func TestCollectRepoStatus_MarksOnlyUnreadDoneSession(t *testing.T) {
 		os.WriteFile(filepath.Join(sessDir, ss.SessionID+".json"), data, 0o644)
 	}
 	lastRead := base.Add(1*time.Minute).Format(time.RFC3339) + "\n"
-	os.WriteFile(filepath.Join(sessDir, ".lastread"), []byte(lastRead), 0o644)
+	os.WriteFile(filepath.Join(home, ".willow", "status", repoName, wtName, ".lastread"), []byte(lastRead), 0o644)
 
 	rs := collectRepoStatus(repoName, []worktree.Worktree{
 		{Branch: "done-branch", Path: "/wt/myrepo/" + wtName},

--- a/internal/cli/sw_test.go
+++ b/internal/cli/sw_test.go
@@ -35,7 +35,7 @@ func TestExtractPathFromLine(t *testing.T) {
 
 func writeSessionStatus(t *testing.T, home, repo, wt string, status agent.Status, ts time.Time) {
 	t.Helper()
-	dir := filepath.Join(home, ".willow", "status", repo, wt)
+	dir := filepath.Join(home, ".willow", "status", repo, wt, "claude")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir status dir: %v", err)
 	}

--- a/internal/dashboard/dashboard_test.go
+++ b/internal/dashboard/dashboard_test.go
@@ -182,11 +182,12 @@ func addDashboardWorktree(t *testing.T, bareDir, branch, base string) string {
 func writeDashboardSession(t *testing.T, repo, wtDir, sessionID string, status agent.Status, tool string, ts time.Time) {
 	t.Helper()
 
-	dir := filepath.Join(agent.StatusDir(), repo, wtDir)
+	dir := filepath.Join(agent.StatusDir(), repo, wtDir, "claude")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir status dir: %v", err)
 	}
 	data, err := json.Marshal(agent.SessionStatus{
+		Harness:   "claude",
 		Status:    status,
 		SessionID: sessionID,
 		Tool:      tool,

--- a/internal/tmux/picker_test.go
+++ b/internal/tmux/picker_test.go
@@ -567,11 +567,12 @@ func pickerTestBareRepo(t *testing.T, home, repo string) string {
 
 func writePickerSessionStatus(t *testing.T, repo, wt string, status agent.Status) {
 	t.Helper()
-	dir := filepath.Join(agent.StatusDir(), repo, wt)
+	dir := filepath.Join(agent.StatusDir(), repo, wt, "claude")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir status dir: %v", err)
 	}
 	data, err := json.Marshal(agent.SessionStatus{
+		Harness:   "claude",
 		Status:    status,
 		SessionID: "session-1",
 		Timestamp: time.Now(),

--- a/website/src/app/(docs)/configuration/page.mdx
+++ b/website/src/app/(docs)/configuration/page.mdx
@@ -124,7 +124,7 @@ Each worktree is a fully isolated directory with its own working copy. Grouped b
 
 ### `<willow-base>/status/`
 
-Created by `ww cc-setup`, `ww codex-setup`, or `ww agent setup`. Contains JSON files with agent status for each worktree and harness. Willow still reads legacy flat Claude files from older installs.
+Created by `ww cc-setup`, `ww codex-setup`, or `ww agent setup`. Contains JSON files with agent status for each worktree and harness.
 
 ```jsonc
 // <willow-base>/status/myrepo/auth-refactor/codex/<session_id>.json


### PR DESCRIPTION
## Description of the change
Remove the legacy flat session-artifact compatibility path so Willow only reads and cleans up harness-scoped status files under `<willow-base>/status/<repo>/<worktree>/<harness>/`. Also update docs and tests to reflect the harness-only layout.

**Ticket:**

## Test plan
Go unit/integration suite, focused agent status tests, docs website build, and manual `willow status` verification after migrating local marker files.

## Loom or screenshots

## Considerations
Migrated existing local flat status artifacts into `claude/`; one overlapping timeline was merged with the newer harness-scoped session timeline.
