### PR TITLE
:zap: perf[git]: skip tags during fetches

### DIFF
--- a/internal/cli/checkout.go
+++ b/internal/cli/checkout.go
@@ -145,10 +145,10 @@ func checkoutCmd() *cli.Command {
 				done = tr.StartCtx(ctx, "git fetch")
 				if cdOnly {
 					fmt.Fprintf(os.Stderr, "Fetching from origin...\n")
-					repoGit.RunStream(os.Stderr, "fetch", "--progress", "origin")
+					repoGit.RunStream(os.Stderr, "fetch", "--no-tags", "--progress", "origin")
 				} else {
 					_ = u.Spin("Fetching from origin", func() error {
-						_, err := repoGit.Run("fetch", "origin")
+						_, err := repoGit.Run("fetch", "--no-tags", "origin")
 						return err
 					})
 				}

--- a/internal/cli/gc.go
+++ b/internal/cli/gc.go
@@ -75,7 +75,7 @@ func gcCmd() *cli.Command {
 				cfg := config.Load(repo.BareDir)
 				repoGit := &git.Git{Dir: repo.BareDir, Verbose: flags.Verbose}
 				if *cfg.Defaults.Fetch && !cmd.Bool("no-fetch") {
-					if _, err := repoGit.Run("fetch", "--prune", "origin"); err != nil {
+					if _, err := repoGit.Run("fetch", "--no-tags", "--prune", "origin"); err != nil {
 						u.Warn(fmt.Sprintf("Skipping remote refresh for %s: %v", repo.Name, err))
 					}
 				}

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -119,13 +119,13 @@ func resolveDetachedRef(ctx context.Context, tr *trace.Tracer, cmd *cli.Command,
 		done = tr.StartCtx(ctx, "git fetch detached ref")
 		if cdOnly {
 			fmt.Fprintf(os.Stderr, "Fetching %s from origin...\n", baseBranch)
-			if _, err := repoGit.RunStream(os.Stderr, "fetch", "--progress", "origin", baseBranch); err != nil {
+			if _, err := repoGit.RunStream(os.Stderr, "fetch", "--no-tags", "--progress", "origin", baseBranch); err != nil {
 				done()
 				return "", "", fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
 			}
 		} else {
 			if err := u.Spin(fmt.Sprintf("Fetching %s from origin", u.Bold(baseBranch)), func() error {
-				_, err := repoGit.Run("fetch", "origin", baseBranch)
+				_, err := repoGit.Run("fetch", "--no-tags", "origin", baseBranch)
 				return err
 			}); err != nil {
 				done()
@@ -312,7 +312,7 @@ func newCmd() *cli.Command {
 				shouldFetch := *cfg.Defaults.Fetch && !cmd.Bool("no-fetch")
 				if shouldFetch {
 					if err := u.Spin("Fetching latest branches from origin", func() error {
-						_, err := repoGit.Run("fetch", "origin")
+						_, err := repoGit.Run("fetch", "--no-tags", "origin")
 						return err
 					}); err != nil {
 						u.Warn(fmt.Sprintf("Failed to fetch: %v", err))
@@ -339,12 +339,12 @@ func newCmd() *cli.Command {
 					done = tr.StartCtx(ctx, "git fetch branch")
 					if cdOnly {
 						fmt.Fprintf(os.Stderr, "Fetching %s from origin...\n", branch)
-						if _, err := repoGit.RunStream(os.Stderr, "fetch", "--progress", "origin", branch); err != nil {
+						if _, err := repoGit.RunStream(os.Stderr, "fetch", "--no-tags", "--progress", "origin", branch); err != nil {
 							return fmt.Errorf("failed to fetch origin/%s: %w", branch, err)
 						}
 					} else {
 						if err := u.Spin(fmt.Sprintf("Fetching %s from origin", u.Bold(branch)), func() error {
-							_, err := repoGit.Run("fetch", "origin", branch)
+							_, err := repoGit.Run("fetch", "--no-tags", "origin", branch)
 							return err
 						}); err != nil {
 							return fmt.Errorf("failed to fetch origin/%s: %w", branch, err)
@@ -404,12 +404,12 @@ func newCmd() *cli.Command {
 				done = tr.StartCtx(ctx, "git fetch")
 				if cdOnly {
 					fmt.Fprintf(os.Stderr, "Fetching %s from origin...\n", baseBranch)
-					if _, err := repoGit.RunStream(os.Stderr, "fetch", "--progress", "origin", baseBranch); err != nil {
+					if _, err := repoGit.RunStream(os.Stderr, "fetch", "--no-tags", "--progress", "origin", baseBranch); err != nil {
 						return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)
 					}
 				} else {
 					if err := u.Spin(fmt.Sprintf("Fetching %s from origin", u.Bold(baseBranch)), func() error {
-						_, err := repoGit.Run("fetch", "origin", baseBranch)
+						_, err := repoGit.Run("fetch", "--no-tags", "origin", baseBranch)
 						return err
 					}); err != nil {
 						return fmt.Errorf("failed to fetch origin/%s: %w", baseBranch, err)

--- a/internal/cli/rename.go
+++ b/internal/cli/rename.go
@@ -417,7 +417,7 @@ func fetchRemoteBranchRef(repoGit *git.Git, remote, branch string) (bool, error)
 		return false, nil
 	}
 	refspec := "+refs/heads/" + branch + ":refs/remotes/" + remote + "/" + branch
-	if _, err := repoGit.Run("fetch", remote, refspec); err != nil {
+	if _, err := repoGit.Run("fetch", "--no-tags", remote, refspec); err != nil {
 		return false, fmt.Errorf("failed to fetch %s/%s before remote rename: %w", remote, branch, err)
 	}
 	return true, nil

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -124,7 +124,7 @@ func syncCmd() *cli.Command {
 			if !cmd.Bool("no-fetch") {
 				done = tr.StartCtx(ctx, "git fetch")
 				if err := u.Spin("Fetching origin", func() error {
-					_, err := repoGit.Run("fetch", "origin")
+					_, err := repoGit.Run("fetch", "--no-tags", "origin")
 					return err
 				}); err != nil {
 					u.Warn(fmt.Sprintf("fetch failed: %v (continuing anyway)", err))

--- a/internal/cli/tmux.go
+++ b/internal/cli/tmux.go
@@ -560,7 +560,7 @@ func existingBranchesForRepo(repo string, refresh bool) ([]string, error) {
 
 	repoGit := &git.Git{Dir: bareDir}
 	if refresh {
-		_, _ = repoGit.Run("fetch", "origin")
+		_, _ = repoGit.Run("fetch", "--no-tags", "origin")
 	}
 
 	remoteBranches, err := repoGit.RemoteBranches()


### PR DESCRIPTION
## Description of the change
Skip tag auto-follow during Willow fetch refreshes for branch-oriented commands, reducing unnecessary network/ref work while preserving remote-tracking branch updates.

## Test plan
- Go test suite
- Local Willow build

## Considerations
Implementation assisted by Codex.