### PR TITLE
:sparkles: feat[agent]: add cursor agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 </p>
 
 <p align="center">
-  Spin up isolated worktrees for Claude Code or Codex CLI sessions.<br>
+  Spin up isolated worktrees for Claude Code, Codex CLI, or Cursor Agent sessions.<br>
   Switch between them instantly with fzf.<br>
   See which agents are busy, waiting, or idle.<br><br>
   <a href="https://getwillow.dev">Documentation</a>
@@ -41,7 +41,7 @@ Running multiple agent sessions on the same repo means constant context-switchin
 ├── worktrees/
 │   └── myrepo/
 │       ├── main/                 # each branch = isolated directory
-│       ├── auth-refactor/        # Claude Code or Codex running here
+│       ├── auth-refactor/        # Claude Code, Codex, or Cursor running here
 │       └── payments/             # another agent running here
 └── status/
     └── myrepo/
@@ -49,8 +49,10 @@ Running multiple agent sessions on the same repo means constant context-switchin
         │   └── claude/
         │       └── <session_id>.json   # {"status": "BUSY", ...}
         └── payments/
-            └── codex/
-                └── <session_id>.json   # {"status": "WAIT", ...}
+            ├── codex/
+            │   └── <session_id>.json   # {"status": "DONE", ...}
+            └── cursor/
+                └── <session_id>.json   # {"status": "BUSY", ...}
 ```
 
 `<willow-base>` defaults to `~/.willow`. You can override it with `WILLOW_BASE_DIR` or the global `baseDir` config, and move an existing setup with `ww migrate-base <path>`.
@@ -142,10 +144,11 @@ python3 skills/willow-autoresearch/scripts/bench_willow.py --reference-repo ~/co
 ```bash
 ww cc-setup                 # Claude Code hooks
 ww codex-setup              # Codex CLI hooks
-ww agent setup all          # both
+ww cursor-setup             # Cursor Agent hooks
+ww agent setup all          # all built-in harnesses
 ```
 
-Installs hooks that write per-session agent status (`BUSY` / `DONE` / `WAIT` / `IDLE`) to `<willow-base>/status/<repo>/<worktree>/<harness>/`. Claude hooks live in `~/.claude/settings.json`; Codex hooks live in `~/.codex/hooks.json` and may need review in Codex with `/hooks`. Multiple harnesses can run in the same worktree at the same time. This powers the status column in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`.
+Installs hooks that write per-session agent status (`BUSY` / `DONE` / `WAIT` / `IDLE`) to `<willow-base>/status/<repo>/<worktree>/<harness>/`. Claude hooks live in `~/.claude/settings.json`; Codex hooks live in `~/.codex/hooks.json` and may need review in Codex with `/hooks`; Cursor hooks live in `~/.cursor/hooks.json`. Cursor currently reports `BUSY`, `DONE`, and cleanup events, but not `WAIT`. Multiple harnesses can run in the same worktree at the same time. This powers the status column in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`.
 
 ## Quick start
 
@@ -156,9 +159,10 @@ ww clone git@github.com:org/myrepo.git
 # Create a worktree and cd into it
 ww new auth-refactor
 
-# Start Claude Code or Codex
+# Start Claude Code, Codex, or Cursor Agent
 claude
 # or: codex
+# or: cursor-agent
 
 # In another terminal — create a second worktree
 ww new payments-fix
@@ -465,6 +469,7 @@ ww dispatch "Add retry logic" --name add-retries             # explicit branch n
 ww dispatch "Write tests for auth" --base feature/auth       # stacked on a branch
 ww dispatch "Refactor payments" --repo myrepo                # target specific repo
 ww dispatch "Fix auth" --agent codex                         # one-off Codex dispatch
+ww dispatch "Fix auth" --agent cursor                        # one-off Cursor dispatch
 ```
 
 ![ww dispatch](screenshots/demo-dispatch.gif)
@@ -475,8 +480,10 @@ ww dispatch "Fix auth" --agent codex                         # one-off Codex dis
 | `-r, --repo` | Target repo by name |
 | `-b, --base` | Base branch to fork from |
 | `--no-fetch` | Skip fetching from remote |
-| `--agent` | Override `agent.default` (`claude` or `codex`) |
-| `--yolo` | Run with the harness's full-access flag (`claude`: `--dangerously-skip-permissions`; `codex`: `--dangerously-bypass-approvals-and-sandbox`) |
+| `--agent` | Override `agent.default` (`claude`, `codex`, or `cursor`) |
+| `--yolo` | Run with the harness's full-access flag (`claude`: `--dangerously-skip-permissions`; `codex`: `--dangerously-bypass-approvals-and-sandbox`; `cursor`: `--force`) |
+
+Willow owns worktree creation for dispatches. Cursor's own `--worktree` path is not used because Willow has already created and selected the isolated worktree before launching `cursor-agent`.
 
 ### `ww cc-setup`
 
@@ -486,13 +493,17 @@ One-time hook installation for Claude Code status tracking.
 
 One-time hook installation for Codex CLI status tracking. Codex may ask you to review and trust the hook with `/hooks`.
 
-### `ww agent setup [claude|codex|all]`
+### `ww cursor-setup`
 
-Install hooks for one harness or both.
+One-time hook installation for Cursor Agent status tracking. Willow writes direct Cursor hook entries to `~/.cursor/hooks.json`, preserves unrelated hooks, and leaves hooks fail open.
+
+### `ww agent setup [claude|codex|cursor|all]`
+
+Install hooks for one harness or all built-in harnesses.
 
 ### `ww doctor`
 
-Check your willow setup for common issues. Verifies git version, optional tools (`gh`, `tmux`), Claude/Codex CLIs and hooks, willow directories, stale sessions, and config validity. Flags unmarked legacy Claude hooks left over from older releases.
+Check your willow setup for common issues. Verifies git version, optional tools (`gh`, `tmux`), Claude Code, Codex CLI, and Cursor Agent binaries and hooks, willow directories, stale sessions, and config validity. Flags unmarked legacy Claude hooks left over from older releases.
 
 ```bash
 ww doctor          # report issues only
@@ -534,7 +545,7 @@ Print shell integration script.
 
 ## Agent status
 
-After running `ww cc-setup`, `ww codex-setup`, or `ww agent setup all`, supported agents automatically report their state:
+After running `ww cc-setup`, `ww codex-setup`, `ww cursor-setup`, or `ww agent setup all`, supported agents automatically report their state:
 
 | Icon | Status | Meaning |
 |------|--------|---------|
@@ -544,7 +555,7 @@ After running `ww cc-setup`, `ww codex-setup`, or `ww agent setup all`, supporte
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. In the tmux picker, active parent rows with one session include a harness label like `[claude]` or `[codex]`; multi-session rows rely on the labeled child rows. Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
+Status appears in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`. In the tmux picker, active parent rows with one session include a harness label like `[claude]`, `[codex]`, or `[cursor]`; multi-session rows rely on the labeled child rows. Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`.
 
 ## Configuration
 
@@ -572,10 +583,10 @@ Config merges two tiers (local wins):
     "command": ""
   },
   "agent": {
-    "default": "claude",
+    "default": "cursor",
     "harnesses": {
-      "codex": {
-        "command": "codex",
+      "cursor": {
+        "command": "cursor-agent",
         "args": []
       }
     }
@@ -627,7 +638,7 @@ Recommended Ghostty layout per worktree:
 ┌─────────────────────────────────────┐
 │ Tab: myrepo/auth-refactor           │
 ├──────────────────┬──────────────────┤
-│  claude          │  codex           │
+│  claude/codex    │  cursor-agent    │
 │  (agent 1)       │  (agent 2)       │
 ├──────────────────┴──────────────────┤
 │  shell (git diff, tests, etc.)      │

--- a/internal/agent/harness/codex.go
+++ b/internal/agent/harness/codex.go
@@ -207,7 +207,35 @@ func extractCodexFiles(topLevelFile string, toolInput json.RawMessage) []string 
 			extractPatchFilesFromText(v, add)
 		}
 	}
+	extractPathLikeStrings(input, add)
 	return files
+}
+
+func extractPathLikeStrings(value any, add func(string)) {
+	switch v := value.(type) {
+	case map[string]any:
+		for key, child := range v {
+			lower := strings.ToLower(key)
+			if strings.Contains(lower, "path") || lower == "file" || lower == "filename" {
+				switch typed := child.(type) {
+				case string:
+					add(typed)
+					continue
+				case []any:
+					for _, item := range typed {
+						if s, ok := item.(string); ok {
+							add(s)
+						}
+					}
+				}
+			}
+			extractPathLikeStrings(child, add)
+		}
+	case []any:
+		for _, child := range v {
+			extractPathLikeStrings(child, add)
+		}
+	}
 }
 
 func extractPatchFilesFromText(text string, add func(string)) {

--- a/internal/agent/harness/cursor.go
+++ b/internal/agent/harness/cursor.go
@@ -1,0 +1,184 @@
+package harness
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var cursorHookEvents = []string{
+	"sessionStart",
+	"beforeSubmitPrompt",
+	"preToolUse",
+	"postToolUse",
+	"postToolUseFailure",
+	"beforeShellExecution",
+	"afterShellExecution",
+	"afterFileEdit",
+	"stop",
+	"sessionEnd",
+}
+
+func init() {
+	Register(Cursor{})
+}
+
+type Cursor struct{}
+
+func (Cursor) ID() string                { return CursorID }
+func (Cursor) DisplayName() string       { return "Cursor Agent" }
+func (Cursor) ExecutableName() string    { return "cursor-agent" }
+func (Cursor) SetupCommandLabel() string { return "ww cursor-setup" }
+func (Cursor) DocsHint() string {
+	return "Cursor hooks are installed into ~/.cursor/hooks.json."
+}
+func (Cursor) HookEvents() []string { return append([]string{}, cursorHookEvents...) }
+func (Cursor) Capabilities() Capabilities {
+	return Capabilities{
+		SupportsSessionEnd:   true,
+		SupportsFilesTouched: true,
+		SupportsTurnID:       true,
+	}
+}
+
+func (Cursor) HookCommand(exe string) string {
+	return exe + " hook --harness cursor"
+}
+
+func (h Cursor) InstallHooks(command string) (bool, error) {
+	before, _ := os.ReadFile(cursorHooksPath())
+	if err := h.addHookToConfig(command); err != nil {
+		return false, err
+	}
+	after, _ := os.ReadFile(cursorHooksPath())
+	return !bytes.Equal(before, after), nil
+}
+
+func (h Cursor) HooksInstalled(command string) bool {
+	settings, err := readJSONFile(cursorHooksPath())
+	if err != nil {
+		return false
+	}
+	hooksMap, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, event := range h.HookEvents() {
+		if !eventHasHook(hooksMap, event, command) {
+			return false
+		}
+	}
+	return true
+}
+
+func (Cursor) LegacyHooks() []LegacyHook { return nil }
+
+func (Cursor) RemoveLegacyHooks() ([]string, bool, error) {
+	return nil, false, nil
+}
+
+type cursorHookInput struct {
+	SessionID      string          `json:"session_id"`
+	ConversationID string          `json:"conversation_id"`
+	GenerationID   string          `json:"generation_id"`
+	HookEventName  string          `json:"hook_event_name"`
+	ToolName       string          `json:"tool_name"`
+	FilePath       string          `json:"file_path"`
+	Model          string          `json:"model"`
+	ModelID        string          `json:"model_id"`
+	ToolInput      json.RawMessage `json:"tool_input"`
+}
+
+func (Cursor) NormalizeHook(raw []byte) (NormalizedHook, bool) {
+	var in cursorHookInput
+	if err := json.Unmarshal(bytes.TrimSpace(raw), &in); err != nil {
+		return NormalizedHook{}, false
+	}
+	sessionID := nonEmptyString(in.SessionID, in.ConversationID)
+	if sessionID == "" {
+		return NormalizedHook{}, false
+	}
+	files := extractCodexFiles(in.FilePath, in.ToolInput)
+	return NormalizedHook{
+		HarnessID:    CursorID,
+		SessionID:    sessionID,
+		EventName:    in.HookEventName,
+		ToolName:     in.ToolName,
+		FilePath:     in.FilePath,
+		FilesTouched: files,
+		Model:        nonEmptyString(in.Model, in.ModelID),
+		TurnID:       in.GenerationID,
+	}, true
+}
+
+func (Cursor) BuildLaunch(opts LaunchOptions) LaunchCommand {
+	return launchCommand("cursor-agent", nil, opts, false, []string{"--force"})
+}
+
+func (Cursor) BuildShellLaunch(opts ShellLaunchOptions) string {
+	return shellLaunch("cursor-agent", nil, opts, false, []string{"--force"})
+}
+
+func (h Cursor) addHookToConfig(command string) error {
+	settings, err := readJSONFile(cursorHooksPath())
+	if err != nil {
+		return err
+	}
+	if _, ok := settings["version"]; !ok {
+		settings["version"] = float64(1)
+	}
+
+	hooksMap, ok := settings["hooks"].(map[string]any)
+	if !ok {
+		hooksMap = make(map[string]any)
+	}
+
+	willowRule := map[string]any{
+		"command": command,
+		"timeout": float64(5),
+	}
+
+	for _, event := range h.HookEvents() {
+		existing, _ := hooksMap[event].([]any)
+		filtered := make([]any, 0, len(existing))
+		for _, rule := range existing {
+			if !isWillowCursorRule(rule) {
+				filtered = append(filtered, rule)
+			}
+		}
+		hooksMap[event] = append(filtered, willowRule)
+	}
+
+	settings["hooks"] = hooksMap
+	return writeJSONFile(cursorHooksPath(), settings)
+}
+
+func cursorHooksPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".cursor", "hooks.json")
+}
+
+func isWillowCursorRule(rule any) bool {
+	ruleMap, ok := rule.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, cmd := range ruleCommands(ruleMap) {
+		cmd = strings.TrimSpace(cmd)
+		if strings.Contains(cmd, " hook --harness cursor") && strings.Contains(cmd, "willow") {
+			return true
+		}
+	}
+	return false
+}
+
+func nonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/agent/harness/harness_test.go
+++ b/internal/agent/harness/harness_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRegistryBuiltIns(t *testing.T) {
-	for _, id := range []string{ClaudeID, CodexID} {
+	for _, id := range []string{ClaudeID, CodexID, CursorID} {
 		h, ok := Get(id)
 		if !ok {
 			t.Fatalf("missing harness %q", id)
@@ -82,6 +82,68 @@ func TestCodexHookInstaller(t *testing.T) {
 	}
 }
 
+func TestCursorHookInstaller(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	h := Cursor{}
+	command := "/usr/local/bin/willow hook --harness cursor"
+
+	settingsPath := filepath.Join(home, ".cursor", "hooks.json")
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o755); err != nil {
+		t.Fatalf("mkdir settings dir: %v", err)
+	}
+	if err := os.WriteFile(settingsPath, []byte(`{
+		"hooks": {
+			"stop": [
+				{"command": "/tmp/other-hook"},
+				{"command": "/old/willow hook --harness cursor", "timeout": 1}
+			]
+		}
+	}`), 0o644); err != nil {
+		t.Fatalf("write existing settings: %v", err)
+	}
+
+	changed, err := h.InstallHooks(command)
+	if err != nil {
+		t.Fatalf("InstallHooks: %v", err)
+	}
+	if !changed {
+		t.Fatal("first install should change hooks.json")
+	}
+	if !h.HooksInstalled(command) {
+		t.Fatal("HooksInstalled returned false")
+	}
+	changed, err = h.InstallHooks(command)
+	if err != nil {
+		t.Fatalf("second InstallHooks: %v", err)
+	}
+	if changed {
+		t.Fatal("second install should be idempotent")
+	}
+
+	settings := readTestJSON(t, settingsPath)
+	if got := settings["version"]; got == nil {
+		t.Fatal("version should be set")
+	}
+	hooks := settings["hooks"].(map[string]any)
+	for _, event := range h.HookEvents() {
+		rules, ok := hooks[event].([]any)
+		if !ok || len(rules) == 0 {
+			t.Fatalf("event %s rules = %#v, want rules", event, hooks[event])
+		}
+	}
+	stopRules := hooks["stop"].([]any)
+	if len(stopRules) != 2 {
+		t.Fatalf("stop rules = %#v, want preserved third-party hook plus willow hook", stopRules)
+	}
+	if !eventHasHook(hooks, "stop", "/tmp/other-hook") {
+		t.Fatal("third-party stop hook should be preserved")
+	}
+	if eventHasHook(hooks, "stop", "/old/willow hook --harness cursor") {
+		t.Fatal("stale willow cursor hook should be replaced")
+	}
+}
+
 func TestLaunchBuilders(t *testing.T) {
 	claude := Claude{}.BuildLaunch(LaunchOptions{Prompt: "fix bug", Yolo: true})
 	if claude.Command != "claude" || strings.Join(claude.Args, " ") != "fix bug --dangerously-skip-permissions" {
@@ -97,6 +159,11 @@ func TestLaunchBuilders(t *testing.T) {
 	custom := Codex{}.BuildLaunch(LaunchOptions{Prompt: "fix bug", Yolo: true, Overrides: override})
 	if custom.Command != "my-codex" || strings.Join(custom.Args, " ") != "--profile work --all-clear fix bug" {
 		t.Fatalf("custom Codex launch = %#v", custom)
+	}
+
+	cursor := Cursor{}.BuildLaunch(LaunchOptions{Prompt: "fix bug", Yolo: true})
+	if cursor.Command != "cursor-agent" || strings.Join(cursor.Args, " ") != "--force fix bug" {
+		t.Fatalf("Cursor launch = %#v", cursor)
 	}
 }
 
@@ -122,6 +189,58 @@ func TestCodexNormalizeHook(t *testing.T) {
 	}
 	if strings.Join(got.FilesTouched, ",") != "internal/foo.go,old.go" {
 		t.Fatalf("FilesTouched = %#v", got.FilesTouched)
+	}
+}
+
+func TestCursorNormalizeHook(t *testing.T) {
+	raw := []byte(`{
+		"conversation_id": "conv",
+		"generation_id": "gen",
+		"hook_event_name": "stop",
+		"model_id": "cursor-model"
+	}`)
+	got, ok := Cursor{}.NormalizeHook(raw)
+	if !ok {
+		t.Fatal("NormalizeHook returned false")
+	}
+	if got.HarnessID != CursorID || got.SessionID != "conv" || got.EventName != "stop" {
+		t.Fatalf("normalized hook = %#v", got)
+	}
+	if got.TurnID != "gen" || got.Model != "cursor-model" {
+		t.Fatalf("metadata not preserved: %#v", got)
+	}
+}
+
+func TestCursorNormalizeHookSessionAndFiles(t *testing.T) {
+	raw := []byte(`{
+		"session_id": "sess",
+		"conversation_id": "conv",
+		"hook_event_name": "afterFileEdit",
+		"file_path": "/tmp/a.go",
+		"tool_input": {
+			"target_path": "/tmp/b.go",
+			"metadata": {"source_path": "/tmp/c.go"},
+			"paths": ["/tmp/d.go"]
+		}
+	}`)
+	got, ok := Cursor{}.NormalizeHook(raw)
+	if !ok {
+		t.Fatal("NormalizeHook returned false")
+	}
+	if got.SessionID != "sess" {
+		t.Fatalf("SessionID = %q, want sess", got.SessionID)
+	}
+	if strings.Join(got.FilesTouched, ",") != "/tmp/a.go,/tmp/b.go,/tmp/c.go,/tmp/d.go" {
+		t.Fatalf("FilesTouched = %#v", got.FilesTouched)
+	}
+}
+
+func TestCursorNormalizeHookRejectsMissingID(t *testing.T) {
+	if _, ok := (Cursor{}).NormalizeHook([]byte(`{"hook_event_name":"stop"}`)); ok {
+		t.Fatal("NormalizeHook should reject missing session/conversation id")
+	}
+	if _, ok := (Cursor{}).NormalizeHook([]byte(`not json`)); ok {
+		t.Fatal("NormalizeHook should reject invalid JSON")
 	}
 }
 

--- a/internal/agent/harness/registry.go
+++ b/internal/agent/harness/registry.go
@@ -12,6 +12,7 @@ import (
 const (
 	ClaudeID = "claude"
 	CodexID  = "codex"
+	CursorID = "cursor"
 )
 
 type Capabilities struct {

--- a/internal/agent/hook_handler.go
+++ b/internal/agent/hook_handler.go
@@ -58,7 +58,7 @@ func HandleHook(r io.Reader, harnessIDs ...string) error {
 	destDir := SessionDir(repo, wt, h.ID())
 	destFile := SessionPath(repo, wt, h.ID(), in.SessionID)
 
-	if in.EventName == "SessionEnd" {
+	if in.EventName == "SessionEnd" || in.EventName == "sessionEnd" {
 		_ = removeSessionArtifacts(repo, wt, h.ID(), in.SessionID)
 		return nil
 	}
@@ -76,7 +76,7 @@ func HandleHook(r io.Reader, harnessIDs ...string) error {
 	prev := readSession(destFile)
 
 	toolCount := prev.ToolCount
-	if in.EventName == "PreToolUse" {
+	if in.EventName == "PreToolUse" || in.EventName == "preToolUse" {
 		toolCount++
 	}
 
@@ -86,7 +86,7 @@ func HandleHook(r io.Reader, harnessIDs ...string) error {
 	}
 
 	toolField := ""
-	if in.EventName == "PreToolUse" || in.EventName == "PermissionRequest" {
+	if in.EventName == "PreToolUse" || in.EventName == "preToolUse" || in.EventName == "PermissionRequest" {
 		toolField = in.ToolName
 	}
 
@@ -128,6 +128,13 @@ func computeStatus(harnessID string, in harness.NormalizedHook, destFile string)
 		case "PermissionRequest":
 			return StatusWait, false
 		case "Stop":
+			return StatusDone, false
+		}
+		return StatusBusy, false
+	}
+
+	if harnessID == harness.CursorID {
+		if in.EventName == "stop" {
 			return StatusDone, false
 		}
 		return StatusBusy, false

--- a/internal/agent/hook_handler_test.go
+++ b/internal/agent/hook_handler_test.go
@@ -128,6 +128,96 @@ func TestHandleHook_StopSetsDone(t *testing.T) {
 	}
 }
 
+func TestHandleHook_CursorWorkEventSetsBusy(t *testing.T) {
+	repo, wt := setupWorktreeHome(t)
+
+	raw := []byte(`{
+		"session_id": "cursor-s1",
+		"hook_event_name": "preToolUse",
+		"tool_name": "Shell"
+	}`)
+	if err := HandleHook(bytes.NewReader(raw), "cursor"); err != nil {
+		t.Fatalf("HandleHook: %v", err)
+	}
+
+	got := readSession(SessionPath(repo, wt, "cursor", "cursor-s1"))
+	if got.Status != StatusBusy {
+		t.Errorf("status = %q, want %q", got.Status, StatusBusy)
+	}
+	if got.ToolCount != 1 {
+		t.Errorf("tool_count = %d, want 1", got.ToolCount)
+	}
+	if got.Tool != "Shell" {
+		t.Errorf("tool = %q, want Shell", got.Tool)
+	}
+}
+
+func TestHandleHook_CursorStopSetsDone(t *testing.T) {
+	repo, wt := setupWorktreeHome(t)
+
+	raw := []byte(`{
+		"conversation_id": "cursor-conv",
+		"generation_id": "gen-1",
+		"hook_event_name": "stop",
+		"model": "gpt-5"
+	}`)
+	if err := HandleHook(bytes.NewReader(raw), "cursor"); err != nil {
+		t.Fatalf("HandleHook: %v", err)
+	}
+
+	got := readSession(SessionPath(repo, wt, "cursor", "cursor-conv"))
+	if got.Status != StatusDone {
+		t.Errorf("status = %q, want %q", got.Status, StatusDone)
+	}
+	if got.TurnID != "gen-1" || got.Model != "gpt-5" {
+		t.Errorf("metadata = %#v, want turn/model preserved", got)
+	}
+}
+
+func TestHandleHook_CursorSessionEndRemovesFiles(t *testing.T) {
+	repo, wt := setupWorktreeHome(t)
+	dir := SessionDir(repo, wt, "cursor")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "s1.json"), []byte("{}"), 0o644)
+	os.WriteFile(filepath.Join(dir, "s1.files"), []byte("/x"), 0o644)
+	os.WriteFile(filepath.Join(dir, "s1.timeline"), []byte("{}"), 0o644)
+
+	raw := []byte(`{
+		"session_id": "s1",
+		"hook_event_name": "sessionEnd"
+	}`)
+	if err := HandleHook(bytes.NewReader(raw), "cursor"); err != nil {
+		t.Fatalf("HandleHook: %v", err)
+	}
+
+	for _, ext := range []string{".json", ".files", ".timeline"} {
+		if _, err := os.Stat(filepath.Join(dir, "s1"+ext)); !os.IsNotExist(err) {
+			t.Errorf("%s should be removed", ext)
+		}
+	}
+}
+
+func TestHandleHook_CursorTracksEditedFiles(t *testing.T) {
+	repo, wt := setupWorktreeHome(t)
+
+	raw := []byte(`{
+		"session_id": "s1",
+		"hook_event_name": "afterFileEdit",
+		"file_path": "/tmp/a.go"
+	}`)
+	if err := HandleHook(bytes.NewReader(raw), "cursor"); err != nil {
+		t.Fatalf("HandleHook: %v", err)
+	}
+
+	data, err := os.ReadFile(FilesPathForHarness(repo, wt, "cursor", "s1"))
+	if err != nil {
+		t.Fatalf("read files list: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "/tmp/a.go" {
+		t.Fatalf("files list = %q, want edited path", data)
+	}
+}
+
 func TestHandleHook_SessionEndRemovesFiles(t *testing.T) {
 	repo, wt := setupWorktreeHome(t)
 	dir := SessionDir(repo, wt, "claude")

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -159,6 +159,7 @@ func NewApp() *cli.Command {
 			agentCmd(),
 			setupCmd(),
 			codexSetupCmd(),
+			cursorSetupCmd(),
 			hookCmd(),
 			shellInitCmd(),
 			gcCmd(),

--- a/internal/cli/dispatch.go
+++ b/internal/cli/dispatch.go
@@ -52,7 +52,7 @@ func dispatchCmd() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:  "agent",
-				Usage: "Agent harness to launch (claude or codex; default from agent.default)",
+				Usage: "Agent harness to launch (claude, codex, or cursor; default from agent.default)",
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {

--- a/internal/cli/dispatch_test.go
+++ b/internal/cli/dispatch_test.go
@@ -166,6 +166,35 @@ func TestDispatchCmdAgentOverrideWinsOverConfigDefault(t *testing.T) {
 	}
 }
 
+func TestDispatchCmdRunsCursorWithYolo(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	helperLog := filepath.Join(t.TempDir(), "willow-helper.log")
+	t.Setenv("WILLOW_TEST_HELPER_PROCESS", "willow")
+	t.Setenv("WILLOW_TEST_HELPER_WT_ROOT", filepath.Join(home, ".willow", "worktrees"))
+	t.Setenv("WILLOW_TEST_HELPER_LOG", helperLog)
+
+	binDir := t.TempDir()
+	cursorLog := filepath.Join(t.TempDir(), "cursor.log")
+	writeTestExecutable(t, binDir, "cursor-agent", "#!/bin/sh\n"+
+		"printf 'cwd=%s\\n' \"$PWD\" >> "+shellQuote(cursorLog)+"\n"+
+		"printf 'args=%s\\n' \"$*\" >> "+shellQuote(cursorLog)+"\n")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := runApp("dispatch", "Fix auth", "--repo", "repo", "--name", "dispatch-cursor", "--agent", "cursor", "--yolo"); err != nil {
+		t.Fatalf("dispatch command failed: %v", err)
+	}
+
+	cursorText := readTestFile(t, cursorLog)
+	for _, want := range []string{
+		filepath.Join(home, ".willow", "worktrees", "repo", "dispatch-cursor"),
+		"args=--force Fix auth",
+	} {
+		if !strings.Contains(cursorText, want) {
+			t.Fatalf("cursor log missing %q:\n%s", want, cursorText)
+		}
+	}
+}
+
 func TestDispatchForegroundRunsClaudeInWorktree(t *testing.T) {
 	binDir := t.TempDir()
 	logPath := filepath.Join(t.TempDir(), "agent.log")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -136,7 +136,7 @@ type agentHooksUI interface {
 func checkAgentHarnesses(u agentHooksUI, fix bool) {
 	cfg := config.Load("")
 	defaultID := harness.DefaultID(cfg)
-	for _, id := range []string{harness.ClaudeID, harness.CodexID} {
+	for _, id := range harness.IDs() {
 		h, err := harness.MustGet(id)
 		if err != nil {
 			continue
@@ -145,14 +145,11 @@ func checkAgentHarnesses(u agentHooksUI, fix bool) {
 		if override := harness.OverridesFor(cfg, id); override.Command != "" {
 			commandName = override.Command
 		}
-		label := h.DisplayName()
-		if id == defaultID {
-			label += " (default)"
-		}
+		label := agentBinaryLabel(h.DisplayName(), id == defaultID)
 		if _, err := exec.LookPath(commandName); err != nil {
-			u.Warn(fmt.Sprintf("%s CLI not found (run: %s after installing)", label, h.SetupCommandLabel()))
+			u.Warn(fmt.Sprintf("%s not found (run: %s after installing)", label, h.SetupCommandLabel()))
 		} else {
-			u.Success(fmt.Sprintf("%s CLI installed", label))
+			u.Success(fmt.Sprintf("%s installed", label))
 		}
 
 		if !agent.IsHarnessInstalled(id) {
@@ -214,6 +211,17 @@ func checkWillowDirs(u interface {
 		}
 		u.Success(fmt.Sprintf("%s exists", d.path))
 	}
+}
+
+func agentBinaryLabel(displayName string, isDefault bool) string {
+	label := displayName
+	if isDefault {
+		label += " (default)"
+	}
+	if strings.HasSuffix(strings.ToLower(strings.TrimSpace(displayName)), "cli") {
+		return label
+	}
+	return label + " CLI"
 }
 
 func checkStaleSessions(u interface {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -258,6 +258,30 @@ func TestCheckAgentHarnesses(t *testing.T) {
 	}
 }
 
+func TestCheckAgentHarnessesIncludesCursor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	binDir := t.TempDir()
+	writeTestExecutable(t, binDir, "claude", "#!/bin/sh\nexit 0\n")
+	writeTestExecutable(t, binDir, "codex", "#!/bin/sh\nexit 0\n")
+	writeTestExecutable(t, binDir, "cursor-agent", "#!/bin/sh\nexit 0\n")
+	t.Setenv("PATH", binDir)
+
+	for _, id := range []string{harness.ClaudeID, harness.CodexID, harness.CursorID} {
+		if _, err := agent.InstallHarness(id); err != nil {
+			t.Fatalf("install %s hooks: %v", id, err)
+		}
+	}
+
+	u := &fakeDoctorUI{}
+	checkAgentHarnesses(u, false)
+	for _, want := range []string{"Claude Code (default) CLI installed", "Codex CLI installed", "Cursor Agent CLI installed", "Cursor Agent hooks installed"} {
+		if !u.hasSuccess(want) {
+			t.Fatalf("successes = %v, want %q", u.successes, want)
+		}
+	}
+}
+
 func TestCheckWillowDirs(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -34,6 +34,17 @@ func codexSetupCmd() *cli.Command {
 	}
 }
 
+func cursorSetupCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "cursor-setup",
+		Usage: "Install Cursor Agent hooks for status tracking",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			defer trace.Span(ctx, "cli.cursor-setup")()
+			return runAgentSetup(cmd, []string{harness.CursorID})
+		},
+	}
+}
+
 func agentCmd() *cli.Command {
 	return &cli.Command{
 		Name:  "agent",
@@ -41,11 +52,11 @@ func agentCmd() *cli.Command {
 		Commands: []*cli.Command{
 			{
 				Name:  "setup",
-				Usage: "Install agent hooks for claude, codex, or all",
+				Usage: "Install agent hooks for claude, codex, cursor, or all",
 				Arguments: []cli.Argument{
 					&cli.StringArg{
 						Name:      "harness",
-						UsageText: "[claude|codex|all]",
+						UsageText: "[claude|codex|cursor|all]",
 					},
 				},
 				Action: func(ctx context.Context, cmd *cli.Command) error {
@@ -66,16 +77,14 @@ func agentCmd() *cli.Command {
 }
 
 func setupTargets(target string) ([]string, error) {
-	switch harness.NormalizeID(target) {
-	case "all":
-		return []string{harness.ClaudeID, harness.CodexID}, nil
-	case harness.ClaudeID:
-		return []string{harness.ClaudeID}, nil
-	case harness.CodexID:
-		return []string{harness.CodexID}, nil
-	default:
-		return nil, fmt.Errorf("unknown agent harness %q (expected claude, codex, or all)", target)
+	normalized := harness.NormalizeID(target)
+	if normalized == "all" {
+		return harness.IDs(), nil
 	}
+	if _, ok := harness.Get(normalized); ok {
+		return []string{normalized}, nil
+	}
+	return nil, fmt.Errorf("unknown agent harness %q (expected %s, or all)", target, strings.Join(harness.IDs(), ", "))
 }
 
 func runAgentSetup(cmd *cli.Command, ids []string) error {

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,6 +61,82 @@ func TestCodexSetupCmdInstallsHooksWithExistingTelemetryPreference(t *testing.T)
 	}
 }
 
+func TestCursorSetupCmdInstallsHooksWithExistingTelemetryPreference(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeGlobalConfigFile(t, `{"telemetry":false}`)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("cursor-setup")
+	})
+	if err != nil {
+		t.Fatalf("cursor-setup failed: %v", err)
+	}
+
+	for _, want := range []string{"Installed Cursor Agent hooks", "hook:", "status:", "~/.cursor/hooks.json"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("cursor-setup output missing %q:\n%s", want, out)
+		}
+	}
+	path := filepath.Join(home, ".cursor", "hooks.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("hooks.json not written: %v", err)
+	}
+	settings := readSetupJSON(t, path)
+	if settings["version"] != float64(1) {
+		t.Fatalf("version = %#v, want 1", settings["version"])
+	}
+	hooks := settings["hooks"].(map[string]any)
+	if _, ok := hooks["sessionStart"]; !ok {
+		t.Fatalf("sessionStart hook missing: %#v", hooks)
+	}
+}
+
+func TestAgentSetupAllIncludesCursor(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeGlobalConfigFile(t, `{"telemetry":false}`)
+
+	out, err := captureStdout(t, func() error {
+		return runApp("agent", "setup", "all")
+	})
+	if err != nil {
+		t.Fatalf("agent setup all failed: %v", err)
+	}
+	for _, want := range []string{"Claude Code hooks", "Codex CLI hooks", "Cursor Agent hooks"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("agent setup all output missing %q:\n%s", want, out)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(home, ".claude", "settings.json"),
+		filepath.Join(home, ".codex", "hooks.json"),
+		filepath.Join(home, ".cursor", "hooks.json"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("%s not written: %v", path, err)
+		}
+	}
+}
+
+func TestSetupTargetsAcceptCursor(t *testing.T) {
+	ids, err := setupTargets("cursor")
+	if err != nil {
+		t.Fatalf("setupTargets(cursor): %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "cursor" {
+		t.Fatalf("ids = %v, want [cursor]", ids)
+	}
+
+	ids, err = setupTargets("all")
+	if err != nil {
+		t.Fatalf("setupTargets(all): %v", err)
+	}
+	if !containsString(ids, "cursor") {
+		t.Fatalf("ids = %v, want cursor included", ids)
+	}
+}
+
 func TestSetupCmdPromptsForTelemetryWhenUnset(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -98,4 +175,17 @@ func TestSetupCmdPromptsForTelemetryWhenUnset(t *testing.T) {
 	if cfg.Telemetry == nil || !*cfg.Telemetry {
 		t.Fatalf("telemetry preference = %v, want true", cfg.Telemetry)
 	}
+}
+
+func readSetupJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return out
 }

--- a/internal/cli/tmux_test.go
+++ b/internal/cli/tmux_test.go
@@ -914,6 +914,32 @@ func TestTmuxPickDispatchForRepoStartsCodex(t *testing.T) {
 	}
 }
 
+func TestTmuxPickDispatchForRepoStartsCursor(t *testing.T) {
+	home := setupTmuxCommandHome(t, "repo")
+	tmuxLog := installFakeTmuxForCLI(t)
+	self, willowLog := installFakeWillowForTmux(t, filepath.Join(home, ".willow", "worktrees"))
+	t.Setenv("TMUX", "/tmp/tmux.sock")
+
+	cfg := config.DefaultConfig()
+	if err := tmuxPickDispatchForRepo(self, "Fix via cursor", "repo", "cursor", cfg); err != nil {
+		t.Fatalf("tmuxPickDispatchForRepo: %v", err)
+	}
+
+	willowText := readTestFile(t, willowLog)
+	if !strings.Contains(willowText, "new --cd --repo repo -- dispatch--fix-via-cursor") {
+		t.Fatalf("willow log missing dispatch new:\n%s", willowText)
+	}
+	tmuxText := readTestFile(t, tmuxLog)
+	for _, want := range []string{
+		"send-keys -t repo/dispatch--fix-via-cursor",
+		"'cursor-agent' \"$(cat",
+	} {
+		if !strings.Contains(tmuxText, want) {
+			t.Fatalf("tmux log missing %q:\n%s", want, tmuxText)
+		}
+	}
+}
+
 func TestTmuxPickDeleteKillsSessionAndRunsWillowRm(t *testing.T) {
 	setupTmuxCommandHome(t, "repo")
 	tmuxLog := installFakeTmuxForCLI(t)

--- a/website/src/app/(docs)/commands/page.mdx
+++ b/website/src/app/(docs)/commands/page.mdx
@@ -341,10 +341,11 @@ Requires the [GitHub CLI](https://cli.github.com/) (`gh`).
 Show agent status per worktree/session. Multiple sessions in the same worktree render child rows with labels like `[claude] a044b2af`.
 
 ```
-myrepo (4 worktrees, 3 sessions active, 1 unread)
+myrepo (4 worktrees, 4 sessions active, 1 unread)
 
   🤖 auth-refactor [claude:4f2c9a1b]  BUSY    2m ago
   🤖 auth-refactor [codex:9b7d2e44]   BUSY    5m ago
+  🤖 auth-refactor [cursor:8c1f5a20]  BUSY    6m ago
   ✅ payments      [claude:3ac18f02]  DONE●   12m ago
   🟡 main                     IDLE    1h ago
      old-feature              --
@@ -429,7 +430,7 @@ Without `--prune`, willow only empties the trash directory and prints the comman
 
 ### Desktop notifications
 
-Desktop notifications fire directly from agent hook systems after you run `ww cc-setup`, `ww codex-setup`, or `ww agent setup all` — there's no daemon, no polling, and no `ww notify` subcommand. Whenever an agent transitions from `BUSY` to `DONE` or `WAIT`, the hook fires a macOS Notification Center alert within ~200ms.
+Desktop notifications fire directly from agent hook systems after you run `ww cc-setup`, `ww codex-setup`, `ww cursor-setup`, or `ww agent setup all` — there's no daemon, no polling, and no `ww notify` subcommand. Whenever an agent transitions from `BUSY` to `DONE` or `WAIT`, the hook fires a macOS Notification Center alert within ~200ms.
 
 **Desktop notifications:** Enabled by default. Set `"notify": {"desktop": false}` in config to disable them. The tmux status bar is a separate channel and is unaffected.
 
@@ -447,6 +448,7 @@ ww dispatch "Add retry logic" --name add-retries             # explicit branch n
 ww dispatch "Write tests for auth" --base feature/auth       # stacked on a branch
 ww dispatch "Refactor payments" --repo myrepo                # target specific repo
 ww dispatch "Fix auth" --agent codex                         # one-off Codex dispatch
+ww dispatch "Fix auth" --agent cursor                        # one-off Cursor dispatch
 ```
 
 | Flag | Description | Default |
@@ -455,15 +457,19 @@ ww dispatch "Fix auth" --agent codex                         # one-off Codex dis
 | `-r, --repo` | Target repo by name | Auto-detected from cwd |
 | `-b, --base` | Base branch to fork from | Config default |
 | `--no-fetch` | Skip fetching from remote | `false` |
-| `--agent` | Override `agent.default` (`claude` or `codex`) | Config default |
+| `--agent` | Override `agent.default` (`claude`, `codex`, or `cursor`) | Config default |
 | `--yolo` | Run with the harness's full-access flag | `false` |
+
+`--yolo` maps to the selected harness: Claude uses `--dangerously-skip-permissions`, Codex uses `--dangerously-bypass-approvals-and-sandbox`, and Cursor uses `--force`.
 
 **How it works:**
 1. Creates a new worktree (reuses `ww new` internally)
-2. Launches the selected harness (`claude "<prompt>"` or `codex "<prompt>"`)
+2. Launches the selected harness (`claude "<prompt>"`, `codex "<prompt>"`, or `cursor-agent "<prompt>"`)
 3. Logs a `dispatch` event (visible in `ww log`)
 
 The agent appears in `ww status`, `ww dashboard`, and the tmux picker. Switch to it anytime with `ww sw`.
+
+Willow owns worktree creation for dispatches. Cursor's own `--worktree` path is not used because Willow has already created and selected the isolated worktree before launching `cursor-agent`.
 
 ### `ww cc-setup`
 
@@ -480,9 +486,15 @@ Hook installation for Codex CLI status tracking. Safe to re-run: each invocation
 
 The hook tracks `UserPromptSubmit`, `PreToolUse`, `PermissionRequest`, `PostToolUse`, and `Stop`, writing status to `<willow-base>/status/<repo>/<worktree>/codex/<session_id>.json`.
 
+### `ww cursor-setup`
+
+Hook installation for Cursor Agent status tracking. Safe to re-run: each invocation overwrites Willow's entries in `~/.cursor/hooks.json` with the current binary path and leaves unrelated hook rules untouched. Willow uses direct Cursor hook entries and omits fail-closed behavior so hooks fail open.
+
+The hook tracks `sessionStart`, `beforeSubmitPrompt`, `preToolUse`, `postToolUse`, `postToolUseFailure`, `beforeShellExecution`, `afterShellExecution`, `afterFileEdit`, `stop`, and `sessionEnd`, writing status to `<willow-base>/status/<repo>/<worktree>/cursor/<session_id>.json`. Cursor currently reports `BUSY`, `DONE`, and cleanup events, but not `WAIT`.
+
 ### `ww agent setup`
 
-Install hooks for one harness or both. With no argument, this installs all built-in harnesses.
+Install hooks for `claude`, `codex`, `cursor`, or all built-in harnesses. With no argument, this installs all built-in harnesses.
 
 The hook also tracks enriched session data:
 - **`tool_count`** — number of tool invocations in the session
@@ -491,7 +503,7 @@ The hook also tracks enriched session data:
 
 ### Agent status
 
-After running `ww cc-setup`, `ww codex-setup`, or `ww agent setup all`, supported agents automatically report their state:
+After running `ww cc-setup`, `ww codex-setup`, `ww cursor-setup`, or `ww agent setup all`, supported agents automatically report their state:
 
 | Icon | Status | Meaning |
 |------|--------|---------|
@@ -501,7 +513,7 @@ After running `ww cc-setup`, `ww codex-setup`, or `ww agent setup all`, supporte
 | 🟡 | `IDLE` | Agent session ended |
 | | `--` | No activity detected |
 
-Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`. The tmux picker labels active parent rows with one session (`[claude]` or `[codex]`) so single-session worktrees are easy to distinguish; multi-session rows rely on the labeled child rows.
+Stale `BUSY`/`WAIT` status (>2 min) automatically degrades to `IDLE`. Completed sessions stay `DONE` until the session ends. Completed sessions show a `●` unread indicator until you switch to that worktree via `ww sw`. The tmux picker labels active parent rows with one session (`[claude]`, `[codex]`, or `[cursor]`) so single-session worktrees are easy to distinguish; multi-session rows rely on the labeled child rows.
 
 ## Configuration
 
@@ -580,6 +592,8 @@ ww doctor --fix    # prompt to remove unmarked legacy willow hooks from settings
 ✔ Claude Code hooks installed
 ✔ Codex CLI installed
 ✔ Codex CLI hooks installed
+✔ Cursor Agent CLI installed
+✔ Cursor Agent hooks installed
 ✔ <willow-base> exists
 ✔ <willow-base>/repos exists
 ✔ <willow-base>/worktrees exists
@@ -592,7 +606,7 @@ ww doctor --fix    # prompt to remove unmarked legacy willow hooks from settings
 | git version | Warns if &lt; 2.30 |
 | gh CLI | Optional — warns if missing |
 | tmux | Optional — warns if missing |
-| Agent CLIs and hooks | Checks Claude Code and Codex CLI binaries plus Willow hook installation |
+| Agent CLIs and hooks | Checks Claude Code, Codex CLI, and Cursor Agent binaries plus Willow hook installation |
 | Claude legacy hooks | Flags unmarked entries from older Willow releases in `~/.claude/settings.json` |
 | Willow directories | `<willow-base>`, `repos/`, `worktrees/` |
 | Stale sessions | Session files older than 30 minutes |

--- a/website/src/app/(docs)/configuration/page.mdx
+++ b/website/src/app/(docs)/configuration/page.mdx
@@ -44,10 +44,10 @@ The local config lives inside the bare repo directory, so it's private to your m
     "command": ""
   },
   "agent": {
-    "default": "claude",
+    "default": "cursor",
     "harnesses": {
-      "codex": {
-        "command": "codex",
+      "cursor": {
+        "command": "cursor-agent",
         "args": []
       }
     }
@@ -78,9 +78,9 @@ The local config lives inside the bare repo directory, so it's private to your m
 | `teardown` | `string[]` | Commands to run before removing a worktree |
 | `defaults.fetch` | `boolean` | Whether to fetch before creating a worktree |
 | `defaults.autoSetupRemote` | `boolean` | Auto-configure remote tracking for new branches |
-| `notify.desktop` | `boolean` | Send desktop notifications from Claude Code hooks when an agent finishes or needs input (default: `true`) |
+| `notify.desktop` | `boolean` | Send desktop notifications from agent hooks when an agent finishes or needs input (default: `true`) |
 | `notify.command` | `string` | Custom command for non-tmux notifications. Receives `WILLOW_NOTIFY_TITLE` and `WILLOW_NOTIFY_BODY` |
-| `agent.default` | `string` | Default harness for `ww dispatch` and tmux `Ctrl-G` (`claude` or `codex`; default: `claude`) |
+| `agent.default` | `string` | Default harness for `ww dispatch` and tmux `Ctrl-G` (`claude`, `codex`, or `cursor`; default: `claude`) |
 | `agent.harnesses.<id>.command` | `string` | Override the executable used for a harness |
 | `agent.harnesses.<id>.args` | `string[]` | Extra args passed before the prompt when launching a harness |
 | `agent.harnesses.<id>.yoloArgs` | `string[]` | Override the args used by `--yolo` for that harness |
@@ -110,7 +110,9 @@ When telemetry is enabled, Willow only reports system errors and panics, along w
         └── auth-refactor/
             ├── claude/
             │   └── <session_id>.json
-            └── codex/
+            ├── codex/
+            │   └── <session_id>.json
+            └── cursor/
                 └── <session_id>.json
 ```
 
@@ -124,7 +126,7 @@ Each worktree is a fully isolated directory with its own working copy. Grouped b
 
 ### `<willow-base>/status/`
 
-Created by `ww cc-setup`, `ww codex-setup`, or `ww agent setup`. Contains JSON files with agent status for each worktree and harness.
+Created by `ww cc-setup`, `ww codex-setup`, `ww cursor-setup`, or `ww agent setup`. Contains JSON files with agent status for each worktree and harness.
 
 ```jsonc
 // <willow-base>/status/myrepo/auth-refactor/codex/<session_id>.json
@@ -141,6 +143,8 @@ Created by `ww cc-setup`, `ww codex-setup`, or `ww agent setup`. Contains JSON f
 
 ### Agent hooks
 
-`ww cc-setup` registers the hidden `willow hook --harness claude` subcommand in `~/.claude/settings.json`. `ww codex-setup` registers `willow hook --harness codex` in `~/.codex/hooks.json`. When an agent fires a hook event, it invokes the willow binary directly — there is no intermediate shell script or background daemon.
+`ww cc-setup` registers the hidden `willow hook --harness claude` subcommand in `~/.claude/settings.json`. `ww codex-setup` registers `willow hook --harness codex` in `~/.codex/hooks.json`. `ww cursor-setup` registers `willow hook --harness cursor` in `~/.cursor/hooks.json`. When an agent fires a hook event, it invokes the willow binary directly — there is no intermediate shell script or background daemon.
 
 Codex treats user-level command hooks as reviewable hooks. If Codex warns about hooks that need review, open `/hooks` inside the Codex CLI and trust the Willow hook.
+
+Cursor hooks are installed as direct hook entries with a short timeout and fail open. Willow preserves unrelated Cursor hook rules and replaces only earlier Willow Cursor entries.

--- a/website/src/app/(docs)/guide/page.mdx
+++ b/website/src/app/(docs)/guide/page.mdx
@@ -111,10 +111,11 @@ python3 skills/willow-autoresearch/scripts/bench_willow.py --reference-repo ~/co
 ```bash
 ww cc-setup                 # Claude Code hooks
 ww codex-setup              # Codex CLI hooks
-ww agent setup all          # both
+ww cursor-setup             # Cursor Agent hooks
+ww agent setup all          # all built-in harnesses
 ```
 
-Installs hooks that write per-session agent status (`BUSY` / `DONE` / `WAIT` / `IDLE`) to `<willow-base>/status/<repo>/<worktree>/<harness>/`. Claude hooks live in `~/.claude/settings.json`; Codex hooks live in `~/.codex/hooks.json` and may need review in Codex with `/hooks`. Multiple harnesses can run in the same worktree at the same time. This powers the status column in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`.
+Installs hooks that write per-session agent status (`BUSY` / `DONE` / `WAIT` / `IDLE`) to `<willow-base>/status/<repo>/<worktree>/<harness>/`. Claude hooks live in `~/.claude/settings.json`; Codex hooks live in `~/.codex/hooks.json` and may need review in Codex with `/hooks`; Cursor hooks live in `~/.cursor/hooks.json`. Cursor currently reports `BUSY`, `DONE`, and cleanup events, but not `WAIT`. Multiple harnesses can run in the same worktree at the same time. This powers the status column in `ww ls`, `ww sw`, `ww status`, and `ww dashboard`.
 
 ## Quick start
 
@@ -125,9 +126,10 @@ ww clone git@github.com:org/myrepo.git
 # Create a worktree and cd into it
 wwn auth-refactor
 
-# Start Claude Code or Codex
+# Start Claude Code, Codex, or Cursor Agent
 claude
 # or: codex
+# or: cursor-agent
 
 # In another terminal — create a second worktree
 wwn payments-fix
@@ -164,7 +166,7 @@ Recommended Ghostty layout per worktree:
 ┌─────────────────────────────────────┐
 │ Tab: myrepo/auth-refactor           │
 ├──────────────────┬──────────────────┤
-│  claude          │  codex           │
+│  claude/codex    │  cursor-agent    │
 │  (agent 1)       │  (agent 2)       │
 ├──────────────────┴──────────────────┤
 │  shell (git diff, tests, etc.)      │

--- a/website/src/app/(docs)/tmux/page.mdx
+++ b/website/src/app/(docs)/tmux/page.mdx
@@ -30,7 +30,7 @@ bind w run-shell -b 'tmux display-popup -E -w 70% -h 70% "/path/to/willow tmux p
 
 Press `prefix + w` to open the worktree picker in a popup.
 
-The right panel shows a live preview of the tmux pane content (for example Claude Code or Codex CLI output).
+The right panel shows a live preview of the tmux pane content (for example Claude Code, Codex CLI, or Cursor Agent output).
 Set `"tmux": {"switcherPreview": false}` in config to hide that panel, use the full popup for the fzf picker, and make `ww tmux install` emit the smaller popup binding.
 
 ### Keybindings
@@ -53,9 +53,9 @@ Set `"tmux": {"switcherPreview": false}` in config to hide that panel, use the f
 
 ### Dispatch
 
-Type a prompt in the query field and press `Ctrl-G` to dispatch the configured default agent harness. This creates a worktree (branch auto-named from the prompt, e.g. `dispatch--fix-the-login-bug`), opens a tmux session, and launches `claude` or `codex` with your prompt. You're switched to the session immediately.
+Type a prompt in the query field and press `Ctrl-G` to dispatch the configured default agent harness. This creates a worktree (branch auto-named from the prompt, e.g. `dispatch--fix-the-login-bug`), opens a tmux session, and launches `claude`, `codex`, or `cursor-agent` with your prompt. You're switched to the session immediately.
 
-Press `Ctrl-O` instead when you want to pick `claude` or `codex` for just this dispatch without changing `agent.default`.
+Press `Ctrl-O` instead when you want to pick `claude`, `codex`, or `cursor` for just this dispatch without changing `agent.default`.
 
 ### PR picker
 
@@ -90,7 +90,7 @@ Worktrees whose exact current-head PR is merged show a dim `[merged]` tag, and w
 - **Urgency sort** — current session first, then `WAIT`, unread `DONE`, `BUSY`, read `DONE`, `IDLE`, then offline
 - **Status colors** — BUSY (green), WAIT (red), DONE (blue), IDLE (yellow)
 - **Unread indicator** — `●` marks completed sessions you haven't viewed
-- **Harness labels** — active single-session parent rows show `[claude]` or `[codex]`; multi-session rows use child labels like `[claude] a044b2af`
+- **Harness labels** — active single-session parent rows show `[claude]`, `[codex]`, or `[cursor]`; multi-session rows use child labels like `[claude] a044b2af`
 - **Merged indicator** — `[merged]` marks worktrees whose exact current-head PR is merged when `gh` data is available
 - **Stack-aware ordering** — stacked branches stay grouped together and inherit the most urgent item in the tree
 - **Multi-agent sub-rows** — when a worktree has multiple active sessions, each is shown as an indented sub-row with its harness label, status, and tool info


### PR DESCRIPTION
## Description of the change
Adds Cursor Agent as Willow’s third built-in agent harness, including hook installation, hook normalization, status tracking, dispatch support, tmux picker dispatch, doctor checks, docs, and tests. Cursor hooks are installed into ~/.cursor/hooks.json while preserving unrelated user hooks.

**Ticket:**

## Test plan
Go unit/integration tests and website production build. Also upgraded and verified the local cursor-agent CLI.

## Loom or screenshots

## Considerations
Cursor currently reports BUSY, DONE, and cleanup events, but not WAIT because the CLI does not expose a documented permission-wait hook equivalent.