### PR TITLE
:sparkles: feat[notify]: focus the agent's session when a notification is clicked

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,8 @@ Desktop notifications fire directly from agent hook systems — no daemon, no po
 
 Desktop notifications are enabled by default. Set `"notify": {"desktop": false}` to disable them, or set `"notify": {"command": "..."}` to run a custom shell command instead (it receives `WILLOW_NOTIFY_TITLE` and `WILLOW_NOTIFY_BODY` env vars). The tmux status bar widget uses a separate sound-only channel and is unaffected.
 
+Clicking a notification jumps to the agent that triggered it: it switches the tmux session (or selects the matching terminal tab) and brings your terminal forward. This needs [`terminal-notifier`](https://github.com/julienXX/terminal-notifier) (`brew install terminal-notifier`); macOS `osascript` notifications can't carry a click action. Without it, notifications still fire but clicking does nothing useful. Run `ww doctor` to check. Tab selection works in iTerm2 and Terminal.app; other terminals get app-focus plus the tmux switch.
+
 ### `ww dispatch <prompt> [flags]`
 
 Create a worktree and launch the configured agent harness with a prompt. From the terminal, the agent runs interactively in the foreground. From the tmux picker, `Ctrl-G` launches the configured default in a background session and `Ctrl-O` lets you pick a one-off harness.

--- a/internal/agent/hook_handler.go
+++ b/internal/agent/hook_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/iamrajjoshi/willow/internal/agent/harness"
 	"github.com/iamrajjoshi/willow/internal/config"
+	"github.com/iamrajjoshi/willow/internal/focus"
 	"github.com/iamrajjoshi/willow/internal/notify"
 	"github.com/iamrajjoshi/willow/internal/telemetry"
 )
@@ -115,6 +116,28 @@ func HandleHook(r io.Reader, harnessIDs ...string) error {
 
 	fireNotifications(repo, wt)
 	return nil
+}
+
+// clickForKey builds the notification click action for a worktree transition.
+// The target is captured from the live hook environment ($TMUX,
+// __CFBundleIdentifier) because the click handler runs later, detached, with no
+// inherited environment. Returns nil when willow can't locate its own binary,
+// in which case the notification still fires without a click action.
+func clickForKey(key string) *notify.Click {
+	willowPath, err := os.Executable()
+	if err != nil {
+		return nil
+	}
+	target := focus.Target{
+		Session:    key,
+		TmuxSocket: focus.SocketFromEnv(os.Getenv("TMUX")),
+		TermBundle: os.Getenv("__CFBundleIdentifier"),
+	}
+	return &notify.Click{
+		Execute: focus.ExecuteCommand(willowPath, target),
+		Sender:  target.TermBundle,
+		Group:   "willow-" + key,
+	}
 }
 
 // computeStatus returns the new status for this event plus a skip flag.
@@ -355,7 +378,7 @@ func fireNotifications(repo, wt string) {
 		case cfg.Notify.Command != "":
 			err = notify.SendCustom(cfg.Notify.Command, "willow", body)
 		case cfg.Notify.Desktop == nil || *cfg.Notify.Desktop:
-			err = notify.Send("willow", body)
+			err = notify.SendWithClick("willow", body, clickForKey(tr.Key))
 		}
 		if err != nil {
 			telemetry.CaptureException(err)

--- a/internal/agent/hook_handler_test.go
+++ b/internal/agent/hook_handler_test.go
@@ -404,6 +404,40 @@ func TestWriteSessionConcurrentWriters(t *testing.T) {
 	}
 }
 
+func TestClickForKey_BuildsTmuxTarget(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/sock,123,0")
+	t.Setenv("__CFBundleIdentifier", "com.googlecode.iterm2")
+
+	click := clickForKey("myrepo/feat-x")
+	if click == nil {
+		t.Fatal("clickForKey returned nil")
+	}
+	if click.Sender != "com.googlecode.iterm2" {
+		t.Errorf("Sender = %q, want iterm2 bundle", click.Sender)
+	}
+	if click.Group != "willow-myrepo/feat-x" {
+		t.Errorf("Group = %q, want willow-myrepo/feat-x", click.Group)
+	}
+	for _, want := range []string{"focus", "--session 'myrepo/feat-x'", "--tmux-socket '/tmp/sock'"} {
+		if !strings.Contains(click.Execute, want) {
+			t.Errorf("Execute = %q, missing %q", click.Execute, want)
+		}
+	}
+}
+
+func TestClickForKey_NoTmuxOmitsSocket(t *testing.T) {
+	t.Setenv("TMUX", "")
+	t.Setenv("__CFBundleIdentifier", "com.apple.Terminal")
+
+	click := clickForKey("myrepo/feat-x")
+	if click == nil {
+		t.Fatal("clickForKey returned nil")
+	}
+	if strings.Contains(click.Execute, "--tmux-socket") {
+		t.Errorf("Execute should omit --tmux-socket outside tmux: %q", click.Execute)
+	}
+}
+
 func TestResolveWorktree_UsesConfiguredBaseDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -161,6 +161,7 @@ func NewApp() *cli.Command {
 			codexSetupCmd(),
 			cursorSetupCmd(),
 			hookCmd(),
+			focusCmd(),
 			shellInitCmd(),
 			gcCmd(),
 			migrateBaseCmd(),

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +35,7 @@ func doctorCmd() *cli.Command {
 			checkGitVersion(u)
 			checkBinary(u, "gh", "gh CLI", "https://cli.github.com")
 			checkBinary(u, "tmux", "tmux", "https://github.com/tmux/tmux")
+			checkClickableNotifications(u)
 			checkAgentHarnesses(u, cmd.Bool("fix"))
 			checkWillowDirs(u)
 			checkStaleSessions(u)
@@ -124,6 +126,20 @@ func checkBinary(u binaryChecker, name, label, installURL string) {
 		return
 	}
 	u.Success(fmt.Sprintf("%s installed", label))
+}
+
+// checkClickableNotifications reports whether terminal-notifier is available.
+// Without it, desktop notifications still fire via osascript but can't focus
+// the agent's session on click. macOS-only; silent elsewhere.
+func checkClickableNotifications(u binaryChecker) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	if _, err := exec.LookPath("terminal-notifier"); err != nil {
+		u.Warn("terminal-notifier not found; notification clicks won't focus the session (install: brew install terminal-notifier)")
+		return
+	}
+	u.Success("terminal-notifier installed (clickable notifications)")
 }
 
 type agentHooksUI interface {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -196,6 +197,32 @@ func TestCheckBinary(t *testing.T) {
 	if !u.hasWarning("tmux not found") {
 		t.Fatalf("warnings = %v, want tmux missing", u.warnings)
 	}
+}
+
+func TestCheckClickableNotifications(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("clickable-notification check is macOS-only")
+	}
+
+	t.Run("missing warns", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		u := &fakeDoctorUI{}
+		checkClickableNotifications(u)
+		if !u.hasWarning("terminal-notifier not found") {
+			t.Fatalf("warnings = %v, want terminal-notifier missing", u.warnings)
+		}
+	})
+
+	t.Run("present succeeds", func(t *testing.T) {
+		binDir := t.TempDir()
+		writeTestExecutable(t, binDir, "terminal-notifier", "#!/bin/sh\nexit 0\n")
+		t.Setenv("PATH", binDir)
+		u := &fakeDoctorUI{}
+		checkClickableNotifications(u)
+		if !u.hasSuccess("terminal-notifier installed") {
+			t.Fatalf("successes = %v, want terminal-notifier installed", u.successes)
+		}
+	})
 }
 
 func TestCheckAgentHarnesses(t *testing.T) {

--- a/internal/cli/focus_cmd.go
+++ b/internal/cli/focus_cmd.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/iamrajjoshi/willow/internal/focus"
+	"github.com/iamrajjoshi/willow/internal/trace"
+	"github.com/urfave/cli/v3"
+)
+
+// focusCmd is the hidden subcommand a clickable desktop notification invokes to
+// bring the triggering agent's terminal session to the foreground. It's wired
+// into the notification's click action by the hook, not run by users directly.
+func focusCmd() *cli.Command {
+	return &cli.Command{
+		Name:   "focus",
+		Usage:  "Bring an agent session to the foreground (internal, invoked by notification clicks)",
+		Hidden: true,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "session", Usage: "Session name (repo/worktree)", Required: true},
+			&cli.StringFlag{Name: "tmux-socket", Usage: "tmux socket path; empty if the session isn't in tmux"},
+			&cli.StringFlag{Name: "term-bundle", Usage: "Host terminal bundle id to activate"},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			defer trace.Span(ctx, "cli.focus")()
+			return focus.Focus(focus.Target{
+				Session:    cmd.String("session"),
+				TmuxSocket: cmd.String("tmux-socket"),
+				TermBundle: cmd.String("term-bundle"),
+			})
+		},
+	}
+}

--- a/internal/focus/focus.go
+++ b/internal/focus/focus.go
@@ -1,0 +1,176 @@
+// Package focus brings an agent's terminal session to the foreground when the
+// user clicks a willow desktop notification.
+//
+// It shells out to tmux and osascript directly rather than importing
+// internal/tmux: that package depends on internal/agent, and agent is what
+// builds the click target, so importing tmux here would form a cycle.
+package focus
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+const (
+	bundleITerm2   = "com.googlecode.iterm2"
+	bundleTerminal = "com.apple.Terminal"
+)
+
+// Indirected for tests. runCmd runs a command and discards output; runCmdOutput
+// runs one and returns stdout.
+var (
+	runCmd = func(name string, args ...string) error {
+		return exec.Command(name, args...).Run()
+	}
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		return exec.Command(name, args...).Output()
+	}
+)
+
+// Target describes where a notification click should navigate. Every field is
+// captured when the notification fires: the click handler runs later, detached,
+// with an empty environment, so nothing can be read from env at click time.
+//
+// Session is "repo/wtDir". That string is simultaneously the tmux session name
+// and the terminal tab title set by `shell-init --tab-title`, so it's all the
+// click needs to find either target.
+type Target struct {
+	Session    string
+	TmuxSocket string // tmux socket path; empty when the agent wasn't in tmux
+	TermBundle string // host terminal bundle id, from __CFBundleIdentifier
+}
+
+// Focus brings the agent's session to the foreground. In tmux it points the
+// attached clients at the session; otherwise it selects the matching terminal
+// tab. Either way it then activates the host terminal app. Steps are
+// best-effort: a failure in one doesn't abort the others.
+func Focus(t Target) error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("focus: unsupported platform %q", runtime.GOOS)
+	}
+	return focusTarget(t)
+}
+
+func focusTarget(t Target) error {
+	var firstErr error
+	if t.TmuxSocket != "" {
+		if err := focusTmuxSession(t.TmuxSocket, t.Session); err != nil {
+			firstErr = err
+		}
+	} else {
+		selectTab(t)
+	}
+
+	if err := activate(t.TermBundle); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+// focusTmuxSession points every attached client at the session. A bare
+// switch-client has no "current client" when run detached (as the click
+// handler is), so each client is switched by name.
+func focusTmuxSession(socket, session string) error {
+	if err := runCmd("tmux", "-S", socket, "has-session", "-t", session); err != nil {
+		return fmt.Errorf("focus: tmux session %q not found: %w", session, err)
+	}
+	out, err := runCmdOutput("tmux", "-S", socket, "list-clients", "-F", "#{client_name}")
+	if err != nil {
+		return fmt.Errorf("focus: list tmux clients: %w", err)
+	}
+	for _, client := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if client = strings.TrimSpace(client); client == "" {
+			continue
+		}
+		_ = runCmd("tmux", "-S", socket, "switch-client", "-c", client, "-t", session)
+	}
+	return nil
+}
+
+// activate brings the terminal app forward without opening a new window.
+func activate(bundle string) error {
+	if bundle == "" {
+		return nil
+	}
+	script := fmt.Sprintf("tell application id %q to activate", bundle)
+	return runCmd("osascript", "-e", script)
+}
+
+// selectTab tries to focus the terminal tab whose title matches the session
+// name ("repo/wtDir", set by `shell-init --tab-title`). Only iTerm2 and
+// Terminal.app expose tab control via AppleScript; on other terminals
+// activate() alone brings the app forward. Best-effort: errors are swallowed
+// because tab titles depend on the user's --tab-title setup.
+func selectTab(t Target) {
+	var script string
+	switch t.TermBundle {
+	case bundleITerm2:
+		script = iterm2SelectScript(t.Session)
+	case bundleTerminal:
+		script = terminalSelectScript(t.Session)
+	default:
+		return
+	}
+	_ = runCmd("osascript", "-e", script)
+}
+
+func iterm2SelectScript(title string) string {
+	return fmt.Sprintf(`tell application "iTerm2"
+	repeat with w in windows
+		repeat with t in tabs of w
+			repeat with s in sessions of t
+				if name of s contains %q then
+					select w
+					select t
+					tell s to select
+					return
+				end if
+			end repeat
+		end repeat
+	end repeat
+end tell`, title)
+}
+
+func terminalSelectScript(title string) string {
+	return fmt.Sprintf(`tell application "Terminal"
+	repeat with w in windows
+		repeat with t in tabs of w
+			if (name of t contains %q) or (custom title of t contains %q) then
+				set selected of t to true
+				set frontmost of w to true
+				return
+			end if
+		end repeat
+	end repeat
+end tell`, title, title)
+}
+
+// ExecuteCommand builds the shell command terminal-notifier runs on click.
+// willowPath is the absolute willow binary, captured at fire time so the
+// detached click handler doesn't depend on PATH.
+func ExecuteCommand(willowPath string, t Target) string {
+	parts := []string{shellQuote(willowPath), "focus", "--session", shellQuote(t.Session)}
+	if t.TmuxSocket != "" {
+		parts = append(parts, "--tmux-socket", shellQuote(t.TmuxSocket))
+	}
+	if t.TermBundle != "" {
+		parts = append(parts, "--term-bundle", shellQuote(t.TermBundle))
+	}
+	return strings.Join(parts, " ")
+}
+
+// SocketFromEnv extracts the tmux socket path from a $TMUX value
+// ("/path/to/socket,pid,session" → "/path/to/socket"). Empty if unset.
+func SocketFromEnv(tmuxEnv string) string {
+	if tmuxEnv == "" {
+		return ""
+	}
+	socket, _, _ := strings.Cut(tmuxEnv, ",")
+	return socket
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/focus/focus_test.go
+++ b/internal/focus/focus_test.go
@@ -1,0 +1,192 @@
+package focus
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSocketFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"full tmux value", "/private/tmp/tmux-501/default,12345,0", "/private/tmp/tmux-501/default"},
+		{"socket only", "/tmp/sock", "/tmp/sock"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SocketFromEnv(tt.in); got != tt.want {
+				t.Errorf("SocketFromEnv(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteCommand_TmuxTarget(t *testing.T) {
+	got := ExecuteCommand("/usr/local/bin/willow", Target{
+		Session:    "repo/feature",
+		TmuxSocket: "/tmp/sock",
+		TermBundle: "com.googlecode.iterm2",
+	})
+	for _, want := range []string{
+		"'/usr/local/bin/willow' focus",
+		"--session 'repo/feature'",
+		"--tmux-socket '/tmp/sock'",
+		"--term-bundle 'com.googlecode.iterm2'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("ExecuteCommand() = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestExecuteCommand_OmitsEmptyFlags(t *testing.T) {
+	got := ExecuteCommand("/usr/local/bin/willow", Target{Session: "repo/feature"})
+	if strings.Contains(got, "--tmux-socket") {
+		t.Errorf("ExecuteCommand() should omit --tmux-socket when empty: %q", got)
+	}
+	if strings.Contains(got, "--term-bundle") {
+		t.Errorf("ExecuteCommand() should omit --term-bundle when empty: %q", got)
+	}
+}
+
+func TestExecuteCommand_QuotesAdversarialInput(t *testing.T) {
+	got := ExecuteCommand("/usr/local/bin/willow", Target{
+		Session: "repo/foo'; rm -rf ~ #",
+	})
+	// The single quote in the session must be escaped so it can't break out of
+	// the quoted argument and inject a command.
+	if !strings.Contains(got, `'repo/foo'\''; rm -rf ~ #'`) {
+		t.Errorf("ExecuteCommand() did not safely quote injection attempt: %q", got)
+	}
+}
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "'plain'"},
+		{"repo/wt", "'repo/wt'"},
+		{"a'b", `'a'\''b'`},
+	}
+	for _, tt := range tests {
+		if got := shellQuote(tt.in); got != tt.want {
+			t.Errorf("shellQuote(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSelectScripts_EmbedTitle(t *testing.T) {
+	if !strings.Contains(iterm2SelectScript("repo/wt"), `"repo/wt"`) {
+		t.Error("iterm2SelectScript should embed the quoted title")
+	}
+	if !strings.Contains(terminalSelectScript("repo/wt"), `"repo/wt"`) {
+		t.Error("terminalSelectScript should embed the quoted title")
+	}
+}
+
+// recordedCmd captures one runCmd invocation.
+type recordedCmd struct {
+	name string
+	args []string
+}
+
+// withRecordedCmds swaps the package command runners for recorders and restores
+// them after fn. clientList is what list-clients returns.
+func withRecordedCmds(t *testing.T, clientList string, fn func(record *[]recordedCmd)) {
+	t.Helper()
+	origRun, origOut := runCmd, runCmdOutput
+	t.Cleanup(func() { runCmd, runCmdOutput = origRun, origOut })
+
+	var recorded []recordedCmd
+	runCmd = func(name string, args ...string) error {
+		recorded = append(recorded, recordedCmd{name, args})
+		return nil
+	}
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		recorded = append(recorded, recordedCmd{name, args})
+		return []byte(clientList), nil
+	}
+	fn(&recorded)
+}
+
+func cmdArgsContain(cmds []recordedCmd, name, substr string) bool {
+	for _, c := range cmds {
+		if c.name != name {
+			continue
+		}
+		if strings.Contains(strings.Join(c.args, " "), substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFocusTarget_TmuxSwitchesEachClient(t *testing.T) {
+	withRecordedCmds(t, "client-a\nclient-b\n", func(record *[]recordedCmd) {
+		err := focusTarget(Target{
+			Session:    "repo/wt",
+			TmuxSocket: "/tmp/sock",
+			TermBundle: bundleITerm2,
+		})
+		if err != nil {
+			t.Fatalf("focusTarget returned error: %v", err)
+		}
+		switches := 0
+		for _, c := range *record {
+			if c.name == "tmux" && len(c.args) > 0 && contains(c.args, "switch-client") {
+				switches++
+			}
+		}
+		if switches != 2 {
+			t.Errorf("expected 2 switch-client calls (one per client), got %d", switches)
+		}
+		if !cmdArgsContain(*record, "osascript", "activate") {
+			t.Error("expected the host terminal to be activated")
+		}
+		if cmdArgsContain(*record, "osascript", "iTerm2") {
+			t.Error("tmux path should not also run the tab-select script")
+		}
+	})
+}
+
+func TestFocusTarget_NoTmuxSelectsTab(t *testing.T) {
+	withRecordedCmds(t, "", func(record *[]recordedCmd) {
+		_ = focusTarget(Target{Session: "repo/wt", TermBundle: bundleITerm2})
+		if cmdArgsContain(*record, "tmux", "switch-client") {
+			t.Error("no-tmux path should not switch tmux clients")
+		}
+		if !cmdArgsContain(*record, "osascript", "iTerm2") {
+			t.Error("expected the iTerm2 tab-select script to run")
+		}
+		if !cmdArgsContain(*record, "osascript", "activate") {
+			t.Error("expected the host terminal to be activated")
+		}
+	})
+}
+
+func TestFocusTarget_UnknownTerminalActivatesOnly(t *testing.T) {
+	withRecordedCmds(t, "", func(record *[]recordedCmd) {
+		_ = focusTarget(Target{Session: "repo/wt", TermBundle: "com.example.unknown"})
+		for _, c := range *record {
+			if c.name == "osascript" && strings.Contains(strings.Join(c.args, " "), "repeat with") {
+				t.Error("unknown terminal should not run a tab-select script")
+			}
+		}
+		if !cmdArgsContain(*record, "osascript", "activate") {
+			t.Error("expected the host terminal to be activated")
+		}
+	})
+}
+
+func contains(values []string, want string) bool {
+	for _, v := range values {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,10 +1,19 @@
 package notify
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"runtime"
+	"time"
 )
+
+// notifierTimeout bounds how long a spawned terminal-notifier may run. It's a
+// backstop: terminal-notifier hands the notification to Notification Center and
+// exits in well under a second, but a wedged Notification Center daemon can
+// leave it blocked. The hook fires notifications inline, so an unbounded exec
+// would stall the agent — kill it instead.
+const notifierTimeout = 10 * time.Second
 
 // Send fires a desktop notification.
 // macOS: uses `osascript` (shipped on every Mac).
@@ -23,9 +32,63 @@ func Send(title, body string) error {
 	}
 }
 
+// Click describes what happens when the user clicks a notification.
+//
+//   - Execute is a shell command run on click (terminal-notifier `-execute`).
+//   - Sender is a terminal bundle id; it sets the notification icon and, on
+//     click, brings that app forward (terminal-notifier `-sender`).
+//   - Group coalesces repeat notifications for the same target so they replace
+//     rather than stack (terminal-notifier `-group`).
+//
+// Click actions require terminal-notifier. macOS `display notification`
+// (osascript) has no click-action API: clicking it activates osascript's host
+// (Script Editor), not the agent's terminal.
+type Click struct {
+	Execute string
+	Sender  string
+	Group   string
+}
+
+// SendWithClick fires a notification that focuses the agent's session on click.
+// It uses terminal-notifier when available; otherwise it falls back to the
+// plain, non-clickable Send so notifications still fire on a stock Mac.
+func SendWithClick(title, body string, click *Click) error {
+	if runtime.GOOS == "darwin" && click != nil && click.Execute != "" {
+		if path, err := exec.LookPath("terminal-notifier"); err == nil {
+			return sendTerminalNotifier(path, title, body, *click)
+		}
+	}
+	return Send(title, body)
+}
+
 func sendDarwin(title, body string) error {
 	script := fmt.Sprintf("display notification %q with title %q", body, title)
 	return exec.Command("osascript", "-e", script).Run()
+}
+
+func sendTerminalNotifier(path, title, body string, c Click) error {
+	args := []string{"-title", title, "-message", body, "-execute", c.Execute}
+	if c.Sender != "" {
+		args = append(args, "-sender", c.Sender)
+	}
+	if c.Group != "" {
+		args = append(args, "-group", c.Group)
+	}
+
+	// The hook fires notifications inline, so don't block on the notifier:
+	// start it, then reap in the background. CommandContext kills it if it
+	// wedges past notifierTimeout (a stuck Notification Center daemon).
+	ctx, cancel := context.WithTimeout(context.Background(), notifierTimeout)
+	cmd := exec.CommandContext(ctx, path, args...)
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return err
+	}
+	go func() {
+		defer cancel()
+		_ = cmd.Wait()
+	}()
+	return nil
 }
 
 func sendLinux(title, body string) error {

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -13,3 +13,16 @@ func TestSendCustom_NoPanic(t *testing.T) {
 		t.Errorf("SendCustom() with 'true' command should not error: %v", err)
 	}
 }
+
+func TestSendWithClick_NilClickFallsBack(t *testing.T) {
+	// A nil click must behave like a plain Send (no panic, no crash in CI).
+	_ = SendWithClick("test title", "test body", nil)
+}
+
+func TestSendWithClick_NoPanic(t *testing.T) {
+	_ = SendWithClick("test title", "test body", &Click{
+		Execute: "true",
+		Sender:  "com.apple.Terminal",
+		Group:   "willow-repo/wt",
+	})
+}


### PR DESCRIPTION
## Problem

Clicking a willow desktop notification opens an empty document in Script Editor instead of taking you to the agent that triggered it. Notifications fire through `osascript -e 'display notification ...'`, and that AppleScript verb has no click-action API, so macOS activates the process that posted the notification (osascript, whose host app is Script Editor).

## Solution

When `terminal-notifier` is installed, willow uses it instead of `osascript`. terminal-notifier supports a click action, so the notification can carry one. On click, willow re-invokes itself with a hidden `ww focus` subcommand that navigates to the triggering session:

```
notification click
      │
      ▼
  ww focus --session repo/wt --tmux-socket … --term-bundle …
      │
      ├─ in tmux?  → switch every attached client to that session
      │             (switch-client needs an explicit -c when detached)
      └─ otherwise → select the terminal tab titled "repo/wt"
                     (iTerm2 / Terminal.app via AppleScript)
      │
      ▼
  activate the host terminal app
```

The transition key (`repo/wt`) is already both the tmux session name and the `--tab-title` tab title, so it's all the click needs. The tmux socket and host-terminal bundle id are captured when the notification fires, because the click handler runs later, detached, with no inherited environment.

If `terminal-notifier` isn't installed, notifications still fire via the old `osascript` path (just not clickable), and `ww doctor` reports that clicks won't work with an install hint. The notifier runs detached with a timeout backstop so a stuck Notification Center daemon can't block the agent hook.

### What's in the PR

- `internal/focus/` new package: builds the click command and performs the tmux-switch / tab-select / app-activate navigation
- `internal/notify/notify.go`: `SendWithClick` prefers terminal-notifier, falls back to osascript; runs the notifier non-blocking
- `internal/agent/hook_handler.go`: captures the click target from the live hook env on a BUSY→DONE/WAIT transition
- `internal/cli/focus_cmd.go`: hidden `ww focus` subcommand the click invokes
- `internal/cli/doctor.go`: reports terminal-notifier availability

## Test plan

Unit tests for the command builder, the env-capture, the notifier fallback, and the doctor check. Manual: clicked a DONE notification from iTerm2 with the agent in a tmux session and confirmed it switches to that session and focuses iTerm2.

Tested on macOS only; Linux `notify-send` is unchanged (click handling there needs a separate mechanism).